### PR TITLE
fix: ensure consistent message IDs in streaming deltas for AI SDK v5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/ai-sdk-provider",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -418,6 +418,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
     let reasoningStarted = false;
     let textId: string | undefined;
     let reasoningId: string | undefined;
+    let openrouterResponseId: string | undefined;
     
     return {
       stream: response.pipeThrough(
@@ -445,6 +446,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
             }
 
             if (value.id) {
+              openrouterResponseId = value.id;
               controller.enqueue({
                 type: 'response-metadata',
                 id: value.id,
@@ -506,7 +508,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
 
             if (delta.content != null) {
               if (!textStarted) {
-                textId = generateId();
+                textId = openrouterResponseId || generateId();
                 controller.enqueue({
                   type: 'text-start',
                   id: textId,
@@ -522,7 +524,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
 
             const emitReasoningChunk = (chunkText: string) => {
               if (!reasoningStarted) {
-                reasoningId = generateId();
+                reasoningId = openrouterResponseId || generateId();
                 controller.enqueue({
                   type: 'reasoning-start',
                   id: reasoningId,

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -416,6 +416,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
 
     let textStarted = false;
     let reasoningStarted = false;
+    let textId: string | undefined;
+    let reasoningId: string | undefined;
     
     return {
       stream: response.pipeThrough(
@@ -504,31 +506,33 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
 
             if (delta.content != null) {
               if (!textStarted) {
+                textId = generateId();
                 controller.enqueue({
                   type: 'text-start',
-                  id: generateId(),
+                  id: textId,
                 });
                 textStarted = true;
               }
               controller.enqueue({
                 type: 'text-delta',
                 delta: delta.content,
-                id: generateId(),
+                id: textId!,
               });
             }
 
             const emitReasoningChunk = (chunkText: string) => {
               if (!reasoningStarted) {
+                reasoningId = generateId();
                 controller.enqueue({
                   type: 'reasoning-start',
-                  id: generateId(),
+                  id: reasoningId,
                 });
                 reasoningStarted = true;
               }
               controller.enqueue({
                 type: 'reasoning-delta',
                 delta: chunkText,
-                id: generateId(),
+                id: reasoningId!,
               });
             };
 
@@ -711,10 +715,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
             }
 
             if (textStarted) {
-              controller.enqueue({ type: 'text-end', id: generateId() });
+              controller.enqueue({ type: 'text-end', id: textId! });
             }
             if (reasoningStarted) {
-              controller.enqueue({ type: 'reasoning-end', id: generateId() });
+              controller.enqueue({ type: 'reasoning-end', id: reasoningId! });
             }
 
             controller.enqueue({

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -516,7 +516,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
               controller.enqueue({
                 type: 'text-delta',
                 delta: delta.content,
-                id: textId!,
+                id: textId || generateId(),
               });
             }
 
@@ -532,7 +532,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
               controller.enqueue({
                 type: 'reasoning-delta',
                 delta: chunkText,
-                id: reasoningId!,
+                id: reasoningId || generateId(),
               });
             };
 
@@ -715,10 +715,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
             }
 
             if (textStarted) {
-              controller.enqueue({ type: 'text-end', id: textId! });
+              controller.enqueue({ type: 'text-end', id: textId || generateId() });
             }
             if (reasoningStarted) {
-              controller.enqueue({ type: 'reasoning-end', id: reasoningId! });
+              controller.enqueue({ type: 'reasoning-end', id: reasoningId || generateId() });
             }
 
             controller.enqueue({


### PR DESCRIPTION
# feat: use OpenRouter response ID for streaming message consistency

## Summary

Replaces custom ID generation with OpenRouter's native response ID for streaming message consistency, addressing AI SDK v5 compatibility issues. Instead of calling `generateId()` for each streaming part, the implementation now extracts and reuses `value.id` from OpenRouter's response metadata, ensuring all text parts (text-start, text-delta, text-end) and reasoning parts share the same authentic provider ID.

**Key Changes:**
- Extract `openrouterResponseId` from `value.id` in streaming response metadata  
- Use OpenRouter's actual ID instead of generated IDs for `textId` and `reasoningId`
- Maintain fallback to `generateId()` if OpenRouter ID is unavailable
- Preserves AI SDK v5 compatibility fix while using provider's native identifiers
- Version bump from 1.0.0-beta.2 → 1.0.0-beta.3

**Example ID Evolution:**
- **Before**: Generated IDs like `UpSfjgfrgZP9bDQI`, `xdflPP7t1RZvBMey` (different for each part)
- **After**: OpenRouter native IDs like `gen-1752968910-8mBLSUi5hDa6NwBgKlBj` (shared across all parts)

## Review & Testing Checklist for Human

- [ ] **Critical**: Verify that `value.id` from response metadata is actually the same as the "first chat delta chunk ID" mentioned in requirements - this may be a misalignment in implementation
- [ ] **Critical**: Test streaming with different model providers (Claude, GPT, Llama, etc.) to ensure ID consistency across OpenRouter's 300+ models
- [ ] **Critical**: Test edge cases where `value.id` might be undefined or missing - verify fallback to `generateId()` works correctly
- [ ] **Important**: Confirm this actually resolves the "text part [ID] not found" errors reported in GitHub issue #106 with real AI SDK v5 usage scenarios
- [ ] **Important**: Test both reasoning and non-reasoning requests to ensure consistent behavior across different request types

**Recommended Test Plan:**
1. Run streaming requests with 3-5 different model providers and capture all streaming parts
2. Verify all text parts share the same ID that matches OpenRouter's response ID format
3. Test scenarios where OpenRouter might not provide `value.id` (if any exist)
4. Create a reproduction case for the original GitHub issue #106 and verify it's resolved

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    AISDKv5["AI SDK v5<br/>streamText()"]:::context
    ChatIndex["src/chat/index.ts<br/>doStream()"]:::major-edit
    OpenRouter["OpenRouter API<br/>streaming response"]:::context
    PackageJSON["package.json<br/>version bump"]:::minor-edit
    
    AISDKv5 -->|"calls"| ChatIndex
    OpenRouter -->|"streaming chunks<br/>with value.id"| ChatIndex
    ChatIndex -->|"LanguageModelV2StreamPart[]<br/>with consistent OpenRouter IDs"| AISDKv5
    
    subgraph StreamingFlow["Streaming Transform Logic"]
        ResponseID["openrouterResponseId<br/>(extracted from value.id)"]:::major-edit
        TextID["textId = openrouterResponseId<br/>|| generateId()"]:::major-edit
        ReasoningID["reasoningId = openrouterResponseId<br/>|| generateId()"]:::major-edit
        
        TextStart["text-start<br/>(uses textId)"]:::minor-edit
        TextDelta["text-delta<br/>(uses textId)"]:::minor-edit  
        TextEnd["text-end<br/>(uses textId)"]:::minor-edit
    end
    
    ChatIndex -.->|"contains"| StreamingFlow
    ResponseID -->|"provides ID"| TextID
    ResponseID -->|"provides ID"| ReasoningID
    TextID -->|"consistent ID"| TextStart
    TextID -->|"consistent ID"| TextDelta
    TextID -->|"consistent ID"| TextEnd
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Potential Risk**: The implementation uses `value.id` from response metadata rather than extracting ID from the first delta chunk specifically. Need to verify these are equivalent.
- **Testing Coverage**: Successfully tested with Anthropic Claude model showing consistent ID `gen-1752968910-8mBLSUi5hDa6NwBgKlBj` across 82 streaming parts, but limited to single provider.
- **Backward Compatibility**: Maintains fallback to `generateId()` ensuring robustness, but edge case behavior needs validation.
- **Session Context**: Implemented by @louisgv in Devin session https://app.devin.ai/sessions/39b657a3df7a4a41ac87ae03ba63a3a7
- **AI SDK Compatibility**: Intended to resolve GitHub issue #106 - "AI SDK v5 streamText not working with OpenRouter" but requires real-world validation.