### PR TITLE
feat: support `gemini-2.5-flash-image-preview`

### DIFF
--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -31,7 +31,12 @@ export function getFileUrl({
     : `data:${part.mediaType ?? defaultMediaType};base64,${stringUrl}`;
 }
 
-export function getMediaType(base64: string, defaultMediaType: string): string {
-  const match = base64.match(/^data:([^;]+)/);
+export function getMediaType(dataUrl: string, defaultMediaType: string): string {
+  const match = dataUrl.match(/^data:([^;]+)/);
   return match ? match[1] ?? defaultMediaType : defaultMediaType;
+}
+
+export function getBase64FromDataUrl(dataUrl: string): string {
+  const match = dataUrl.match(/^data:[^;]*;base64,(.+)$/);
+  return match ? match[1]! : dataUrl;
 }

--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -30,3 +30,8 @@ export function getFileUrl({
     ? stringUrl
     : `data:${part.mediaType ?? defaultMediaType};base64,${stringUrl}`;
 }
+
+export function getMediaType(base64: string, defaultMediaType: string): string {
+  const match = base64.match(/^data:([^;]+)/);
+  return match ? match[1] ?? defaultMediaType : defaultMediaType;
+}

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@ai-sdk/provider-utils/test';
 import { createOpenRouter } from '../provider';
 import { ReasoningDetailType } from '../schemas/reasoning-details';
+import type { ImageResponse } from '../schemas/image';
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -107,6 +108,8 @@ const TEST_LOGPROBS = {
   ],
 };
 
+const TEST_IMAGE_URL = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABAAAAAQACAIAAADwf7zUAAAAiXpUWHRSYXcgcHJvZmlsZSB0eXBlIGlwdGMAAAiZTYwxDgIxDAT7vOKekDjrtV1T0VHwgbtcIiEhgfh/QaDgmGlWW0w6X66n5fl6jNu9p+ULkapDENgzpj+Kl5aFfa6KnYWgSjZjGOiSYRxTY/v8KIijI==`;
+
 const provider = createOpenRouter({
   apiKey: 'test-api-key',
   compatibility: 'strict',
@@ -125,6 +128,7 @@ describe('doGenerate', () => {
     content = '',
     reasoning,
     reasoning_details,
+    images,
     usage = {
       prompt_tokens: 4,
       total_tokens: 34,
@@ -136,6 +140,7 @@ describe('doGenerate', () => {
     content?: string;
     reasoning?: string;
     reasoning_details?: Array<ReasoningDetailUnion>;
+    images?: Array<ImageResponse>;
     usage?: {
       prompt_tokens: number;
       total_tokens: number;
@@ -167,6 +172,7 @@ describe('doGenerate', () => {
               content,
               reasoning,
               reasoning_details,
+              images,
             },
             logprobs,
             finish_reason,
@@ -578,6 +584,31 @@ describe('doGenerate', () => {
         },
       },
     });
+  });
+
+  it('should pass images', async () => {
+    prepareJsonResponse({
+      content: '',
+      images: [
+        {
+          type: 'image_url',
+          image_url: { url: TEST_IMAGE_URL },
+        },
+      ],
+      usage: { prompt_tokens: 53, total_tokens: 70, completion_tokens: 17 },
+    });
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toStrictEqual([
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        data: TEST_IMAGE_URL,
+      },
+    ]);
   });
 });
 
@@ -1186,6 +1217,70 @@ describe('doStream', () => {
       {
         type: 'finish',
         finishReason: 'tool-calls',
+        providerMetadata: {
+          openrouter: {
+            usage: {
+              completionTokens: 17,
+              promptTokens: 53,
+              totalTokens: 70,
+              cost: undefined,
+            },
+          },
+        },
+        usage: {
+          inputTokens: 53,
+          outputTokens: 17,
+          totalTokens: 70,
+          reasoningTokens: Number.NaN,
+          cachedInputTokens: Number.NaN,
+        },
+      },
+    ]);
+  });
+
+  it('should stream images', async () => {
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"",` +
+          `"images":[{"type":"image_url","image_url":{"url":"${TEST_IMAGE_URL}"},"index":0}]},` +
+          `"logprobs":null,"finish_reason":"stop"}]}\n\n`,
+        `data: {"id":"chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP","object":"chat.completion.chunk","created":1711357598,"model":"gpt-3.5-turbo-0125",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[],"usage":{"prompt_tokens":53,"completion_tokens":17,"total_tokens":70}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+      {
+        type: 'response-metadata',
+        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
+      },
+      {
+        type: 'response-metadata',
+        modelId: 'gpt-3.5-turbo-0125',
+      },
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        data: TEST_IMAGE_URL,
+      },
+      {
+        type: 'response-metadata',
+        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
+      },
+      {
+        type: 'response-metadata',
+        modelId: 'gpt-3.5-turbo-0125',
+      },
+      {
+        type: 'finish',
+        finishReason: 'stop',
         providerMetadata: {
           openrouter: {
             usage: {

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -110,6 +110,8 @@ const TEST_LOGPROBS = {
 
 const TEST_IMAGE_URL = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABAAAAAQACAIAAADwf7zUAAAAiXpUWHRSYXcgcHJvZmlsZSB0eXBlIGlwdGMAAAiZTYwxDgIxDAT7vOKekDjrtV1T0VHwgbtcIiEhgfh/QaDgmGlWW0w6X66n5fl6jNu9p+ULkapDENgzpj+Kl5aFfa6KnYWgSjZjGOiSYRxTY/v8KIijI==`;
 
+const TEST_IMAGE_BASE64 = TEST_IMAGE_URL.split(',')[1]!;
+
 const provider = createOpenRouter({
   apiKey: 'test-api-key',
   compatibility: 'strict',
@@ -606,7 +608,7 @@ describe('doGenerate', () => {
       {
         type: 'file',
         mediaType: 'image/png',
-        data: TEST_IMAGE_URL,
+        data: TEST_IMAGE_BASE64,
       },
     ]);
   });
@@ -1268,7 +1270,7 @@ describe('doStream', () => {
       {
         type: 'file',
         mediaType: 'image/png',
-        data: TEST_IMAGE_URL,
+        data: TEST_IMAGE_BASE64,
       },
       {
         type: 'response-metadata',

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -36,7 +36,7 @@ import {
   OpenRouterNonStreamChatCompletionResponseSchema,
   OpenRouterStreamChatCompletionChunkSchema,
 } from './schemas';
-import { getMediaType } from './file-url-utils';
+import { getBase64FromDataUrl, getMediaType } from './file-url-utils';
 
 type OpenRouterChatConfig = {
   provider: string;
@@ -331,7 +331,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
         content.push({
           type: 'file' as const,
           mediaType: getMediaType(image.image_url.url, 'image/jpeg'),
-          data: image.image_url.url,
+          data: getBase64FromDataUrl(image.image_url.url),
         });
       }
     }
@@ -787,7 +787,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
                 controller.enqueue({
                   type: 'file',
                   mediaType: getMediaType(image.image_url.url, 'image/jpeg'),
-                  data: image.image_url.url,
+                  data: getBase64FromDataUrl(image.image_url.url),
                 })
               }
             }

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -36,6 +36,7 @@ import {
   OpenRouterNonStreamChatCompletionResponseSchema,
   OpenRouterStreamChatCompletionChunkSchema,
 } from './schemas';
+import { getMediaType } from './file-url-utils';
 
 type OpenRouterChatConfig = {
   provider: string;
@@ -321,6 +322,16 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
           toolCallId: toolCall.id ?? generateId(),
           toolName: toolCall.function.name,
           input: toolCall.function.arguments,
+        });
+      }
+    }
+
+    if (choice.message.images) {
+      for (const image of choice.message.images) {
+        content.push({
+          type: 'file' as const,
+          mediaType: getMediaType(image.image_url.url, 'image/jpeg'),
+          data: image.image_url.url,
         });
       }
     }
