### PR TITLE
feat: add provider routing support

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -131,6 +131,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       reasoning: this.settings.reasoning,
       usage: this.settings.usage,
 
+      // Provider routing settings:
+      provider: this.settings.provider,
+
       // extra body:
       ...this.config.extraBody,
       ...this.settings.extraBody,

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -43,4 +43,52 @@ A unique identifier representing your end-user, which can help OpenRouter to
 monitor and detect abuse. Learn more.
 */
   user?: string;
+
+  /**
+   * Provider routing preferences to control request routing behavior
+   */
+  provider?: {
+    /**
+     * List of provider slugs to try in order (e.g. ["anthropic", "openai"])
+     */
+    order?: string[];
+    /**
+     * Whether to allow backup providers when primary is unavailable (default: true)
+     */
+    allow_fallbacks?: boolean;
+    /**
+     * Only use providers that support all parameters in your request (default: false)
+     */
+    require_parameters?: boolean;
+    /**
+     * Control whether to use providers that may store data
+     */
+    data_collection?: 'allow' | 'deny';
+    /**
+     * List of provider slugs to allow for this request
+     */
+    only?: string[];
+    /**
+     * List of provider slugs to skip for this request
+     */
+    ignore?: string[];
+    /**
+     * List of quantization levels to filter by (e.g. ["int4", "int8"])
+     */
+    quantizations?: Array<'int4' | 'int8' | 'fp4' | 'fp6' | 'fp8' | 'fp16' | 'bf16' | 'fp32' | 'unknown'>;
+    /**
+     * Sort providers by price, throughput, or latency
+     */
+    sort?: 'price' | 'throughput' | 'latency';
+    /**
+     * Maximum pricing you want to pay for this request
+     */
+    max_price?: {
+      prompt?: number | string;
+      completion?: number | string;
+      image?: number | string;
+      audio?: number | string;
+      request?: number | string;
+    };
+  };
 } & OpenRouterSharedSettings;


### PR DESCRIPTION
# feat: add provider routing support

## Summary

This PR adds comprehensive provider routing support to the OpenRouter AI SDK provider, enabling developers to control how requests are routed across OpenRouter's provider network. The implementation adds optional provider routing parameters to chat settings and passes them through to the OpenRouter API.

**Key Changes:**
- Added `provider` field to `OpenRouterChatSettings` with full routing configuration options
- Updated request handling in `getArgs` method to include provider routing parameters
- All new fields are optional to maintain backward compatibility

**Provider Routing Features Added:**
- `order`: Specify preferred provider order (e.g. `["anthropic", "openai"]`)
- `allow_fallbacks`: Control backup provider usage when primary is unavailable
- `require_parameters`: Only use providers supporting all request parameters
- `data_collection`: Control whether providers may store data (`allow`/`deny`)
- `only`/`ignore`: Allow/block specific provider lists
- `quantizations`: Filter by quantization levels (`int4`, `int8`, `fp4`, etc.)
- `sort`: Sort providers by `price`, `throughput`, or `latency`
- `max_price`: Set maximum pricing limits per token/request type

## Review & Testing Checklist for Human

- [ ] **Verify parameter names match OpenRouter API documentation exactly** - The parameter names and structure should be cross-referenced against the official OpenRouter provider routing documentation
- [ ] **Test actual API calls with provider routing parameters** - Create test requests with various routing configurations to ensure they work as expected with the live OpenRouter API
- [ ] **Validate quantization enum completeness** - Check that all supported quantization levels are included and spelled correctly

**Recommended Test Plan:**
1. Test basic provider ordering with `order: ["anthropic", "openai"]`
2. Test provider filtering with `only` and `ignore` parameters
3. Test price-based routing with `max_price` settings
4. Verify backward compatibility with existing code (no provider routing specified)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    Client[Client Application] --> Settings[OpenRouterChatSettings]
    Settings --> ChatModel[OpenRouterChatLanguageModel]
    ChatModel --> GetArgs[getArgs method]
    GetArgs --> API[OpenRouter API]
    
    Settings -.-> ProviderConfig[provider routing config]:::major-edit
    ProviderConfig -.-> GetArgs
    
    subgraph "Files Modified"
        TypesFile["src/types/<br/>openrouter-chat-settings.ts"]:::major-edit
        ChatFile["src/chat/index.ts"]:::minor-edit
    end
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

This PR is part 1 of splitting the original combined web search + provider routing PR into focused, reviewable chunks. The implementation is straightforward parameter passing with comprehensive TypeScript types and JSDoc documentation.

**Session Details:**
- Devin session: https://app.devin.ai/sessions/1eae218929d5447b867ff4fd78634672
- Requested by: Louis (@louisgv)
- Link to Devin run: https://app.devin.ai/sessions/1eae218929d5447b867ff4fd78634672

**Testing Status:**
- ✅ TypeScript compilation passes
- ✅ All existing tests pass (67/67 in both Node and Edge environments)
- ⚠️ Live API testing with provider routing parameters recommended