### PR TITLE
fix: Pass through json schema for generateObject and streamObject

### DIFF
--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -524,6 +524,8 @@ describe('doGenerate', () => {
       responseFormat: {
         type: 'json',
         schema: testSchema,
+        name: 'PersonResponse',
+        description: 'A person object',
       },
     });
 
@@ -533,9 +535,64 @@ describe('doGenerate', () => {
       response_format: {
         type: 'json_schema',
         json_schema: {
-          name: 'response',
-          strict: true,
           schema: testSchema,
+          strict: true,
+          name: 'PersonResponse',
+          description: 'A person object',
+        },
+      },
+    });
+  });
+
+  it('should pass responseFormat for JSON object without schema', async () => {
+    prepareJsonResponse({ content: '{"message": "Hello"}' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+      },
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_object',
+      },
+    });
+  });
+
+  it('should use default name when name is not provided in responseFormat', async () => {
+    prepareJsonResponse({ content: '{"name": "John", "age": 30}' });
+
+    const testSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name', 'age'],
+      additionalProperties: false,
+    };
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: testSchema,
+      },
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          schema: testSchema,
+          strict: true,
+          name: 'response',
         },
       },
     });
@@ -1253,6 +1310,8 @@ describe('doStream', () => {
       responseFormat: {
         type: 'json',
         schema: testSchema,
+        name: 'PersonResponse',
+        description: 'A person object',
       },
     });
 
@@ -1264,10 +1323,32 @@ describe('doStream', () => {
       response_format: {
         type: 'json_schema',
         json_schema: {
-          name: 'response',
-          strict: true,
           schema: testSchema,
+          strict: true,
+          name: 'PersonResponse',
+          description: 'A person object',
         },
+      },
+    });
+  });
+
+  it('should pass responseFormat for JSON object without schema in streaming', async () => {
+    prepareStreamResponse({ content: ['{"message": "Hello"}'] });
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+      },
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      stream: true,
+      stream_options: { include_usage: true },
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_object',
       },
     });
   });

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -505,6 +505,41 @@ describe('doGenerate', () => {
       'custom-request-header': 'request-header-value',
     });
   });
+
+  it('should pass responseFormat for JSON schema structured outputs', async () => {
+    prepareJsonResponse({ content: '{"name": "John", "age": 30}' });
+
+    const testSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name', 'age'],
+      additionalProperties: false,
+    };
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: testSchema,
+      },
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'response',
+          strict: true,
+          schema: testSchema,
+        },
+      },
+    });
+  });
 });
 
 describe('doStream', () => {
@@ -706,34 +741,38 @@ describe('doStream', () => {
     });
 
     const elements = await convertReadableStreamToArray(stream);
-    
+
     // Filter for reasoning-related elements
-    const reasoningElements = elements.filter(el => 
-      el.type === 'reasoning-start' || 
-      el.type === 'reasoning-delta' || 
-      el.type === 'reasoning-end'
+    const reasoningElements = elements.filter(
+      (el) =>
+        el.type === 'reasoning-start' ||
+        el.type === 'reasoning-delta' ||
+        el.type === 'reasoning-end',
     );
-    
+
     // Debug output to see what we're getting
     // console.log('Reasoning elements count:', reasoningElements.length);
     // console.log('Reasoning element types:', reasoningElements.map(el => el.type));
-    
+
     // We should get reasoning content from reasoning_details when present, not reasoning field
     // start + 4 deltas (text, summary, encrypted, reasoning-only) + end = 6
     expect(reasoningElements).toHaveLength(6);
-    
+
     // Verify the content comes from reasoning_details, not reasoning field
     const reasoningDeltas = reasoningElements
-      .filter(el => el.type === 'reasoning-delta')
-      .map(el => (el as { type: 'reasoning-delta'; delta: string; id: string }).delta);
-    
+      .filter((el) => el.type === 'reasoning-delta')
+      .map(
+        (el) =>
+          (el as { type: 'reasoning-delta'; delta: string; id: string }).delta,
+      );
+
     expect(reasoningDeltas).toEqual([
-      'Let me think about this...',  // from reasoning_details text
-      'User wants a greeting',        // from reasoning_details summary
-      '[REDACTED]',                   // from reasoning_details encrypted
-      'This reasoning is used',       // from reasoning field (no reasoning_details)
+      'Let me think about this...', // from reasoning_details text
+      'User wants a greeting', // from reasoning_details summary
+      '[REDACTED]', // from reasoning_details encrypted
+      'This reasoning is used', // from reasoning field (no reasoning_details)
     ]);
-    
+
     // Verify that "This should be ignored..." and "Also ignored" are NOT in the output
     expect(reasoningDeltas).not.toContain('This should be ignored...');
     expect(reasoningDeltas).not.toContain('Also ignored');
@@ -1194,5 +1233,42 @@ describe('doStream', () => {
       'providers.anthropic.custom_field',
       'custom_value',
     );
+  });
+
+  it('should pass responseFormat for JSON schema structured outputs', async () => {
+    prepareStreamResponse({ content: ['{"name": "John", "age": 30}'] });
+
+    const testSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name', 'age'],
+      additionalProperties: false,
+    };
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: testSchema,
+      },
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      stream: true,
+      stream_options: { include_usage: true },
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'response',
+          strict: true,
+          schema: testSchema,
+        },
+      },
+    });
   });
 });

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -544,25 +544,6 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass responseFormat for JSON object without schema', async () => {
-    prepareJsonResponse({ content: '{"message": "Hello"}' });
-
-    await model.doGenerate({
-      prompt: TEST_PROMPT,
-      responseFormat: {
-        type: 'json',
-      },
-    });
-
-    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
-      model: 'anthropic/claude-3.5-sonnet',
-      messages: [{ role: 'user', content: 'Hello' }],
-      response_format: {
-        type: 'json_object',
-      },
-    });
-  });
-
   it('should use default name when name is not provided in responseFormat', async () => {
     prepareJsonResponse({ content: '{"name": "John", "age": 30}' });
 
@@ -1328,27 +1309,6 @@ describe('doStream', () => {
           name: 'PersonResponse',
           description: 'A person object',
         },
-      },
-    });
-  });
-
-  it('should pass responseFormat for JSON object without schema in streaming', async () => {
-    prepareStreamResponse({ content: ['{"message": "Hello"}'] });
-
-    await model.doStream({
-      prompt: TEST_PROMPT,
-      responseFormat: {
-        type: 'json',
-      },
-    });
-
-    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
-      stream: true,
-      stream_options: { include_usage: true },
-      model: 'anthropic/claude-3.5-sonnet',
-      messages: [{ role: 'user', content: 'Hello' }],
-      response_format: {
-        type: 'json_object',
       },
     });
   });

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -139,7 +139,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
     if (responseFormat?.type === 'json') {
       return {
         ...baseArgs,
-        response_format: { type: 'json_object' },
+        response_format: {
+          type: "json_object",
+          json_schema: responseFormat.schema,
+        },
       };
     }
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -140,8 +140,12 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       return {
         ...baseArgs,
         response_format: {
-          type: "json_object",
-          json_schema: responseFormat.schema,
+          type: 'json_schema',
+          json_schema: {
+            name: 'response',
+            strict: true,
+            schema: responseFormat.schema,
+          },
         },
       };
     }
