### PR TITLE
feat: add api_keys parameter to provider settings

### DIFF
--- a/src/facade.ts
+++ b/src/facade.ts
@@ -34,6 +34,11 @@ Custom headers to include in the requests.
   readonly headers?: Record<string, string>;
 
   /**
+   * Record of provider slugs to API keys for injecting into provider routing.
+   */
+  readonly api_keys?: Record<string, string>;
+
+  /**
    * Creates a new OpenRouter provider instance.
    */
   constructor(options: OpenRouterProviderSettings = {}) {
@@ -42,6 +47,7 @@ Custom headers to include in the requests.
       'https://openrouter.ai/api/v1';
     this.apiKey = options.apiKey;
     this.headers = options.headers;
+    this.api_keys = options.api_keys;
   }
 
   private get baseConfig() {
@@ -54,6 +60,9 @@ Custom headers to include in the requests.
           description: 'OpenRouter',
         })}`,
         ...this.headers,
+        ...(this.api_keys && Object.keys(this.api_keys).length > 0 && {
+          'X-Provider-API-Keys': JSON.stringify(this.api_keys)
+        }),
       }),
     };
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -88,6 +88,12 @@ or to provide a custom fetch implementation for e.g. testing.
 A JSON object to send as the request body to access OpenRouter features & upstream provider features.
   */
   extraBody?: Record<string, unknown>;
+
+  /**
+   * Record of provider slugs to API keys for injecting into provider routing.
+   * Maps provider slugs (e.g. "anthropic", "openai") to their respective API keys.
+   */
+  api_keys?: Record<string, string>;
 }
 
 /**
@@ -110,6 +116,9 @@ export function createOpenRouter(
       description: 'OpenRouter',
     })}`,
     ...options.headers,
+    ...(options.api_keys && Object.keys(options.api_keys).length > 0 && {
+      'X-Provider-API-Keys': JSON.stringify(options.api_keys)
+    }),
   });
 
   const createChatModel = (


### PR DESCRIPTION
# feat: add api_keys parameter to provider settings

## Summary

Adds a new optional `api_keys` parameter to `OpenRouterProviderSettings` that accepts a record mapping provider slugs (e.g., "anthropic", "openai") to their respective API keys. When provided, these keys are injected into requests via the `X-Provider-API-Keys` header as a JSON-stringified object.

**Changes:**
- Added `api_keys?: Record<string, string>` to `OpenRouterProviderSettings` interface
- Updated both deprecated `OpenRouter` class and `createOpenRouter` function to handle the parameter
- Implemented header injection logic with JSON serialization
- Maintained backward compatibility (parameter is optional)

## Review & Testing Checklist for Human

**⚠️ Critical items requiring verification:**

- [ ] **Verify header format**: Confirm that `X-Provider-API-Keys` with JSON.stringify format matches what OpenRouter's backend expects for provider routing
- [ ] **End-to-end functionality test**: Test with actual provider routing to ensure injected API keys are properly utilized by the backend
- [ ] **Security review**: Verify that JSON.stringify'ing API keys into headers is secure and doesn't expose them inappropriately in logs/debugging
- [ ] **Consider adding tests**: Evaluate if unit tests should be added to verify header injection logic

### Notes

- No validation is performed on provider slugs or API key formats
- Implementation assumes backend reads `X-Provider-API-Keys` header - this needs verification
- All existing tests pass (69/69) and TypeScript compilation succeeds

---
**Link to Devin run:** https://app.devin.ai/sessions/f1580e970a9b4d84a48c0b78017a9248  
**Requested by:** @louisgv