### PR TITLE
feat: add usage accounting support to OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const { text } = await generateText({
 
 ## Supported models
 
-This list is not a definitive list of models supported by OpenRouter, as it constantly changes as we add new models (and deprecate old ones) to our system.  
+This list is not a definitive list of models supported by OpenRouter, as it constantly changes as we add new models (and deprecate old ones) to our system.
 You can find the latest list of models supported by OpenRouter [here](https://openrouter.ai/models).
 
 You can find the latest list of tool-supported models supported by OpenRouter [here](https://openrouter.ai/models?order=newest&supported_parameters=tools). (Note: This list may contain models that are not compatible with the AI SDK.)
@@ -153,4 +153,31 @@ await streamText({
     },
   ],
 });
+```
+
+## Use Cases
+
+### Usage Accounting
+
+The provider supports [OpenRouter usage accounting](https://openrouter.ai/docs/use-cases/usage-accounting), which allows you to track token usage details directly in your API responses, without making additional API calls.
+
+```typescript
+// Enable usage accounting
+const model = openrouter('openai/gpt-3.5-turbo', {
+  usage: {
+    include: true,
+  }
+});
+
+// Access usage accounting data
+const result = await generateText({
+  model,
+  prompt: 'Hello, how are you today?',
+});
+
+// Provider-specific usage details (available in providerMetadata)
+if (result.providerMetadata?.openrouter?.usage) {
+  console.log('Cost:', result.providerMetadata.openrouter.usage.cost);
+  console.log('Total Tokens:', result.providerMetadata.openrouter.usage.totalTokens);
+}
 ```

--- a/src/openrouter-chat-language-model.ts
+++ b/src/openrouter-chat-language-model.ts
@@ -130,6 +130,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
       // OpenRouter specific settings:
       include_reasoning: this.settings.includeReasoning,
       reasoning: this.settings.reasoning,
+      usage: this.settings.usage,
 
       // extra body:
       ...this.config.extraBody,
@@ -202,6 +203,48 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
       throw new Error('No choice in response');
     }
 
+    // Extract detailed usage information
+    const usageInfo = response.usage
+      ? {
+          promptTokens: response.usage.prompt_tokens ?? 0,
+          completionTokens: response.usage.completion_tokens ?? 0,
+        }
+      : {
+          promptTokens: 0,
+          completionTokens: 0,
+        };
+
+    // Collect provider-specific metadata
+    const providerMetadata: Record<string, any> = {};
+
+    // Add OpenRouter usage accounting details if available AND usage accounting was requested
+    if (response.usage && this.settings.usage?.include) {
+      providerMetadata.openrouter = {
+        usage: {
+          promptTokens: response.usage.prompt_tokens,
+          promptTokensDetails: response.usage.prompt_tokens_details
+            ? {
+                cachedTokens:
+                  response.usage.prompt_tokens_details.cached_tokens ?? 0,
+              }
+            : undefined,
+          completionTokens: response.usage.completion_tokens,
+          completionTokensDetails: response.usage.completion_tokens_details
+            ? {
+                reasoningTokens:
+                  response.usage.completion_tokens_details.reasoning_tokens ??
+                  0,
+              }
+            : undefined,
+          cost: response.usage.cost,
+          totalTokens: response.usage.total_tokens ?? 0,
+        },
+      };
+    }
+
+    // Prepare the final result
+    const hasProviderMetadata = Object.keys(providerMetadata).length > 0;
+
     return {
       response: {
         id: response.id,
@@ -216,14 +259,12 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
         args: toolCall.function.arguments!,
       })),
       finishReason: mapOpenRouterFinishReason(choice.finish_reason),
-      usage: {
-        promptTokens: response.usage?.prompt_tokens ?? 0,
-        completionTokens: response.usage?.completion_tokens ?? 0,
-      },
+      usage: usageInfo,
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
       warnings: [],
       logprobs: mapOpenRouterChatLogProbsOutput(choice.logprobs),
+      ...(hasProviderMetadata ? { providerMetadata } : {}),
     };
   }
 
@@ -245,7 +286,13 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
         // only include stream_options when in strict compatibility mode:
         stream_options:
           this.config.compatibility === 'strict'
-            ? { include_usage: true }
+            ? {
+                include_usage: true,
+                // If user has requested usage accounting, make sure we get it in the stream
+                ...(this.settings.usage?.include
+                  ? { include_usage: true }
+                  : {}),
+              }
             : undefined,
       },
       failedResponseHandler: openrouterFailedResponseHandler,
@@ -275,6 +322,19 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
       completionTokens: Number.NaN,
     };
     let logprobs: LanguageModelV1LogProbs;
+
+    // Track provider-specific usage information
+    let openrouterUsage: {
+      promptTokens?: number;
+      promptTokensDetails?: { cachedTokens: number };
+      completionTokens?: number;
+      completionTokensDetails?: { reasoningTokens: number };
+      cost?: number;
+      totalTokens?: number;
+    } = {};
+
+    // Store usage accounting setting for reference in the transformer
+    const shouldIncludeUsageAccounting = !!this.settings.usage?.include;
 
     return {
       stream: response.pipeThrough(
@@ -320,6 +380,26 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
                 promptTokens: value.usage.prompt_tokens,
                 completionTokens: value.usage.completion_tokens,
               };
+
+              // Collect OpenRouter specific usage information
+              openrouterUsage.promptTokens = value.usage.prompt_tokens;
+              if (value.usage.prompt_tokens_details) {
+                openrouterUsage.promptTokensDetails = {
+                  cachedTokens:
+                    value.usage.prompt_tokens_details.cached_tokens ?? 0,
+                };
+              }
+
+              openrouterUsage.completionTokens = value.usage.completion_tokens;
+              if (value.usage.completion_tokens_details) {
+                openrouterUsage.completionTokensDetails = {
+                  reasoningTokens:
+                    value.usage.completion_tokens_details.reasoning_tokens ?? 0,
+                };
+              }
+
+              openrouterUsage.cost = value.usage.cost;
+              openrouterUsage.totalTokens = value.usage.total_tokens;
             }
 
             const choice = value.choices[0];
@@ -490,11 +570,34 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
               }
             }
 
+            // Prepare provider metadata with OpenRouter usage accounting information
+            const providerMetadata: Record<string, any> = {};
+
+            // Only add OpenRouter metadata if we have usage information AND usage accounting was requested
+            if (
+              shouldIncludeUsageAccounting &&
+              (openrouterUsage.totalTokens !== undefined ||
+                openrouterUsage.cost !== undefined ||
+                openrouterUsage.promptTokensDetails !== undefined ||
+                openrouterUsage.completionTokensDetails !== undefined)
+            ) {
+              providerMetadata.openrouter = {
+                usage: openrouterUsage,
+              };
+            }
+
+            // Only add providerMetadata if we have OpenRouter metadata and it is explicitly requested
+            // This is to maintain backward compatibility with existing tests and clients
+            const hasProviderMetadata =
+              Object.keys(providerMetadata).length > 0 &&
+              shouldIncludeUsageAccounting;
+
             controller.enqueue({
               type: 'finish',
               finishReason,
               logprobs,
               usage,
+              ...(hasProviderMetadata ? { providerMetadata } : {}),
             });
           },
         }),
@@ -512,8 +615,19 @@ const OpenRouterChatCompletionBaseResponseSchema = z.object({
   usage: z
     .object({
       prompt_tokens: z.number(),
+      prompt_tokens_details: z
+        .object({
+          cached_tokens: z.number(),
+        })
+        .optional(),
       completion_tokens: z.number(),
+      completion_tokens_details: z
+        .object({
+          reasoning_tokens: z.number(),
+        })
+        .optional(),
       total_tokens: z.number(),
+      cost: z.number().optional(),
     })
     .nullish(),
 });

--- a/src/openrouter-stream-usage-accounting.test.ts
+++ b/src/openrouter-stream-usage-accounting.test.ts
@@ -1,0 +1,159 @@
+import type { OpenRouterChatSettings } from './openrouter-chat-settings';
+
+import {
+  convertReadableStreamToArray,
+  StreamingTestServer,
+} from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+
+import { OpenRouterChatLanguageModel } from './openrouter-chat-language-model';
+
+describe('OpenRouter Streaming Usage Accounting', () => {
+  const server = new StreamingTestServer(
+    'https://api.openrouter.ai/chat/completions',
+  );
+
+  server.setupTestEnvironment();
+
+  function prepareStreamResponse(includeUsage = true) {
+    server.responseChunks = [
+      `data: {"id":"test-id","model":"test-model","choices":[{"delta":{"content":"Hello"},"index":0}]}\n\n`,
+      `data: {"choices":[{"finish_reason":"stop","index":0}]}\n\n`,
+    ];
+
+    if (includeUsage) {
+      server.responseChunks.push(
+        `data: {"usage":{"prompt_tokens":10,"prompt_tokens_details":{"cached_tokens":5},"completion_tokens":20,"completion_tokens_details":{"reasoning_tokens":8},"total_tokens":30,"cost":0.0015},"choices":[]}\n\n`,
+      );
+    }
+
+    server.responseChunks.push('data: [DONE]\n\n');
+  }
+
+  it('should include stream_options.include_usage in request when enabled', async () => {
+    prepareStreamResponse();
+
+    // Create model with usage accounting enabled
+    const settings: OpenRouterChatSettings = {
+      usage: { include: true },
+    };
+
+    const model = new OpenRouterChatLanguageModel('test-model', settings, {
+      provider: 'openrouter.chat',
+      url: () => 'https://api.openrouter.ai/chat/completions',
+      headers: () => ({}),
+      compatibility: 'strict',
+      fetch: global.fetch,
+    });
+
+    // Call the model with streaming
+    await model.doStream({
+      mode: { type: 'regular' },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxTokens: 100,
+      inputFormat: 'messages',
+    });
+
+    // Verify stream options
+    const requestBody = await server.getRequestBodyJson();
+    expect(requestBody).toBeDefined();
+    expect(requestBody.stream).toBe(true);
+    expect(requestBody.stream_options).toEqual({
+      include_usage: true,
+    });
+  });
+
+  it('should include provider-specific metadata in finish event when usage accounting is enabled', async () => {
+    prepareStreamResponse(true);
+
+    // Create model with usage accounting enabled
+    const settings: OpenRouterChatSettings = {
+      usage: { include: true },
+    };
+
+    const model = new OpenRouterChatLanguageModel('test-model', settings, {
+      provider: 'openrouter.chat',
+      url: () => 'https://api.openrouter.ai/chat/completions',
+      headers: () => ({}),
+      compatibility: 'strict',
+      fetch: global.fetch,
+    });
+
+    // Call the model with streaming
+    const result = await model.doStream({
+      mode: { type: 'regular' },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxTokens: 100,
+      inputFormat: 'messages',
+    });
+
+    // Read all chunks from the stream
+    const chunks = await convertReadableStreamToArray(result.stream);
+
+    // Find the finish chunk
+    const finishChunk = chunks.find((chunk) => chunk.type === 'finish');
+    expect(finishChunk).toBeDefined();
+
+    // Verify metadata is included
+    expect(finishChunk?.providerMetadata).toBeDefined();
+    const openrouterData = finishChunk?.providerMetadata?.openrouter as any;
+    expect(openrouterData).toBeDefined();
+
+    const usage = openrouterData?.usage as any;
+    expect(usage).toBeDefined();
+    expect(usage.totalTokens).toBe(30);
+    expect(usage.cost).toBe(0.0015);
+    expect(usage.promptTokensDetails?.cachedTokens).toBe(5);
+    expect(usage.completionTokensDetails?.reasoningTokens).toBe(8);
+  });
+
+  it('should not include provider-specific metadata when usage accounting is disabled', async () => {
+    prepareStreamResponse(false);
+
+    // Create model with usage accounting disabled
+    const settings: OpenRouterChatSettings = {
+      // No usage property
+    };
+
+    const model = new OpenRouterChatLanguageModel('test-model', settings, {
+      provider: 'openrouter.chat',
+      url: () => 'https://api.openrouter.ai/chat/completions',
+      headers: () => ({}),
+      compatibility: 'strict',
+      fetch: global.fetch,
+    });
+
+    // Call the model with streaming
+    const result = await model.doStream({
+      mode: { type: 'regular' },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxTokens: 100,
+      inputFormat: 'messages',
+    });
+
+    // Read all chunks from the stream
+    const chunks = await convertReadableStreamToArray(result.stream);
+
+    // Find the finish chunk
+    const finishChunk = chunks.find((chunk) => chunk.type === 'finish');
+    expect(finishChunk).toBeDefined();
+
+    // Verify that provider metadata is not included
+    expect(finishChunk?.providerMetadata?.openrouter).toBeUndefined();
+  });
+});

--- a/src/openrouter-usage-accounting.test.ts
+++ b/src/openrouter-usage-accounting.test.ts
@@ -1,0 +1,159 @@
+import type { OpenRouterChatSettings } from './openrouter-chat-settings';
+
+import { JsonTestServer } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+
+import { OpenRouterChatLanguageModel } from './openrouter-chat-language-model';
+
+describe('OpenRouter Usage Accounting', () => {
+  const server = new JsonTestServer(
+    'https://api.openrouter.ai/chat/completions',
+  );
+
+  server.setupTestEnvironment();
+
+  function prepareJsonResponse(includeUsage = true) {
+    server.responseBodyJson = {
+      id: 'test-id',
+      model: 'test-model',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Hello, I am an AI assistant.',
+          },
+          index: 0,
+          finish_reason: 'stop',
+        },
+      ],
+      usage: includeUsage
+        ? {
+            prompt_tokens: 10,
+            prompt_tokens_details: {
+              cached_tokens: 5,
+            },
+            completion_tokens: 20,
+            completion_tokens_details: {
+              reasoning_tokens: 8,
+            },
+            total_tokens: 30,
+            cost: 0.0015,
+          }
+        : undefined,
+    };
+  }
+
+  it('should include usage parameter in the request when enabled', async () => {
+    prepareJsonResponse();
+
+    // Create model with usage accounting enabled
+    const settings: OpenRouterChatSettings = {
+      usage: { include: true },
+    };
+
+    const model = new OpenRouterChatLanguageModel('test-model', settings, {
+      provider: 'openrouter.chat',
+      url: () => 'https://api.openrouter.ai/chat/completions',
+      headers: () => ({}),
+      compatibility: 'strict',
+      fetch: global.fetch,
+    });
+
+    // Call the model
+    await model.doGenerate({
+      mode: { type: 'regular' },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxTokens: 100,
+      inputFormat: 'messages',
+    });
+
+    // Check request contains usage parameter
+    const requestBody = await server.getRequestBodyJson();
+    expect(requestBody).toBeDefined();
+    expect(requestBody).toHaveProperty('usage');
+    expect(requestBody.usage).toEqual({ include: true });
+  });
+
+  it('should include provider-specific metadata in response when usage accounting is enabled', async () => {
+    prepareJsonResponse();
+
+    // Create model with usage accounting enabled
+    const settings: OpenRouterChatSettings = {
+      usage: { include: true },
+    };
+
+    const model = new OpenRouterChatLanguageModel('test-model', settings, {
+      provider: 'openrouter.chat',
+      url: () => 'https://api.openrouter.ai/chat/completions',
+      headers: () => ({}),
+      compatibility: 'strict',
+      fetch: global.fetch,
+    });
+
+    // Call the model
+    const result = await model.doGenerate({
+      mode: { type: 'regular' },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxTokens: 100,
+      inputFormat: 'messages',
+    });
+
+    // Check result contains provider metadata
+    expect(result.providerMetadata).toBeDefined();
+    const providerData = result.providerMetadata;
+
+    // Check for OpenRouter usage data
+    expect(providerData?.openrouter).toBeDefined();
+    const openrouterData = providerData?.openrouter as Record<string, any>;
+    expect(openrouterData.usage).toBeDefined();
+
+    const usage = openrouterData.usage;
+    expect(usage.totalTokens).toBe(30);
+    expect(usage.cost).toBe(0.0015);
+    expect(usage.promptTokensDetails?.cachedTokens).toBe(5);
+    expect(usage.completionTokensDetails?.reasoningTokens).toBe(8);
+  });
+
+  it('should not include provider-specific metadata when usage accounting is disabled', async () => {
+    prepareJsonResponse();
+
+    // Create model with usage accounting disabled
+    const settings: OpenRouterChatSettings = {
+      // No usage property
+    };
+
+    const model = new OpenRouterChatLanguageModel('test-model', settings, {
+      provider: 'openrouter.chat',
+      url: () => 'https://api.openrouter.ai/chat/completions',
+      headers: () => ({}),
+      compatibility: 'strict',
+      fetch: global.fetch,
+    });
+
+    // Call the model
+    const result = await model.doGenerate({
+      mode: { type: 'regular' },
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxTokens: 100,
+      inputFormat: 'messages',
+    });
+
+    // Verify that OpenRouter metadata is not included
+    expect(result.providerMetadata?.openrouter?.usage).toBeUndefined();
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,17 @@ export type OpenRouterProviderOptions = {
    * help OpenRouter to monitor and detect abuse.
    */
   user?: string;
+
+  /**
+   * Enable usage accounting to get detailed token usage information.
+   * https://openrouter.ai/docs/use-cases/usage-accounting
+   */
+  usage?: {
+    /**
+     * When true, includes token usage information in the response.
+     */
+    include: boolean;
+  };
 };
 
 export type OpenRouterSharedSettings = OpenRouterProviderOptions & {


### PR DESCRIPTION
Close #56

- Updated README.md to include usage accounting use cases and examples.
- Enhanced OpenRouterChatLanguageModel to support usage accounting settings and metadata extraction.
- Implemented detailed usage information tracking in responses.
- Added tests for usage accounting functionality, ensuring correct metadata inclusion based on settings.

Tested:
- Verified that usage accounting data is included in responses when enabled.
- Confirmed that provider-specific metadata is omitted when usage accounting is disabled.

### Added

- Added support for OpenRouter usage accounting feature
  - Allows tracking token usage details directly in API responses
  - Includes cost, cached tokens, and reasoning tokens information
  - Available in both streaming and non-streaming APIs

### Changed

- Updated schema to support OpenRouter usage accounting response format