### PR TITLE
fix: return reasoning content with generateText()

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "typescript": "5.8.3",
     "vite-tsconfig-paths": "5.1.4",
     "vitest": "3.2.4",
-    "zod": "^3.25.76"
+    "zod": "3.25.76"
   },
   "peerDependencies": {
     "ai": "^5.0.0-beta.12",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1 || ^v4"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "typescript": "5.8.3",
     "vite-tsconfig-paths": "5.1.4",
     "vitest": "3.2.4",
-    "zod": "^4.0.5"
+    "zod": "^3.25.76"
   },
   "peerDependencies": {
     "ai": "^5.0.0-beta.12",
-    "zod": "^4.0.5"
+    "zod": "^3.24.1"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/ai-sdk-provider",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.0.0-beta.1
       '@ai-sdk/provider-utils':
         specifier: 3.0.0-beta.5
-        version: 3.0.0-beta.5(zod@4.0.5)
+        version: 3.0.0-beta.5(zod@3.25.76)
       '@biomejs/biome':
         specifier: 2.1.1
         version: 2.1.1
@@ -28,7 +28,7 @@ importers:
         version: 22.15.24
       ai:
         specifier: 5.0.0-beta.24
-        version: 5.0.0-beta.24(zod@4.0.5)
+        version: 5.0.0-beta.24(zod@3.25.76)
       dotenv:
         specifier: 16.5.0
         version: 16.5.0
@@ -45,8 +45,8 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.15.24)
       zod:
-        specifier: ^4.0.5
-        version: 4.0.5
+        specifier: ^3.25.76
+        version: 3.25.76
 
 packages:
 
@@ -1137,24 +1137,24 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod@4.0.5:
-    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@1.0.0-beta.10(zod@4.0.5)':
+  '@ai-sdk/gateway@1.0.0-beta.10(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0-beta.1
-      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@4.0.5)
-      zod: 4.0.5
+      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.0-beta.5(zod@4.0.5)':
+  '@ai-sdk/provider-utils@3.0.0-beta.5(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0-beta.1
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.3
-      zod: 4.0.5
-      zod-to-json-schema: 3.24.5(zod@4.0.5)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.5(zod@3.25.76)
 
   '@ai-sdk/provider@2.0.0-beta.1':
     dependencies:
@@ -1477,13 +1477,13 @@ snapshots:
 
   acorn@8.14.1: {}
 
-  ai@5.0.0-beta.24(zod@4.0.5):
+  ai@5.0.0-beta.24(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 1.0.0-beta.10(zod@4.0.5)
+      '@ai-sdk/gateway': 1.0.0-beta.10(zod@3.25.76)
       '@ai-sdk/provider': 2.0.0-beta.1
-      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@4.0.5)
+      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 4.0.5
+      zod: 3.25.76
 
   ansi-regex@5.0.1: {}
 
@@ -2094,8 +2094,8 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  zod-to-json-schema@3.24.5(zod@4.0.5):
+  zod-to-json-schema@3.24.5(zod@3.25.76):
     dependencies:
-      zod: 4.0.5
+      zod: 3.25.76
 
-  zod@4.0.5: {}
+  zod@3.25.76: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.15.24)
       zod:
-        specifier: ^3.25.76
+        specifier: 3.25.76
         version: 3.25.76
 
 packages:

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1,10 +1,12 @@
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import type { ReasoningDetailUnion } from '../schemas/reasoning-details';
 
 import {
   convertReadableStreamToArray,
   createTestServer,
 } from '@ai-sdk/provider-utils/test';
 import { createOpenRouter } from '../provider';
