### PR TITLE
fix: prioritize reasoning_details over reasoning

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -539,9 +539,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
               });
             };
 
-            if (delta.reasoning != null) {
-              emitReasoningChunk(delta.reasoning);
-            }
+            
             if (delta.reasoning_details && delta.reasoning_details.length > 0) {
               for (const detail of delta.reasoning_details) {
                 switch (detail.type) {
@@ -570,7 +568,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
                 }
               }
             }
-
+            else if (delta.reasoning != null) {
+              emitReasoningChunk(delta.reasoning);
+            }
+            
             if (delta.tool_calls != null) {
               for (const toolCallDelta of delta.tool_calls) {
                 const index = toolCallDelta.index ?? toolCalls.length - 1;


### PR DESCRIPTION
to avoid sending duplicate reasoning in the stream.

https://github.com/OpenRouterTeam/ai-sdk-provider/issues/122

I'd also love to pitch removing the "redacted" from the stream but I assume its there for some reason? if theres an easy workaround I can implement to not including it in the stream that would be neat too though, since I dont really see it provide much value.