### PR TITLE
fix tool-input-delta being sent before tool-input-start

### DIFF
--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -601,6 +601,11 @@ describe('doStream', () => {
         modelId: 'gpt-3.5-turbo-0125',
       },
       {
+        id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
+        toolName: 'test-tool',
+        type: 'tool-input-start',
+      },
+      {
         type: 'tool-input-delta',
         id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
         delta: '{"',

--- a/src/schemas/error-response.test.ts
+++ b/src/schemas/error-response.test.ts
@@ -1,22 +1,22 @@
-import { OpenRouterErrorResponseSchema } from "./error-response";
+import { OpenRouterErrorResponseSchema } from './error-response';
 
-describe("OpenRouterErrorResponseSchema", () => {
-  it("should be valid without a type, code, and param", () => {
+describe('OpenRouterErrorResponseSchema', () => {
+  it('should be valid without a type, code, and param', () => {
     const errorWithoutTypeCodeAndParam = {
       error: {
-        message: "Example error message",
-        metadata: { provider_name: "Morph" },
+        message: 'Example error message',
+        metadata: { provider_name: 'Morph' },
       },
-      user_id: "example_1",
+      user_id: 'example_1',
     };
 
     const result = OpenRouterErrorResponseSchema.parse(
-      errorWithoutTypeCodeAndParam
+      errorWithoutTypeCodeAndParam,
     );
 
     expect(result).toEqual({
       error: {
-        message: "Example error message",
+        message: 'Example error message',
         code: null,
         type: null,
         param: null,
@@ -24,14 +24,14 @@ describe("OpenRouterErrorResponseSchema", () => {
     });
   });
 
-  it("should be invalid with a type", () => {
+  it('should be invalid with a type', () => {
     const errorWithType = {
       error: {
-        message: "Example error message with type",
-        type: "invalid_request_error",
+        message: 'Example error message with type',
+        type: 'invalid_request_error',
         code: 400,
-        param: "canBeAnything",
-        metadata: { provider_name: "Morph" },
+        param: 'canBeAnything',
+        metadata: { provider_name: 'Morph' },
       },
     };
 
@@ -40,9 +40,9 @@ describe("OpenRouterErrorResponseSchema", () => {
     expect(result).toEqual({
       error: {
         code: 400,
-        message: "Example error message with type",
-        type: "invalid_request_error",
-        param: "canBeAnything",
+        message: 'Example error message with type',
+        type: 'invalid_request_error',
+        param: 'canBeAnything',
       },
     });
   });


### PR DESCRIPTION
On version `1.0.0-beta.3` there is an issue where `tool-input-delta` chunk is enqueued before `tool-input-start` was sent.

In the SSE stream sometimes a tool call delta is received which does not include the tool function name in the arguments:


```
// Tool call started
data: {"id":"gen-1753201170-4Xxbbs9gEk5lOomh7OaE","provider":"Google","model":"anthropic/claude-sonnet-4","object":"chat.completion.chunk","created":1753201170,"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"id":"toolu_vrtx_01Cadi9gBFrWGMoeUzUrVUWa","index":0,"type":"function","function":{"name":"create-code-component","arguments":""}}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}


// Chunk without function name
data: {"id":"gen-1753201170-4Xxbbs9gEk5lOomh7OaE","provider":"Google","model":"anthropic/claude-sonnet-4","object":"chat.completion.chunk","created":1753201170,"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"type":"function","function":{"arguments":""}}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
```


Since the code already safely relies on the tool call index I believe it can also use that same state for tracking whether `tool-input-start` should be sent or not.