### PR TITLE
Try to break e2e test

### DIFF
--- a/e2e/cache-control.test.ts
+++ b/e2e/cache-control.test.ts
@@ -52,10 +52,6 @@ async function callLLM() {
           {
             type: "text",
             text: "a".repeat(4200),
-          },
-          {
-            type: "text",
-            text: 'How many "a" did I use in the previous message?',
             providerOptions: {
               openrouter: {
                 cache_control: {
@@ -63,6 +59,10 @@ async function callLLM() {
                 },
               },
             },
+          },
+          {
+            type: "text",
+            text: 'How many "a" did I use in the previous message?',
           },
         ],
       },


### PR DESCRIPTION
Locally, this seems to break caching for Anthopic. Creating a PR to run the test in CI

re https://github.com/OpenRouterTeam/ai-sdk-provider/issues/35#issuecomment-2918235207