### PR TITLE
Fix error schema failing to parse when field is missing from JSON response

### DIFF
--- a/src/schemas/error-response.test.ts
+++ b/src/schemas/error-response.test.ts
@@ -1,0 +1,49 @@
+import { OpenRouterErrorResponseSchema } from "./error-response";
+
+describe("OpenRouterErrorResponseSchema", () => {
+  it("should be valid without a type, code, and param", () => {
+    const errorWithoutTypeCodeAndParam = {
+      error: {
+        message: "Example error message",
+        metadata: { provider_name: "Morph" },
+      },
+      user_id: "example_1",
+    };
+
+    const result = OpenRouterErrorResponseSchema.parse(
+      errorWithoutTypeCodeAndParam
+    );
+
+    expect(result).toEqual({
+      error: {
+        message: "Example error message",
+        code: 400,
+        type: null,
+        param: null,
+      },
+    });
+  });
+
+  it("should be invalid with a type", () => {
+    const errorWithType = {
+      error: {
+        message: "Example error message with type",
+        type: "invalid_request_error",
+        code: 400,
+        param: "canBeAnything",
+        metadata: { provider_name: "Morph" },
+      },
+    };
+
+    const result = OpenRouterErrorResponseSchema.parse(errorWithType);
+
+    expect(result).toEqual({
+      error: {
+        code: 400,
+        message: "Example error message with type",
+        type: "invalid_request_error",
+        param: "canByAnything",
+      },
+    });
+  });
+});

--- a/src/schemas/error-response.test.ts
+++ b/src/schemas/error-response.test.ts
@@ -17,7 +17,7 @@ describe("OpenRouterErrorResponseSchema", () => {
     expect(result).toEqual({
       error: {
         message: "Example error message",
-        code: 400,
+        code: null,
         type: null,
         param: null,
       },
@@ -42,7 +42,7 @@ describe("OpenRouterErrorResponseSchema", () => {
         code: 400,
         message: "Example error message with type",
         type: "invalid_request_error",
-        param: "canByAnything",
+        param: "canBeAnything",
       },
     });
   });

--- a/src/schemas/error-response.ts
+++ b/src/schemas/error-response.ts
@@ -3,10 +3,10 @@ import { z } from "zod/v4";
 
 export const OpenRouterErrorResponseSchema = z.object({
   error: z.object({
-    code: z.union([z.string(), z.number()]).nullable(),
+    code: z.union([z.string(), z.number()]).nullable().optional().default(null),
     message: z.string(),
-    type: z.string().nullable(),
-    param: z.any().nullable(),
+    type: z.string().nullable().optional().default(null),
+    param: z.any().nullable().optional().default(null),
   }),
 });
 


### PR DESCRIPTION
Given the following request:

```
curl 'https://openrouter.ai/api/v1/chat/completions' \
  -H 'Authorization: Bearer <Replace with your key>' \
  --data-raw '{"model":"morph/morph-v2","temperature":0,"messages":[{"role":"user","content":"<code>example bad request</code>\n<update>example</update>"},{"role":"user","content":"<code>example bad request</code>\n<update></update>"}],"usage":{"include":true}}'
```

Which returns a bad request with following JSON

```
{"error":{"message":"Multi-turn conversations are not supported","code":400,"metadata":{"provider_name":"Morph"}},"user_id":"user_2swnDXUglnNS5LCCz9eGMto7ebS"}
```

The error object will fail to be parsed by the `ai-sdk-provider` package.

I see a fix was made in https://github.com/OpenRouterTeam/ai-sdk-provider/pull/84. But this only accounts for `null` values of the fields, and not the fields being completely omitted from the JSON response.


Because there seem to be actual providers out there omitting these fields, and because the [ErrorResponse schema also doesn't specify these](https://openrouter.ai/docs/api-reference/errors), I think this change makes sense.


p.s. If you choose to accept this PR, would it be possible to hotfix `v0.7` instead of v1? Thank you 🙏 

