### PR TITLE
fix: zod types for reasoning

### DIFF
--- a/src/openrouter-chat-language-model.ts
+++ b/src/openrouter-chat-language-model.ts
@@ -520,7 +520,7 @@ const openrouterChatChunkSchema = z.union([
           .object({
             role: z.enum(["assistant"]).optional(),
             content: z.string().nullish(),
-            reasoning: z.string().nullish(),
+            reasoning: z.string().nullish().optional(),
             tool_calls: z
               .array(
                 z.object({

--- a/src/openrouter-completion-language-model.ts
+++ b/src/openrouter-completion-language-model.ts
@@ -314,7 +314,7 @@ const openAICompletionResponseSchema = z.object({
   choices: z.array(
     z.object({
       text: z.string(),
-      reasoning: z.string().nullable(),
+      reasoning: z.string().nullish().optional(),
       finish_reason: z.string(),
       logprobs: z
         .object({


### PR DESCRIPTION
some tests failing locally 

```
 FAIL  src/openrouter-completion-language-model.test.ts > doGenerate > should pass headers
AI_APICallError: Invalid JSON response
 ❯ node_modules/.pnpm/@ai-sdk+provider-utils@2.1.10_zod@3.24.2/node_modules/@ai-sdk/provider-utils/src/response-handler.ts:170:13
 ❯ postToApi node_modules/.pnpm/@ai-sdk+provider-utils@2.1.10_zod@3.24.2/node_modules/@ai-sdk/provider-utils/src/post-to-api.ts:105:14
 ❯ OpenRouterCompletionLanguageModel.doGenerate src/openrouter-completion-language-model.ts:167:50
    165|     const args = this.getArgs(options);
    166| 
    167|     const { responseHeaders, value: response } = await postJsonToApi({
       |                                                  ^
    168|       url: this.config.url({
    169|         path: "/completions",
 ❯ src/openrouter-completion-language-model.test.ts:242:5

Caused by: AI_TypeValidationError: Type validation failed: Value: {"id":"cmpl-96cAM1v77r4jXa4qb2NSmRREV5oWB","object":"text_completion","created":1711363706,"model":"openai/gpt-3.5-turbo-instruct","choices":[{"text":"","index":0,"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"total_tokens":34,"completion_tokens":30}}.
Error message: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "choices",
      0,
      "reasoning"
    ],
    "message": "Required"
  }
]

...

 Test Files  2 failed | 1 passed (3)
      Tests  12 failed | 26 passed (38)
```

after this change, only 3 tests failing:
```
Test Files  1 failed | 2 passed (3)
Tests  3 failed | 35 passed (38)
```