### PR TITLE
feat: add dynamic provider field to providerMetadata

### DIFF
--- a/e2e/provider-metadata.test.ts
+++ b/e2e/provider-metadata.test.ts
@@ -1,0 +1,54 @@
+import { streamText, generateText } from 'ai';
+import { expect, it, describe } from 'vitest';
+import { createOpenRouter } from '../src';
+
+describe('Provider Metadata - Real API Tests', () => {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+  });
+
+  it('should extract provider field from generateText API response', async () => {
+    const model = openrouter('anthropic/claude-3.5-haiku');
+    const response = await generateText({
+      model,
+      prompt: 'What is 2+2?',
+      maxOutputTokens: 50,
+    });
+
+    expect(response.providerMetadata).toBeDefined();
+    expect(response.providerMetadata?.provider).toBeDefined();
+    expect(typeof response.providerMetadata?.provider).toBe('string');
+    expect(response.providerMetadata?.openrouter).toBeDefined();
+  });
+
+  it('should extract provider field from streamText API response', async () => {
+    const model = openrouter('anthropic/claude-3.5-haiku');
+    const response = streamText({
+      model,
+      prompt: 'What is 2+2?',
+      maxOutputTokens: 50,
+    });
+
+    await response.consumeStream();
+    const providerMetadata = await response.providerMetadata;
+    
+    expect(providerMetadata).toBeDefined();
+    expect(providerMetadata?.provider).toBeDefined();
+    expect(typeof providerMetadata?.provider).toBe('string');
+    expect(providerMetadata?.openrouter).toBeDefined();
+  });
+
+  it('should extract provider field from completion API response', async () => {
+    const model = openrouter.completion('openai/gpt-3.5-turbo-instruct');
+    const response = await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'What is 2+2?' }] }],
+      maxOutputTokens: 50,
+    });
+
+    expect(response.providerMetadata).toBeDefined();
+    expect((response.providerMetadata as any)?.provider).toBeDefined();
+    expect(typeof (response.providerMetadata as any)?.provider).toBe('string');
+    expect(response.providerMetadata?.openrouter).toBeDefined();
+  });
+});

