### PR TITLE
Add GPT-5 context visibility bug reproduction test

### DIFF
--- a/e2e/gpt5-context-visibility-bug.test.ts
+++ b/e2e/gpt5-context-visibility-bug.test.ts
@@ -1,0 +1,127 @@
+import { streamText } from 'ai';
+import { it, vi, expect, describe } from 'vitest';
+import { createOpenRouter } from '../src';
+
+vi.setConfig({
+  testTimeout: 120_000,
+});
+
+describe('GPT-5 Context Visibility Bug', () => {
+  const multiPartTextMessage = [
+    {
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'projects/web/features/playground/persistence/arti' },
+        { type: 'text' as const, text: 'projects/web/features/playground/services/esbuild' },
+        { type: 'text' as const, text: 'projects/web/features/playground/stores/chatroom-' },
+        { type: 'text' as const, text: 'projects/web/features/playground/state/artifacts/' },
+        { type: 'text' as const, text: 'projects/web/features/playground/ui/Artifacts/Art' },
+      ],
+    },
+    {
+      role: 'user' as const,
+      content: [{ type: 'text' as const, text: 'Can you see the UI components that I\'ve provided you with?' }],
+    },
+  ];
+
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+  });
+
+  it('should reproduce GPT-5 context visibility issue', async () => {
+    const gpt5Model = openrouter('openai/gpt-5');
+    const gpt5Response = await streamText({
+      model: gpt5Model,
+      messages: multiPartTextMessage,
+    });
+    
+    await gpt5Response.consumeStream();
+    const gpt5Text = await gpt5Response.text;
+    
+    const gpt41Model = openrouter('openai/gpt-4.1');
+    const gpt41Response = await streamText({
+      model: gpt41Model,
+      messages: multiPartTextMessage,
+    });
+    
+    await gpt41Response.consumeStream();
+    const gpt41Text = await gpt41Response.text;
+    
+    const geminiModel = openrouter('google/gemini-2.5-flash-exp');
+    const geminiResponse = await streamText({
+      model: geminiModel,
+      messages: multiPartTextMessage,
+    });
+    
+    await geminiResponse.consumeStream();
+    const geminiText = await geminiResponse.text;
+    
+    console.log('=== GPT-5 Response ===');
+    console.log(gpt5Text);
+    console.log('\n=== GPT-4.1 Response ===');
+    console.log(gpt41Text);
+    console.log('\n=== Gemini 2.5 Response ===');
+    console.log(geminiText);
+    
+    const gpt5SeesComponents = gpt5Text.toLowerCase().includes('ui components') || 
+                              gpt5Text.toLowerCase().includes('components') ||
+                              gpt5Text.toLowerCase().includes('playground') ||
+                              gpt5Text.toLowerCase().includes('artifacts') ||
+                              gpt5Text.toLowerCase().includes('persistence') ||
+                              gpt5Text.toLowerCase().includes('esbuild');
+    
+    const gpt41SeesComponents = gpt41Text.toLowerCase().includes('ui components') || 
+                               gpt41Text.toLowerCase().includes('components') ||
+                               gpt41Text.toLowerCase().includes('playground') ||
+                               gpt41Text.toLowerCase().includes('artifacts') ||
+                               gpt41Text.toLowerCase().includes('persistence') ||
+                               gpt41Text.toLowerCase().includes('esbuild');
+    
+    const geminiSeesComponents = geminiText.toLowerCase().includes('ui components') || 
+                                geminiText.toLowerCase().includes('components') ||
+                                geminiText.toLowerCase().includes('playground') ||
+                                geminiText.toLowerCase().includes('artifacts') ||
+                                geminiText.toLowerCase().includes('persistence') ||
+                                geminiText.toLowerCase().includes('esbuild');
+    
+    console.log('\n=== Test Results ===');
+    console.log(`GPT-5 sees components: ${gpt5SeesComponents}`);
+    console.log(`GPT-4.1 sees components: ${gpt41SeesComponents}`);
+    console.log(`Gemini 2.5 sees components: ${geminiSeesComponents}`);
+    
+    if (!gpt5SeesComponents && (gpt41SeesComponents || geminiSeesComponents)) {
+      console.log('\n🐛 BUG REPRODUCED: GPT-5 cannot see context that other models can see');
+      
+      expect(gpt5SeesComponents).toBe(true);
+    } else if (gpt5SeesComponents && gpt41SeesComponents && geminiSeesComponents) {
+      console.log('\n✅ All models can see the context - bug may be fixed');
+    } else {
+      console.log('\n❓ Inconclusive results - may need to adjust test criteria');
+    }
+  });
+
+  it('should verify message conversion preserves multiple text parts', async () => {
+    const { convertToOpenRouterChatMessages } = await import('../src/chat/convert-to-openrouter-chat-messages');
+    
+    const convertedMessages = convertToOpenRouterChatMessages(multiPartTextMessage);
+    
+    expect(convertedMessages[0]).toMatchObject({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'projects/web/features/playground/persistence/arti' },
+        { type: 'text', text: 'projects/web/features/playground/services/esbuild' },
+        { type: 'text', text: 'projects/web/features/playground/stores/chatroom-' },
+        { type: 'text', text: 'projects/web/features/playground/state/artifacts/' },
+        { type: 'text', text: 'projects/web/features/playground/ui/Artifacts/Art' },
+      ],
+    });
+    
+    expect(convertedMessages[1]).toMatchObject({
+      role: 'user',
+      content: 'Can you see the UI components that I\'ve provided you with?',
+    });
+    
+    console.log('✅ Message conversion correctly preserves multiple text parts');
+  });
+});

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -98,6 +98,42 @@ describe('user messages', () => {
 
     expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
   });
