### PR TITLE
feat: add web search and provider routing support

### DIFF
--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -53,6 +53,20 @@ export const OpenRouterNonStreamChatCompletionResponseSchema =
               }),
             )
             .optional(),
+
+          /**
+           * Web search annotations containing citation information
+           */
+          annotations: z.array(
+            z.object({
+              type: z.literal('url_citation'),
+              url: z.string(),
+              title: z.string().optional(),
+              content: z.string().optional(),
+              start_index: z.number().optional(),
+              end_index: z.number().optional(),
+            })
+          ).optional(),
         }),
         index: z.number().nullish(),
         logprobs: z
@@ -103,6 +117,20 @@ export const OpenRouterStreamChatCompletionChunkSchema = z.union([
                 }),
               )
               .nullish(),
+
+            /**
+             * Web search annotations containing citation information
+             */
+            annotations: z.array(
+              z.object({
+                type: z.literal('url_citation'),
+                url: z.string(),
+                title: z.string().optional(),
+                content: z.string().optional(),
+                start_index: z.number().optional(),
+                end_index: z.number().optional(),
+              })
+            ).optional(),
           })
           .nullish(),
         logprobs: z

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -43,4 +43,81 @@ A unique identifier representing your end-user, which can help OpenRouter to
 monitor and detect abuse. Learn more.
 */
   user?: string;
+
+  /**
+   * Web search plugin configuration for enabling web search capabilities
+   */
+  plugins?: Array<{
+    type: 'web';
+    /**
+     * Maximum number of search results to include (default: 5)
+     */
+    max_results?: number;
+    /**
+     * Custom search prompt to guide the search query
+     */
+    search_prompt?: string;
+  }>;
+
+  /**
+   * Built-in web search options for models that support native web search
+   */
+  web_search_options?: {
+    /**
+     * Maximum number of search results to include
+     */
+    max_results?: number;
+    /**
+     * Custom search prompt to guide the search query  
+     */
+    search_prompt?: string;
+  };
+
+  /**
+   * Provider routing preferences to control request routing behavior
+   */
+  provider?: {
+    /**
+     * List of provider slugs to try in order (e.g. ["anthropic", "openai"])
+     */
+    order?: string[];
+    /**
+     * Whether to allow backup providers when primary is unavailable (default: true)
+     */
+    allow_fallbacks?: boolean;
+    /**
+     * Only use providers that support all parameters in your request (default: false)
+     */
+    require_parameters?: boolean;
+    /**
+     * Control whether to use providers that may store data
+     */
+    data_collection?: 'allow' | 'deny';
+    /**
+     * List of provider slugs to allow for this request
+     */
+    only?: string[];
+    /**
+     * List of provider slugs to skip for this request
+     */
+    ignore?: string[];
+    /**
+     * List of quantization levels to filter by (e.g. ["int4", "int8"])
+     */
+    quantizations?: Array<'int4' | 'int8' | 'fp4' | 'fp6' | 'fp8' | 'fp16' | 'bf16' | 'fp32' | 'unknown'>;
+    /**
+     * Sort providers by price, throughput, or latency
+     */
+    sort?: 'price' | 'throughput' | 'latency';
+    /**
+     * Maximum pricing you want to pay for this request
+     */
+    max_price?: {
+      prompt?: number | string;
+      completion?: number | string;
+      image?: number | string;
+      audio?: number | string;
+      request?: number | string;
+    };
+  };
 } & OpenRouterSharedSettings;


### PR DESCRIPTION
# feat: add web search and provider routing support

## Summary

This PR adds comprehensive support for OpenRouter's web search and provider routing features to the AI SDK provider. The implementation includes:

**Web Search Support:**
- Plugin-based web search via `plugins` array with `web` type
- Built-in web search via `web_search_options` parameter  
- Automatic web search enablement for models with `:online` suffix
- Web search annotation processing in both streaming and non-streaming responses

**Provider Routing Support:**
- Complete provider routing configuration including `order`, `allow_fallbacks`, `require_parameters`, `data_collection`
- Advanced filtering options: `only`, `ignore`, `quantizations`, `sort`, `max_price`
- Support for all documented quantization levels and sorting criteria

The implementation maintains backward compatibility and follows existing code patterns for parameter handling and response processing.

## Review & Testing Checklist for Human

- [ ] **Test web search functionality end-to-end** - Verify both plugin-based (`plugins: [{ type: 'web' }]`) and built-in (`web_search_options`) approaches work with real API calls
- [ ] **Verify provider routing parameters** - Test that provider routing options like `order`, `sort`, `quantizations`, etc. are properly sent to the API and affect routing behavior
- [ ] **Check `:online` model suffix handling** - Confirm that using a model ID ending in `:online` automatically enables web search when no explicit plugins are provided
- [ ] **Validate annotation processing** - Ensure web search annotations appear correctly in responses and don't break existing content handling
- [ ] **Test for regressions** - Verify existing chat completion functionality (without web search/routing) still works correctly

**Recommended test plan:**
1. Test basic web search: `openrouter('meta-llama/llama-3.1-8b-instruct:online', { ... })`
2. Test plugin configuration: `plugins: [{ type: 'web', max_results: 3, search_prompt: 'Find recent news' }]`
3. Test provider routing: `provider: { order: ['anthropic', 'openai'], sort: 'price' }`
4. Verify streaming responses include annotations correctly
5. Test edge cases like empty annotations, malformed URLs, etc.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    User[User Code] --> Settings["src/types/openrouter-chat-settings.ts"]:::major-edit
    Settings --> ChatModel["src/chat/index.ts"]:::major-edit
    ChatModel --> Schemas["src/chat/schemas.ts"]:::major-edit
    ChatModel --> API[OpenRouter API]:::context
    API --> Responses[API Responses]:::context
    Responses --> ChatModel
    
    Settings --> WebSearch["Web Search Types<br/>plugins, web_search_options"]:::major-edit
    Settings --> Routing["Provider Routing Types<br/>order, sort, quantizations"]:::major-edit
    
    ChatModel --> GetArgs["getArgs() method<br/>:online suffix handling"]:::major-edit
    ChatModel --> Processing["Response Processing<br/>annotations handling"]:::major-edit
    
    Schemas --> Annotations["Annotation Schemas<br/>url_citation objects"]:::major-edit

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit    
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Session Info**: Requested by Louis (@louisgv) - Session: https://app.devin.ai/sessions/1eae218929d5447b867ff4fd78634672
- **Type Safety**: All new types are optional to maintain backward compatibility
- **Documentation**: Types include comprehensive JSDoc comments explaining each parameter
- **Testing**: All existing tests pass, but new functionality requires manual API testing
- **Risk Level**: Medium-High - Substantial new functionality that couldn't be fully validated without live API access

The implementation replicates OpenRouter's documented API structure but should be validated against actual API behavior, especially for edge cases in web search annotation handling and provider routing parameter validation.