### PR TITLE
fix: fix filename of file part

### DIFF
--- a/src/convert-to-openrouter-chat-messages.ts
+++ b/src/convert-to-openrouter-chat-messages.ts
@@ -88,7 +88,9 @@ export function convertToOpenRouterChatMessages(
                   type: 'file' as const,
                   file: {
                     filename: String(
-                      part.providerMetadata?.openrouter?.filename,
+                      part.providerMetadata?.openrouter?.filename ??
+                        part.filename ??
+                        '',
                     ),
                     file_data:
                       part.data instanceof Uint8Array


### PR DESCRIPTION
In the later version of ai-sdk, the [`FilePart`](https://github.com/vercel/ai/blob/0c97722ffc585f01b1f757702b1a6bb4a4fc51f9/packages/ai/core/prompt/content-part.ts#L107) supports `filename` attribute (optional).

The commit adds the feature above, and fixes probable `undefined` string of the filename.