### PR TITLE
fix: Proper file support for AI SDK messages

### DIFF
--- a/src/convert-to-openrouter-chat-messages.ts
+++ b/src/convert-to-openrouter-chat-messages.ts
@@ -1,4 +1,5 @@
 import type {
+  LanguageModelV1FilePart,
   LanguageModelV1Prompt,
   LanguageModelV1ProviderMetadata,
 } from '@ai-sdk/provider';
@@ -85,9 +86,16 @@ export function convertToOpenRouterChatMessages(
                 };
               case 'file':
                 return {
-                  type: 'text' as const,
-                  text:
-                    part.data instanceof URL ? part.data.toString() : part.data,
+                  type: 'file',
+                  file: {
+                    filename: (
+                      part as LanguageModelV1FilePart & { filename: string }
+                    ).filename,
+                    file_data:
+                      part.data instanceof Uint8Array
+                        ? `data:${part.mimeType};base64,${convertUint8ArrayToBase64(part.data)}`
+                        : `data:${part.mimeType};base64,${part.data}`,
+                  },
                   cache_control:
                     getCacheControl(part.providerMetadata) ??
                     messageCacheControl,


### PR DESCRIPTION
📚 Context

This PR adds proper support for file message parts when using the AI SDK provider for OpenRouter. Currently, attempts to send files (e.g., PDFs) result in errors because the file type is not handled correctly.

This issue is discussed in [#55](https://github.com/OpenRouterTeam/ai-sdk-provider/issues/55), and several users (including myself) confirmed this behavior.

🛠️ Changes

- Added handling for file message parts, including proper filename, mimeType, and base64 encoding for file_data.
- Ensures compatibility with AI SDK expectations for file uploads.

✅ How I Tested

- Applied this patch directly in my project using patch-package.
- Verified that PDF files are now correctly uploaded and processed via OpenRouter.
- Tested with both Uint8Array and base64 encoded strings as part.data.

📌 Notes

- This fix ensures compatibility without breaking changes.
- Happy to make adjustments if needed!