### PR TITLE
feat: add v4 release tagging workflow

### DIFF
--- a/.github/workflows/v4-release.yaml
+++ b/.github/workflows/v4-release.yaml
@@ -1,0 +1,33 @@
+name: V4 Release Tagging
+on:
+  push:
+    branches: [ai-sdk-v4]
+  workflow_dispatch: {}
+
+jobs:
+  tag-v4-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm build
+      - run: pnpm test
+      - name: Create/Update v4 tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f v4
+          git push origin v4 --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# feat: add v4 release tagging workflow

## Summary

This PR adds a new GitHub Actions workflow (`v4-release.yaml`) that automatically creates/updates a `v4` git tag whenever releases are pushed to the `ai-sdk-v4` branch. The workflow follows the same pattern as the existing `publish.yaml` workflow, including build validation steps (typecheck, build, test) before creating the tag.

**Key changes:**
- New workflow file: `.github/workflows/v4-release.yaml`
- Triggers on pushes to `ai-sdk-v4` branch and manual workflow dispatch
- Creates/force-updates a `v4` tag pointing to the latest commit on the branch
- Includes quality gates (typecheck, build, test) before tagging

## Review & Testing Checklist for Human

- [ ] **Verify trigger mechanism**: Confirm that triggering on pushes to `ai-sdk-v4` branch aligns with your intended v4 release process (vs GitHub releases or other mechanisms)
- [ ] **Test force tag behavior**: The workflow uses `git push origin v4 --force` - verify this is acceptable and won't conflict with existing v4 tags or release processes
- [ ] **Validate ai-sdk-v4 branch setup**: Ensure the `ai-sdk-v4` branch exists and will contain appropriate release content when pushed to
- [ ] **Test workflow manually**: Consider running the workflow manually via workflow_dispatch to verify it works correctly in your repository environment
- [ ] **Review permissions**: Confirm `contents: write` permission is appropriate for this workflow's tag creation needs

**Recommended test plan**: 
1. Merge this PR to main
2. Make a test push to the `ai-sdk-v4` branch 
3. Verify the workflow runs successfully and creates/updates the `v4` tag as expected
4. Check that the tag points to the correct commit

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    PushToV4["Push to ai-sdk-v4<br/>branch"]:::context
    WorkflowFile[".github/workflows/<br/>v4-release.yaml"]:::major-edit
    BuildSteps["Build & Test<br/>(typecheck, build, test)"]:::context
    TagCreation["Create/Update<br/>v4 tag"]:::context
    
    PushToV4 --> WorkflowFile
    WorkflowFile --> BuildSteps
    BuildSteps --> TagCreation
    
    ExistingPublish[".github/workflows/<br/>publish.yaml"]:::context
    ExistingCI[".github/workflows/<br/>ci.yaml"]:::context
    
    ExistingPublish -.->|"pattern reference"| WorkflowFile
    ExistingCI -.->|"build steps reference"| WorkflowFile

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Assumptions made during implementation:**
- Single `v4` tag that gets force-updated vs versioned tags (v4.0.0, v4.0.1, etc.)
- Push-based triggering vs GitHub release-based triggering
- Force-pushing tags is acceptable behavior for this use case

**Session details:**
- Requested by Louis (@louisgv) 
- Devin session: https://app.devin.ai/sessions/1808369c2e8e45729635e23cd9763a9d


The workflow is modeled after the existing `publish.yaml` workflow but adapted for the v4 tagging use case. The force tag push ensures the `v4` tag always points to the latest release on the `ai-sdk-v4` branch.