### PR TITLE
fix(chat): prevent error when a toolCall is not present at toolCalls index

### DIFF
--- a/src/openrouter-chat-language-model.ts
+++ b/src/openrouter-chat-language-model.ts
@@ -662,7 +662,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV1 {
             // Forward any unsent tool calls if finish reason is 'tool-calls'
             if (finishReason === 'tool-calls') {
               for (const toolCall of toolCalls) {
-                if (!toolCall.sent) {
+                if (toolCall && !toolCall.sent) {
                   controller.enqueue({
                     type: 'tool-call',
                     toolCallType: 'function',


### PR DESCRIPTION
Reference: [PR #126](https://github.com/OpenRouterTeam/ai-sdk-provider/pull/126)

This backports the guard to the 0.x line to prevent a stream crash when a toolCall is missing at a toolCalls index.

Request: GPT-5 model calls consistently hit this issue on 0.x. Could you please cut a 0.7.6 release as soon as possible?