### PR TITLE
fix(chat): prevent error when a toolCall is not present at toolCalls index

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -706,7 +706,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
             // Forward any unsent tool calls if finish reason is 'tool-calls'
             if (finishReason === 'tool-calls') {
               for (const toolCall of toolCalls) {
-                if (!toolCall.sent) {
+                if (toolCall && !toolCall.sent) {
                   controller.enqueue({
                     type: 'tool-call',
                     toolCallId: toolCall.id ?? generateId(),


### PR DESCRIPTION
Hi!

I'm running into an issue where a `toolCall` is not present at index 0 and makes the stream crash:

```ts
[
  <1 empty item>,
  {
    id: 'call_RJG4TjguSFSb6m7lubC_8w',
    type: 'function',
    function: {
      name: 'updateWorkingMemory',
      arguments: '{"memory":"# User Information\\n- **First Name**: \\n- **Last Name**: \\n- **Location**: Dallas\\n- **Occupation**: \\n- **Interests**: \\n- **Goals**: \\n- **Events**: \\n- **Facts**: \\n- **Projects**:\\n"}'
    },
    sent: true
  }
]
```

This PR simply checks that the toolCall is defined before checking its `sent` property.
Also, this happens when using `deepseek/deepseek-chat-v3-0324`