@@ -526,7 +530,6 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
               });
             };
 
-            
             if (delta.reasoning_details && delta.reasoning_details.length > 0) {
               for (const detail of delta.reasoning_details) {
                 switch (detail.type) {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -136,23 +136,20 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       ...this.settings.extraBody,
     };
 
-    if (responseFormat?.type === 'json') {
+    if (responseFormat?.type === 'json' && responseFormat.schema != null) {
       return {
         ...baseArgs,
-        response_format:
-          responseFormat.schema != null
-            ? {
-                type: 'json_schema',
-                json_schema: {
-                  schema: responseFormat.schema,
-                  strict: true,
-                  name: responseFormat.name ?? 'response',
-                  ...(responseFormat.description && {
-                    description: responseFormat.description,
-                  }),
-                },
-              }
-            : { type: 'json_object' },
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            schema: responseFormat.schema,
+            strict: true,
+            name: responseFormat.name ?? 'response',
+            ...(responseFormat.description && {
+              description: responseFormat.description,
+            }),
+          },
+        },
       };
     }
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -136,7 +136,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       ...this.settings.extraBody,
     };
 
-    if (responseFormat?.type === 'json') {
+    if (responseFormat?.type === 'json' && responseFormat.schema !== null) {
       return {
         ...baseArgs,
         response_format: {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -136,17 +136,23 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       ...this.settings.extraBody,
     };
 
-    if (responseFormat?.type === 'json' && responseFormat.schema !== null) {
+    if (responseFormat?.type === 'json') {
       return {
         ...baseArgs,
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'response',
-            strict: true,
-            schema: responseFormat.schema,
-          },
-        },
+        response_format:
+          responseFormat.schema != null
+            ? {
+                type: 'json_schema',
+                json_schema: {
+                  schema: responseFormat.schema,
+                  strict: true,
+                  name: responseFormat.name ?? 'response',
+                  ...(responseFormat.description && {
+                    description: responseFormat.description,
+                  }),
+                },
+              }
+            : { type: 'json_object' },
       };
     }
 


### PR DESCRIPTION
- Fixes https://github.com/OpenRouterTeam/ai-sdk-provider/issues/120

## What

- Pass through responseFormat.schema so schema gets passed to models for generateObject and streamObject
- Update `json_object` to `json_schema` to math openrouter schema (docs [here](https://openrouter.ai/docs/features/structured-outputs))
- Add tests for generateObject and streamObject

