### PR TITLE
fix: `getArgs` return to support responseFormat and tools together

### DIFF
--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1492,4 +1492,82 @@ describe('doStream', () => {
       },
     });
   });
+
+  it('should pass responseFormat for JSON schema structured outputs and tools', async () => {
+    prepareStreamResponse({ content: ['{"name": "John", "age": 30}'] });
+
+    const testSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name', 'age'],
+      additionalProperties: false,
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          description: 'Test tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      toolChoice: {
+        type: 'tool',
+        toolName: 'test-tool',
+      },
+    };
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: testSchema,
+        name: 'PersonResponse',
+        description: 'A person object',
+      },
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      stream: true,
+      stream_options: { include_usage: true },
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          schema: testSchema,
+          strict: true,
+          name: 'PersonResponse',
+          description: 'A person object',
+        },
+      },
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'test-tool',
+            description: 'Test tool',
+            parameters: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      ],
+      tool_choice: {
+        type: 'function',
+        function: { name: 'test-tool' },
+      },
+    });
+  });
 });

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -121,7 +121,21 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       seed,
 
       stop: stopSequences,
-      response_format: responseFormat,
+      response_format: responseFormat?.type === 'json'
+          ? responseFormat.schema != null
+            ? {
+                type: 'json_schema',
+                json_schema: {
+                  schema: responseFormat.schema,
+                  strict: true,
+                  name: responseFormat.name ?? 'response',
+                  ...(responseFormat.description && {
+                    description: responseFormat.description,
+                  }),
+                },
+              }
+            : { type: 'json_object' }
+          : undefined,
       top_k: topK,
 
       // messages:
@@ -142,23 +156,6 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       ...this.config.extraBody,
       ...this.settings.extraBody,
     };
-
-    if (responseFormat?.type === 'json' && responseFormat.schema != null) {
-      return {
-        ...baseArgs,
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            schema: responseFormat.schema,
-            strict: true,
-            name: responseFormat.name ?? 'response',
-            ...(responseFormat.description && {
-              description: responseFormat.description,
-            }),
-          },
-        },
-      };
-    }
 
     if (tools && tools.length > 0) {
       // TODO: support built-in tools


### PR DESCRIPTION
When using a responseFormat and tools in the same call, the `getArgs` method returned only the responseFormat configuration.

Changes have been made so that both the responseFormat and tools can be used at the same time.