### PR TITLE
fix: update file handling in chat message conversion

### DIFF
--- a/src/convert-to-openrouter-chat-messages.test.ts
+++ b/src/convert-to-openrouter-chat-messages.test.ts
@@ -183,7 +183,8 @@ describe('cache control', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: 'file content',
+            data: 'ZmlsZSBjb250ZW50',
+            filename: 'file.txt',
             mimeType: 'text/plain',
           },
         ],
@@ -205,8 +206,11 @@ describe('cache control', () => {
             cache_control: { type: 'ephemeral' },
           },
           {
-            type: 'text',
-            text: 'file content',
+            type: 'file',
+            file: {
+              filename: 'file.txt',
+              file_data: `data:text/plain;base64,ZmlsZSBjb250ZW50`,
+            },
             cache_control: { type: 'ephemeral' },
           },
         ],
@@ -236,7 +240,8 @@ describe('cache control', () => {
           },
           {
             type: 'file',
-            data: 'file content',
+            filename: 'file.txt',
+            data: 'ZmlsZSBjb250ZW50',
             mimeType: 'text/plain',
             // No part-specific provider metadata
           },
@@ -264,8 +269,11 @@ describe('cache control', () => {
             cache_control: { type: 'ephemeral' },
           },
           {
-            type: 'text',
-            text: 'file content',
+            type: 'file',
+            file: {
+              filename: 'file.txt',
+              file_data: `data:text/plain;base64,ZmlsZSBjb250ZW50`,
+            },
             cache_control: { type: 'ephemeral' },
           },
         ],

--- a/src/convert-to-openrouter-chat-messages.ts
+++ b/src/convert-to-openrouter-chat-messages.ts
@@ -85,9 +85,14 @@ export function convertToOpenRouterChatMessages(
                 };
               case 'file':
                 return {
-                  type: 'text' as const,
-                  text:
-                    part.data instanceof URL ? part.data.toString() : part.data,
+                  type: 'file' as const,
+                  file: {
+                    filename: part.filename,
+                    file_data:
+                      part.data instanceof Uint8Array
+                        ? `data:${part.mimeType};base64,${convertUint8ArrayToBase64(part.data)}`
+                        : `data:${part.mimeType};base64,${part.data}`,
+                  },
                   cache_control:
                     getCacheControl(part.providerMetadata) ??
                     messageCacheControl,

--- a/src/openrouter-chat-prompt.ts
+++ b/src/openrouter-chat-prompt.ts
@@ -23,7 +23,17 @@ export interface ChatCompletionUserMessageParam {
 
 export type ChatCompletionContentPart =
   | ChatCompletionContentPartText
-  | ChatCompletionContentPartImage;
+  | ChatCompletionContentPartImage
+  | ChatCompletionContentPartFile;
+
+export interface ChatCompletionContentPartFile {
+  type: 'file';
+  file: {
+    filename: string;
+    file_data: string;
+  };
+  cache_control?: OpenRouterCacheControl;
+}
 
 export interface ChatCompletionContentPartImage {
   type: 'image_url';


### PR DESCRIPTION
fixes #55 #57 

Changes:
- Changed handling of file type content to adhere to [Openrouter documentation](https://openrouter.ai/docs/features/images-and-pdfs#pdf-support)
- Modified tests to reflect file type structure and data format.
- Added necessary types for file content

Tested:
- Tested responses for all message type (text, image, file) with different file sizes
- Tested responses for multiple models
- Modified unit tests are passing


