### PR TITLE
fix: use actual tool description instead of type

### DIFF
--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -438,6 +438,7 @@ describe('doGenerate', () => {
         {
           type: 'function',
           name: 'test-tool',
+          description: 'Test tool',
           inputSchema: {
             type: 'object',
             properties: { value: { type: 'string' } },
@@ -461,7 +462,7 @@ describe('doGenerate', () => {
           type: 'function',
           function: {
             name: 'test-tool',
-            description: 'function',
+            description: 'Test tool',
             parameters: {
               type: 'object',
               properties: { value: { type: 'string' } },

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -167,7 +167,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
           type: 'function' as const,
           function: {
             name: tool.name,
-            description: tool.type,
+            description: tool.description,
             parameters: tool.inputSchema,
           },
         }));


### PR DESCRIPTION
When defining tools in the AI SDK

```ts
export const sendRequestTool = tool({
  description: "Send the current HTTP request for this replay session",
  inputSchema: z.object({}),
  execute: async () => {},
});
```

According to the [OpenRouter docs](https://openrouter.ai/docs/features/tool-calling), the `description` should be sent in the `tools[].function.description` field so the model knows when and how to use the tool

Currently, the OpenRouter provider sends `tool.type` instead of the actual `description`, resulting in requests like this

<img width="492" height="353" alt="CleanShot 2025-08-08 at 22 24 20" src="https://github.com/user-attachments/assets/4ddd2de2-f885-44e7-ba60-15eaf8433201" />  

This PR updates the provider to send the correct `description` value, matching the behavior described in the OpenRouter docs and used by other ai sdk providers

<img width="492" height="286" alt="CleanShot 2025-08-08 at 22 16 32" src="https://github.com/user-attachments/assets/ba22e28e-3ee1-4409-8ff0-074980415e74" /> 