--- a/e2e/usage-accounting.test.ts
+++ b/e2e/usage-accounting.test.ts
@@ -21,6 +21,7 @@ it('receive usage accounting', async () => {
       },
     ],
     onFinish(e) {
+      expect((e.providerMetadata as any)?.provider).toBeDefined();
       expect(e.providerMetadata?.openrouter).toMatchObject({
         usage: expect.objectContaining({
           promptTokens: expect.any(Number),
@@ -37,6 +38,7 @@ it('receive usage accounting', async () => {
   await response.consumeStream();
   const providerMetadata = await response.providerMetadata;
   // You can use expect.any(Type) or expect.objectContaining for schema-like matching
+  expect((providerMetadata as any)?.provider).toBeDefined();
   expect(providerMetadata?.openrouter).toMatchObject({
     usage: expect.objectContaining({
       promptTokens: expect.any(Number),

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -544,15 +544,15 @@ describe('doStream', () => {
     server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
       type: 'stream-chunks',
       chunks: [
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n`,
         ...content.flatMap((text) => {
-          return `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"${text}"},"finish_reason":null}]}\n\n`;
+          return `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","provider":"gpt-3.5-turbo-0613","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"${text}"},"finish_reason":null}]}\n\n`;
         }),
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"${finish_reason}","logprobs":${JSON.stringify(
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","provider":"gpt-3.5-turbo-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"${finish_reason}","logprobs":${JSON.stringify(
           logprobs,
         )}}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","system_fingerprint":"fp_3bc1b5746c","choices":[],"usage":${JSON.stringify(
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1702657020,"model":"gpt-3.5-turbo-0613","provider":"gpt-3.5-turbo-0613","system_fingerprint":"fp_3bc1b5746c","choices":[],"usage":${JSON.stringify(
           usage,
         )}}\n\n`,
         'data: [DONE]\n\n',
@@ -644,6 +644,7 @@ describe('doStream', () => {
         finishReason: 'stop',
 
         providerMetadata: {
+          provider: 'gpt-3.5-turbo-0613',
           openrouter: {
             usage: {
               completionTokens: 227,
@@ -743,34 +744,34 @@ describe('doStream', () => {
     server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
       type: 'stream-chunks',
       chunks: [
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
           `"tool_calls":[{"index":0,"id":"call_O17Uplv4lJvD6DVdIvFFeRMw","type":"function","function":{"name":"test-tool","arguments":""}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\""}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"value"}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\""}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Spark"}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"le"}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" Day"}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"}"}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[],"usage":{"prompt_tokens":53,"completion_tokens":17,"total_tokens":70}}\n\n`,
         'data: [DONE]\n\n',
       ],
@@ -924,6 +925,7 @@ describe('doStream', () => {
         type: 'finish',
         finishReason: 'tool-calls',
         providerMetadata: {
+          provider: 'gpt-3.5-turbo-0613',
           openrouter: {
             usage: {
               completionTokens: 17,
@@ -948,13 +950,13 @@ describe('doStream', () => {
     server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
       type: 'stream-chunks',
       chunks: [
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
           `"tool_calls":[{"index":0,"id":"call_O17Uplv4lJvD6DVdIvFFeRMw","type":"function","function":{"name":"test-tool","arguments":"{\\"value\\":\\"Sparkle Day\\"}"}}]},` +
           `"logprobs":null,"finish_reason":null}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}\n\n`,
-        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125","provider":"gpt-3.5-turbo-0613",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[],"usage":{"prompt_tokens":53,"completion_tokens":17,"total_tokens":70}}\n\n`,
         'data: [DONE]\n\n',
       ],
@@ -1027,6 +1029,7 @@ describe('doStream', () => {
         type: 'finish',
         finishReason: 'tool-calls',
         providerMetadata: {
+          provider: 'gpt-3.5-turbo-0613',
           openrouter: {
             usage: {
               completionTokens: 17,
@@ -1077,6 +1080,7 @@ describe('doStream', () => {
       {
         finishReason: 'error',
         providerMetadata: {
+          provider: undefined,
           openrouter: {
             usage: {},
           },
@@ -1112,6 +1116,7 @@ describe('doStream', () => {
 
       type: 'finish',
       providerMetadata: {
+        provider: undefined,
         openrouter: {
           usage: {},
         },

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -183,7 +183,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       headers?: SharedV2Headers;
       body?: unknown;
     };
-  }> {
+  }>{
     const providerOptions = options.providerOptions || {};
     const openrouterOptions = providerOptions.openrouter || {};
 
@@ -335,7 +335,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
             },
           },
         },
-      },
+        provider: response.provider,
+      } as any,
       request: { body: args },
       response: {
         id: response.id,
@@ -414,6 +415,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
 
     // Track provider-specific usage information
     const openrouterUsage: Partial<OpenRouterUsageAccounting> = {};
+    let provider: string | undefined;
 
     let textStarted = false;
     let reasoningStarted = false;
@@ -459,6 +461,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
                 type: 'response-metadata',
                 modelId: value.model,
               });
+            }
+
+            if (value.provider) {
+              provider = value.provider;
             }
 
             if (value.usage != null) {
@@ -742,7 +748,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
                 openrouter: {
                   usage: openrouterUsage,
                 },
-              },
+                provider: provider,
+              } as any,
             });
           },
         }),

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -5,6 +5,7 @@ import { ReasoningDetailArraySchema } from '../schemas/reasoning-details';
 const OpenRouterChatCompletionBaseResponseSchema = z.object({
   id: z.string().optional(),
   model: z.string().optional(),
+  provider: z.string().optional(),
   usage: z
     .object({
       prompt_tokens: z.number(),

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -260,12 +260,12 @@ describe('doStream', () => {
       type: 'stream-chunks',
       chunks: [
         ...content.map((text) => {
-          return `data: {"id":"cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT","object":"text_completion","created":1711363440,"choices":[{"text":"${text}","index":0,"logprobs":null,"finish_reason":null}],"model":"openai/gpt-3.5-turbo-instruct"}\n\n`;
+          return `data: {"id":"cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT","object":"text_completion","created":1711363440,"choices":[{"text":"${text}","index":0,"logprobs":null,"finish_reason":null}],"model":"openai/gpt-3.5-turbo-instruct","provider":"openai/gpt-3.5-turbo-instruct"}\n\n`;
         }),
         `data: {"id":"cmpl-96c3yLQE1TtZCd6n6OILVmzev8M8H","object":"text_completion","created":1711363310,"choices":[{"text":"","index":0,"logprobs":${JSON.stringify(
           logprobs,
-        )},"finish_reason":"${finish_reason}"}],"model":"openai/gpt-3.5-turbo-instruct"}\n\n`,
-        `data: {"id":"cmpl-96c3yLQE1TtZCd6n6OILVmzev8M8H","object":"text_completion","created":1711363310,"model":"openai/gpt-3.5-turbo-instruct","usage":${JSON.stringify(
+        )},"finish_reason":"${finish_reason}"}],"model":"openai/gpt-3.5-turbo-instruct","provider":"openai/gpt-3.5-turbo-instruct"}\n\n`,
+        `data: {"id":"cmpl-96c3yLQE1TtZCd6n6OILVmzev8M8H","object":"text_completion","created":1711363310,"model":"openai/gpt-3.5-turbo-instruct","provider":"openai/gpt-3.5-turbo-instruct","usage":${JSON.stringify(
           usage,
         )},"choices":[]}\n\n`,
         'data: [DONE]\n\n',
@@ -300,6 +300,7 @@ describe('doStream', () => {
         type: 'finish',
         finishReason: 'stop',
         providerMetadata: {
+          provider: 'openai/gpt-3.5-turbo-instruct',
           openrouter: {
             usage: {
               promptTokens: 10,
@@ -350,6 +351,7 @@ describe('doStream', () => {
       {
         finishReason: 'error',
         providerMetadata: {
+          provider: undefined,
           openrouter: {
             usage: {},
           },
@@ -383,6 +385,7 @@ describe('doStream', () => {
     expect(elements[1]).toStrictEqual({
       finishReason: 'error',
       providerMetadata: {
+        provider: undefined,
         openrouter: {
           usage: {},
         },

--- a/src/completion/schemas.ts
+++ b/src/completion/schemas.ts
@@ -8,6 +8,7 @@ export const OpenRouterCompletionChunkSchema = z.union([
   z.object({
     id: z.string().optional(),
     model: z.string().optional(),
+    provider: z.string().optional(),
     choices: z.array(
       z.object({
         text: z.string(),

--- a/src/tests/usage-accounting.test.ts
+++ b/src/tests/usage-accounting.test.ts
@@ -15,6 +15,7 @@ describe('OpenRouter Usage Accounting', () => {
     const response = {
       id: 'test-id',
       model: 'test-model',
+      provider: 'test-model',
       choices: [
         {
           message: {
@@ -115,6 +116,9 @@ describe('OpenRouter Usage Accounting', () => {
     expect(result.providerMetadata).toBeDefined();
     const providerData = result.providerMetadata;
 
+    // Check for provider field
+    expect((providerData as any)?.provider).toBe('test-model');
+
     // Check for OpenRouter usage data
     expect(providerData?.openrouter).toBeDefined();
     const openrouterData = providerData?.openrouter as Record<string, unknown>;
@@ -162,7 +166,10 @@ describe('OpenRouter Usage Accounting', () => {
       maxOutputTokens: 100,
     });
 
-    // Verify that OpenRouter metadata is not included
+    // Verify that provider field is included
+    expect((result.providerMetadata as any)?.provider).toBe('test-model');
+
+    // Verify that OpenRouter metadata is included
     expect(result.providerMetadata?.openrouter?.usage).toStrictEqual({
       promptTokens: 10,
       completionTokens: 20,


### PR DESCRIPTION
# feat: add dynamic provider field to providerMetadata

## Summary

This PR adds a `provider` field to the `providerMetadata` object returned by both chat and completion language models. The provider field is dynamically extracted from OpenRouter API response chunks rather than being hardcoded, providing accurate provider information (e.g., "anthropic", "openai") for each API call.

**Key Changes:**
- Added optional `provider` field to response schemas for both chat and completion models
- Updated `doGenerate` and `doStream` methods to extract provider from API response chunks
- Modified all unit tests to include provider field validation
- Created new E2E tests to verify provider extraction from real API responses

## Review & Testing Checklist for Human

- [ ] **Test with real OpenRouter API calls** - Verify the provider field is correctly extracted and contains actual provider names (not model names)
- [ ] **Test edge cases** - Check behavior when provider field is missing from API response chunks (should be undefined)
- [ ] **Verify streaming vs non-streaming** - Test both response types to ensure provider extraction works in all scenarios
- [ ] **Run E2E tests with proper credentials** - The E2E tests couldn't run due to missing OPENROUTER_API_KEY environment variable

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    ChatIndex["src/chat/index.ts<br/>Chat Model Implementation"]:::major-edit
    ChatSchemas["src/chat/schemas.ts<br/>Chat Response Schemas"]:::major-edit
    CompletionIndex["src/completion/index.ts<br/>Completion Model Implementation"]:::major-edit
    CompletionSchemas["src/completion/schemas.ts<br/>Completion Response Schemas"]:::major-edit
    
    ChatTests["src/chat/index.test.ts<br/>Chat Unit Tests"]:::minor-edit
    CompletionTests["src/completion/index.test.ts<br/>Completion Unit Tests"]:::minor-edit
    UsageTests["src/tests/usage-accounting.test.ts<br/>Usage Accounting Tests"]:::minor-edit
    E2ETests["e2e/provider-metadata.test.ts<br/>E2E Provider Tests"]:::minor-edit
    
    API["OpenRouter API<br/>Response Chunks"]:::context
    
    API -->|provides provider field| ChatIndex
    API -->|provides provider field| CompletionIndex
    ChatSchemas -->|defines structure| ChatIndex
    CompletionSchemas -->|defines structure| CompletionIndex
    
    ChatIndex -->|tested by| ChatTests
    CompletionIndex -->|tested by| CompletionTests
    ChatIndex -->|tested by| E2ETests
    CompletionIndex -->|tested by| E2ETests
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Link to Devin run**: https://app.devin.ai/sessions/0e4cfdb1ac15408aa2109a9b777713ec
- **Requested by**: @louisgv (louis@openrouter.ai)
- The provider field extraction follows the user's requirement to get the value directly from API response chunks, not from the model field
- All unit tests pass (63/63), but E2E tests require OpenRouter API credentials to verify real-world behavior
- The implementation handles cases where provider field might be undefined (no fallback to model name per user request)