### PR TITLE
fix: Added missing costDetails property

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -328,6 +328,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
                 response.usage?.completion_tokens_details?.reasoning_tokens ??
                 0,
             },
+            costDetails: {
+              upstreamInferenceCost:
+                response.usage?.cost_details?.upstream_inference_cost ?? 0,
+            },
           },
         },
       },

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -21,6 +21,11 @@ const OpenRouterChatCompletionBaseResponseSchema = z.object({
         .nullish(),
       total_tokens: z.number(),
       cost: z.number().optional(),
+      cost_details: z
+        .object({
+          upstream_inference_cost: z.number().nullish(),
+        })
+        .nullish(),
     })
     .nullish(),
 });

--- a/src/schemas/error-response.ts
+++ b/src/schemas/error-response.ts
@@ -1,5 +1,5 @@
-import { createJsonErrorResponseHandler } from "@ai-sdk/provider-utils";
-import { z } from "zod/v4";
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
 
 export const OpenRouterErrorResponseSchema = z.object({
   error: z.object({

--- a/src/schemas/reasoning-details.ts
+++ b/src/schemas/reasoning-details.ts
@@ -1,9 +1,9 @@
-import { z } from "zod/v4";
+import { z } from 'zod/v4';
 
 export enum ReasoningDetailType {
-  Summary = "reasoning.summary",
-  Encrypted = "reasoning.encrypted",
-  Text = "reasoning.text",
+  Summary = 'reasoning.summary',
+  Encrypted = 'reasoning.encrypted',
+  Text = 'reasoning.text',
 }
 
 export const ReasoningDetailSummarySchema = z.object({

--- a/src/tests/usage-accounting.test.ts
+++ b/src/tests/usage-accounting.test.ts
@@ -37,6 +37,9 @@ describe('OpenRouter Usage Accounting', () => {
             },
             total_tokens: 30,
             cost: 0.0015,
+            cost_details: {
+              upstream_inference_cost: 19,
+            },
           }
         : undefined,
     };
@@ -165,6 +168,9 @@ describe('OpenRouter Usage Accounting', () => {
       completionTokens: 20,
       totalTokens: 30,
       cost: 0.0015,
+      costDetails: {
+        upstreamInferenceCost: 19,
+      },
       promptTokensDetails: {
         cachedTokens: 5,
       },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,4 +64,7 @@ export type OpenRouterUsageAccounting = {
   };
   totalTokens: number;
   cost?: number;
+  costDetails: {
+    upstreamInferenceCost: number;
+  };
 };


### PR DESCRIPTION
This adds the `costDetails` property to the usage accounting information, [documented here](https://openrouter.ai/docs/use-cases/usage-accounting).

This allows callers to know how much a chat completion cost in the upstream inference provider.