+
+  it('should convert messages with multiple text parts to content array', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'projects/web/features/playground/persistence/arti' },
+          { type: 'text', text: 'projects/web/features/playground/services/esbuild' },
+          { type: 'text', text: 'projects/web/features/playground/stores/chatroom-' },
+          { type: 'text', text: 'projects/web/features/playground/state/artifacts/' },
+          { type: 'text', text: 'projects/web/features/playground/ui/Artifacts/Art' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Can you see the UI components that I\'ve provided you with?' }],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'projects/web/features/playground/persistence/arti' },
+          { type: 'text', text: 'projects/web/features/playground/services/esbuild' },
+          { type: 'text', text: 'projects/web/features/playground/stores/chatroom-' },
+          { type: 'text', text: 'projects/web/features/playground/state/artifacts/' },
+          { type: 'text', text: 'projects/web/features/playground/ui/Artifacts/Art' },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Can you see the UI components that I\'ve provided you with?',
+      },
+    ]);
+  });
 });
 
 describe('cache control', () => {


### PR DESCRIPTION
# Add GPT-5 context visibility bug reproduction test

## Summary

This PR adds comprehensive test coverage to reproduce and isolate a reported bug where GPT-5 fails to recognize context provided in multi-part text messages, while other models (GPT-4.1, Gemini 2.5) handle the same messages correctly.

**Changes made:**
- Added unit test verifying that multiple text parts in messages are correctly converted to content arrays
- Created E2E test that reproduces the bug by comparing GPT-5 responses against working models using identical multi-part messages
- Confirmed no special GPT-5 handling exists in the message conversion pipeline

## Review & Testing Checklist for Human

- [ ] **Run E2E test with proper API credentials** - The test couldn't be fully validated in dev environment due to missing `OPENROUTER_API_KEY`. Verify it actually reproduces the reported bug.
- [ ] **Validate context detection logic** - The test uses keyword matching (`ui components`, `playground`, `artifacts`, etc.) to detect if models see the context. Confirm this approach correctly identifies the visibility issue.
- [ ] **Test with current model availability** - Verify model IDs (`openai/gpt-5`, `openai/gpt-4.1`, `google/gemini-2.5-flash-exp`) are still available and working on OpenRouter.
- [ ] **Run unit tests** - Confirm the new message conversion test passes and properly validates multi-part text handling.

**Recommended test plan:** Run `pnpm test:e2e e2e/gpt5-context-visibility-bug.test.ts` with proper API credentials and review console output to confirm GPT-5 fails while other models succeed.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["e2e/gpt5-context-visibility-bug.test.ts"]:::major-edit --> B["src/chat/convert-to-openrouter-chat-messages.ts"]:::context
    C["src/chat/convert-to-openrouter-chat-messages.test.ts"]:::minor-edit --> B
    A --> D["OpenRouter API<br/>(GPT-5, GPT-4.1, Gemini 2.5)"]:::context
    B --> E["Multi-part message<br/>conversion logic"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- The bug appears to be model-specific behavior rather than an issue with OpenRouter's message processing, as no special GPT-5 handling was found in the codebase
- E2E test includes detailed logging to help debug model responses and identify patterns in the context visibility issue
- Unit test verifies existing message conversion logic works correctly for multi-part messages


**Session details:** Requested by Robert Yeakel (@robert-j-y) - [Devin session](https://app.devin.ai/sessions/061296ce863a4e1692bff8fdf6256c8c)