+import { ReasoningDetailType } from '../schemas/reasoning-details';
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -133,12 +135,7 @@ describe('doGenerate', () => {
   }: {
     content?: string;
     reasoning?: string;
-    reasoning_details?: Array<{
-      type: string;
-      text?: string;
-      summary?: string;
-      data?: string;
-    }>;
+    reasoning_details?: Array<ReasoningDetailUnion>;
     usage?: {
       prompt_tokens: number;
       total_tokens: number;
@@ -277,11 +274,11 @@ describe('doGenerate', () => {
       content: 'Hello!',
       reasoning_details: [
         {
-          type: 'reasoning.text',
+          type: ReasoningDetailType.Text,
           text: 'Let me analyze this request...',
         },
         {
-          type: 'reasoning.summary',
+          type: ReasoningDetailType.Summary,
           summary: 'The user wants a greeting response.',
         },
       ],
@@ -312,7 +309,7 @@ describe('doGenerate', () => {
       content: 'Hello!',
       reasoning_details: [
         {
-          type: 'reasoning.encrypted',
+          type: ReasoningDetailType.Encrypted,
           data: 'encrypted_reasoning_data_here',
         },
       ],

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -121,6 +121,8 @@ describe('doGenerate', () => {
 
   function prepareJsonResponse({
     content = '',
+    reasoning,
+    reasoning_details,
     usage = {
       prompt_tokens: 4,
       total_tokens: 34,
@@ -130,6 +132,13 @@ describe('doGenerate', () => {
     finish_reason = 'stop',
   }: {
     content?: string;
+    reasoning?: string;
+    reasoning_details?: Array<{
+      type: string;
+      text?: string;
+      summary?: string;
+      data?: string;
+    }>;
     usage?: {
       prompt_tokens: number;
       total_tokens: number;
@@ -159,6 +168,8 @@ describe('doGenerate', () => {
             message: {
               role: 'assistant',
               content,
+              reasoning,
+              reasoning_details,
             },
             logprobs,
             finish_reason,
@@ -236,6 +247,91 @@ describe('doGenerate', () => {
     });
 
     expect(response.finishReason).toStrictEqual('unknown');
+  });
+
+  it('should extract reasoning content from reasoning field', async () => {
+    prepareJsonResponse({
+      content: 'Hello!',
+      reasoning:
+        'I need to think about this... The user said hello, so I should respond with a greeting.',
+    });
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toStrictEqual([
+      {
+        type: 'reasoning',
+        text: 'I need to think about this... The user said hello, so I should respond with a greeting.',
+      },
+      {
+        type: 'text',
+        text: 'Hello!',
+      },
+    ]);
+  });
+
+  it('should extract reasoning content from reasoning_details', async () => {
+    prepareJsonResponse({
+      content: 'Hello!',
+      reasoning_details: [
+        {
+          type: 'reasoning.text',
+          text: 'Let me analyze this request...',
+        },
+        {
+          type: 'reasoning.summary',
+          summary: 'The user wants a greeting response.',
+        },
+      ],
+    });
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toStrictEqual([
+      {
+        type: 'reasoning',
+        text: 'Let me analyze this request...',
+      },
+      {
+        type: 'reasoning',
+        text: 'The user wants a greeting response.',
+      },
+      {
+        type: 'text',
+        text: 'Hello!',
+      },
+    ]);
+  });
+
+  it('should handle encrypted reasoning details', async () => {
+    prepareJsonResponse({
+      content: 'Hello!',
+      reasoning_details: [
+        {
+          type: 'reasoning.encrypted',
+          data: 'encrypted_reasoning_data_here',
+        },
+      ],
+    });
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toStrictEqual([
+      {
+        type: 'reasoning',
+        text: '[REDACTED]',
+      },
+      {
+        type: 'text',
+        text: 'Hello!',
+      },
+    ]);
   });
 
   it('should pass the model and the messages', async () => {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1,5 +1,3 @@
-import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
-import type { OpenRouterUsageAccounting } from '@/src/types/index';
 import type {
   LanguageModelV2,
   LanguageModelV2CallOptions,
@@ -14,12 +12,12 @@ import type {
 import type { ParseResult } from '@ai-sdk/provider-utils';
 import type { FinishReason } from 'ai';
 import type { z } from 'zod/v4';
+import type { OpenRouterUsageAccounting } from '@/src/types/index';
 import type {
   OpenRouterChatModelId,
   OpenRouterChatSettings,
 } from '../types/openrouter-chat-settings';
 
-import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 import { InvalidResponseDataError } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -29,6 +27,7 @@ import {
   isParsableJson,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
+import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 import { openrouterFailedResponseHandler } from '../schemas/error-response';
 import { mapOpenRouterFinishReason } from '../utils/map-finish-reason';
 import { convertToOpenRouterChatMessages } from './convert-to-openrouter-chat-messages';
@@ -235,8 +234,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
           cachedInputTokens: 0,
         };
 
-    const reasoningDetails = (choice.message.reasoning_details ??
-      []) as ReasoningDetailUnion[];
+    const reasoningDetails = choice.message.reasoning_details ?? [];
 
     const reasoning: Array<LanguageModelV2Content> =
       reasoningDetails.length > 0

--- a/src/schemas/error-response.test.ts
+++ b/src/schemas/error-response.test.ts
@@ -1,22 +1,22 @@
-import { OpenRouterErrorResponseSchema } from "./error-response";
+import { OpenRouterErrorResponseSchema } from './error-response';
 
-describe("OpenRouterErrorResponseSchema", () => {
-  it("should be valid without a type, code, and param", () => {
+describe('OpenRouterErrorResponseSchema', () => {
+  it('should be valid without a type, code, and param', () => {
     const errorWithoutTypeCodeAndParam = {
       error: {
-        message: "Example error message",
-        metadata: { provider_name: "Morph" },
+        message: 'Example error message',
+        metadata: { provider_name: 'Morph' },
       },
-      user_id: "example_1",
+      user_id: 'example_1',
     };
 
     const result = OpenRouterErrorResponseSchema.parse(
-      errorWithoutTypeCodeAndParam
+      errorWithoutTypeCodeAndParam,
     );
 
     expect(result).toEqual({
       error: {
-        message: "Example error message",
+        message: 'Example error message',
         code: null,
         type: null,
         param: null,
@@ -24,14 +24,14 @@ describe("OpenRouterErrorResponseSchema", () => {
     });
   });
 
-  it("should be invalid with a type", () => {
+  it('should be invalid with a type', () => {
     const errorWithType = {
       error: {
-        message: "Example error message with type",
-        type: "invalid_request_error",
+        message: 'Example error message with type',
+        type: 'invalid_request_error',
         code: 400,
-        param: "canBeAnything",
-        metadata: { provider_name: "Morph" },
+        param: 'canBeAnything',
+        metadata: { provider_name: 'Morph' },
       },
     };
 
@@ -40,9 +40,9 @@ describe("OpenRouterErrorResponseSchema", () => {
     expect(result).toEqual({
       error: {
         code: 400,
-        message: "Example error message with type",
-        type: "invalid_request_error",
-        param: "canBeAnything",
+        message: 'Example error message with type',
+        type: 'invalid_request_error',
+        param: 'canBeAnything',
       },
     });
   });


### PR DESCRIPTION
This fixes returning the reasoning content with generateText().

streamText() does not have this problem.

Test included.

Downgrade to Zod v3 was necessary because of peer dependency problems:

```
 WARN  Issues with peer dependencies found
.
├─┬ ai 5.0.0-beta.24
│ └─┬ @ai-sdk/gateway 1.0.0-beta.10
│   └─┬ @ai-sdk/provider-utils 3.0.0-beta.5
│     └─┬ zod-to-json-schema 3.24.6
│       └── ✕ unmet peer zod@^3.24.1: found 4.0.5
└─┬ @openrouter/ai-sdk-provider 1.0.0-beta.3
  └── ✕ unmet peer zod@^3.24.1: found 4.0.5
```

Without this downgrade it is necessary to include Zod v4 manually in each client.

Disclaimer: Most code was generated with Sonnet-4 using GitHub Copilot agent.

Gimmick: DeepSeek R1 being totally reasonable as usual 

```json
      "request": {
        "body": {
          "model": "deepseek/deepseek-r1-0528:free",
          "messages": [
            {
              "role": "user",
              "content": "Reply with a simple, informal greeting. Do not overthink this, just reply with \"Hello.\""
            }
          ],
          "usage": {
            "include": true
          }
        }
```
->
```json
[
  {
    "type": "reasoning",
    "text": "Okay, the user just asked for a really straightforward thing: a simple, informal greeting. They even emphasized \"do not overthink\" and literally instructed to reply with \"Hello.\" \n\nHmm, seems like they might be testing if I can follow basic instructions without adding fluff. Or maybe they're just in a hurry and want minimal interaction. \n\nThe request is so clear-cut that there's zero ambiguity. No need to analyze deeper meaning here—they literally spelled out the desired response. \n\n*mentally shrugs* Alright then, playing it exactly as requested: one casual \"Hello.\" sent with zero extras. User gets what user asks for.\n"
  },
  {
    "type": "text",
    "text": "Hello. 😊"
  }
]
```