### PR TITLE
fix: properly embed cache_control in content array for user messages

### DIFF
--- a/src/convert-to-openrouter-chat-messages.test.ts
+++ b/src/convert-to-openrouter-chat-messages.test.ts
@@ -81,8 +81,45 @@ describe('cache control', () => {
     expect(result).toEqual([
       {
         role: 'user',
-        content: 'Hello',
-        cache_control: { type: 'ephemeral' },
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should pass cache control from content part provider metadata (single text part)', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
       },
     ]);
   });
@@ -122,6 +159,22 @@ describe('cache control', () => {
             cache_control: { type: 'ephemeral' },
           },
         ],
+      },
+    ]);
+  });
+
+  it('should pass cache control from user message provider metadata without cache control (single text part)', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: 'Hello',
       },
     ]);
   });

--- a/src/convert-to-openrouter-chat-messages.ts
+++ b/src/convert-to-openrouter-chat-messages.ts
@@ -44,12 +44,22 @@ export function convertToOpenRouterChatMessages(
 
       case 'user': {
         if (content.length === 1 && content[0]?.type === 'text') {
+          const cacheControl =
+            getCacheControl(providerMetadata) ??
+            getCacheControl(content[0].providerMetadata);
+          const contentWithCacheControl: string | ChatCompletionContentPart[] =
+            cacheControl
+              ? [
+                  {
+                    type: 'text',
+                    text: content[0].text,
+                    cache_control: cacheControl,
+                  },
+                ]
+              : content[0].text;
           messages.push({
             role: 'user',
-            content: content[0].text,
-            cache_control:
-              getCacheControl(providerMetadata) ??
-              getCacheControl(content[0].providerMetadata),
+            content: contentWithCacheControl,
           });
           break;
         }


### PR DESCRIPTION
Currently, the `cache_control` handling is incorrect for user text messages with length 1. The correct format is found on the OpenRouter Prompt Caching page: https://openrouter.ai/docs/features/prompt-caching
Example:
```
{
  "messages": [
    {
      "role": "system",
      "content": [
        {
          "type": "text",
          "text": "You are a historian studying the fall of the Roman Empire. You know the following book very well:"
        },
        {
          "type": "text",
          "text": "HUGE TEXT BODY",
          "cache_control": {
            "type": "ephemeral"
          }
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "What triggered the collapse?"
        }
      ]
    }
  ]
}
```

(It is correctly handled if content is an array of more than one element, but there is currently a hardcoded if statement for content of length 1 of type text, which returns the incorrect format.)
Before:
```
{
  "messages": [
    {
      "role": "user",
      "content": "User prompt here",
      "cache_control": {
        "type": "ephemeral"
      }
    }
  ]
}
```
After:
```
{
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "User prompt here",
          "cache_control": {
            "type": "ephemeral"
          }
        }
      ]
    }
  ]
}
```