### PR TITLE
feat: add beta tag support for prerelease versions in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,12 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm test
-      - run: pnpm publish --provenance --access public --no-git-checks
+      - name: Publish to npm
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            pnpm publish --provenance --access public --no-git-checks --tag beta
+          else
+            pnpm publish --provenance --access public --no-git-checks
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# feat: add beta tag support for prerelease versions in publish workflow

## Summary

This PR modifies the GitHub Actions publish workflow to automatically publish prerelease versions to npm with the `beta` tag instead of the default `latest` tag. The implementation uses GitHub's release event context to detect when a release is marked as prerelease and conditionally applies the appropriate npm tag.

**Key changes:**
- Modified `.github/workflows/publish.yaml` to add conditional logic based on `github.event.release.prerelease`
- Prerelease versions (marked as "Pre-release" in GitHub) will be published with `--tag beta`
- Regular releases (marked as "Latest" in GitHub) continue to use the default `latest` tag
- Maintains all existing publish behavior (provenance, access public, no-git-checks)

## Review & Testing Checklist for Human

- [ ] **Test with actual prerelease release**: Create a test prerelease version and verify it gets published with `beta` tag to npm
- [ ] **Test with regular release**: Create a test regular release and verify it still gets published with `latest` tag to npm  
- [ ] **Verify GitHub Actions context availability**: Confirm that `github.event.release.prerelease` is accessible in the workflow when triggered by release events
- [ ] **Check workflow dispatch compatibility**: Ensure manual workflow dispatch still works correctly (may need fallback logic)

**Recommended test plan**: Create a test release marked as prerelease, trigger the workflow, and verify the npm package is tagged correctly using `npm view @openrouter/ai-sdk-provider dist-tags`.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    GR["GitHub Release<br/>(prerelease flag)"] --> WF
    WF[".github/workflows/<br/>publish.yaml"]:::major-edit --> PUB["Publish Step<br/>(conditional logic)"]:::major-edit
    PUB --> NPM_BETA["npm publish<br/>--tag beta"]
    PUB --> NPM_LATEST["npm publish<br/>(latest tag)"]
    NPM_BETA --> NPM["npm registry<br/>@openrouter/ai-sdk-provider"]
    NPM_LATEST --> NPM
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The implementation assumes GitHub's release event context provides `github.event.release.prerelease` as a boolean value
- This change addresses the requirement to publish non-latest releases with the beta tag
- All existing publish workflow functionality (CI checks, provenance, access settings) remains unchanged
- **Link to Devin run**: https://app.devin.ai/sessions/7011f16434854e408278cc45b814415d
- **Requested by**: @louisgv