@@ -768,6 +779,16 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
 
                   toolCall.sent = true;
                 }
+              }
+            }
+
+            if (delta.images != null) {
+              for (const image of delta.images) {
+                controller.enqueue({
+                  type: 'file',
+                  mediaType: getMediaType(image.image_url.url, 'image/jpeg'),
+                  data: image.image_url.url,
+                })
               }
             }
           },

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 import { OpenRouterErrorResponseSchema } from '../schemas/error-response';
 import { ReasoningDetailArraySchema } from '../schemas/reasoning-details';
+import { ImageResponseArraySchema } from '../schemas/image';
 
 const OpenRouterChatCompletionBaseResponseSchema = z.object({
   id: z.string().optional(),
@@ -41,6 +42,7 @@ export const OpenRouterNonStreamChatCompletionResponseSchema =
           content: z.string().nullable().optional(),
           reasoning: z.string().nullable().optional(),
           reasoning_details: ReasoningDetailArraySchema.nullish(),
+          images: ImageResponseArraySchema.nullish(),
 
           tool_calls: z
             .array(
@@ -106,6 +108,7 @@ export const OpenRouterStreamChatCompletionChunkSchema = z.union([
             content: z.string().nullish(),
             reasoning: z.string().nullish().optional(),
             reasoning_details: ReasoningDetailArraySchema.nullish(),
+            images: ImageResponseArraySchema.nullish(),
             tool_calls: z
               .array(
                 z.object({

--- a/src/schemas/image.ts
+++ b/src/schemas/image.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod/v4';
+
+const ImageResponseSchema = z.object({
+  type: z.literal('image_url'),
+  image_url: z.object({
+    url: z.string(),
+  }),
+});
+
+export type ImageResponse = z.infer<typeof ImageResponseSchema>;
+
+const ImageResponseWithUnknownSchema = z.union([
+  ImageResponseSchema,
+  z.unknown().transform(() => null),
+]);
+
+export const ImageResponseArraySchema = z
+  .array(ImageResponseWithUnknownSchema)
+  .transform((d) => d.filter((d): d is ImageResponse => !!d));


### PR DESCRIPTION
- add image handling in chat responses 
- Introduced `getMediaType` utility function to extract media type from base64 strings.
- Updated `OpenRouterChatLanguageModel` to process images in chat responses, including support for streaming images.
- Enhanced test cases to validate image handling in both `doGenerate` and `doStream` methods.
- Updated schemas to include images in chat completion responses.