### PR TITLE
fix: add upstream inference cost tracking

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -533,6 +533,17 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
                 };
               }
 
+              const upstreamInferenceCost =
+                value.usage.cost_details?.upstream_inference_cost;
+              if (
+                upstreamInferenceCost != null &&
+                upstreamInferenceCost !== undefined
+              ) {
+                openrouterUsage.costDetails = {
+                  upstreamInferenceCost,
+                };
+              }
+
               openrouterUsage.cost = value.usage.cost;
               openrouterUsage.totalTokens = value.usage.total_tokens;
             }

--- a/src/tests/stream-usage-accounting.test.ts
+++ b/src/tests/stream-usage-accounting.test.ts
@@ -30,6 +30,9 @@ describe('OpenRouter Streaming Usage Accounting', () => {
             completion_tokens_details: { reasoning_tokens: 8 },
             total_tokens: 30,
             cost: 0.0015,
+            cost_details: {
+              upstream_inference_cost: 19,
+            },
           },
           choices: [],
         })}\n\n`,
@@ -125,6 +128,9 @@ describe('OpenRouter Streaming Usage Accounting', () => {
       completionTokens: 20,
       totalTokens: 30,
       cost: 0.0015,
+      costDetails: {
+        upstreamInferenceCost: 19,
+      },
       promptTokensDetails: { cachedTokens: 5 },
       completionTokensDetails: { reasoningTokens: 8 },
     });


### PR DESCRIPTION
Capture and expose upstream_inference_cost from OpenRouter usage details to provide more granular cost breakdown information.

🤖 Generated with Codebuff