### PR TITLE
feat: add zdr parameter to OpenRouter chat settings

### DIFF
--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -129,5 +129,10 @@ monitor and detect abuse. Learn more.
       audio?: number | string;
       request?: number | string;
     };
+    /**
+     * Whether to restrict routing to only ZDR (Zero Data Retention) endpoints.
+     * When true, only endpoints that do not retain prompts will be used.
+     */
+    zdr?: boolean;
   };
 } & OpenRouterSharedSettings;


### PR DESCRIPTION
# feat: add zdr parameter to OpenRouter chat settings

## Summary
Adds the `zdr` boolean parameter to the OpenRouter chat settings type definition in the AI SDK provider. This parameter enables clients using the AI SDK to restrict routing to only ZDR (Zero Data Retention) endpoints by setting `zdr: true` in their provider configuration.

This change is part of a coordinated feature implementation across repositories - the main routing logic is implemented in [openrouter-web#7637](https://github.com/OpenRouterTeam/openrouter-web/pull/7637).

## Review & Testing Checklist for Human
- [ ] Verify the parameter definition matches the implementation in openrouter-web PR #7637
- [ ] Test end-to-end that setting `zdr: true` in AI SDK actually restricts routing to ZDR endpoints
- [ ] Confirm the parameter documentation accurately describes the behavior (should only have effect when explicitly set to `true`)

### Notes
- This is a companion PR to the main implementation in openrouter-web
- The change is minimal (just type definition) but should be tested with the full feature
- Requested by @chrisclark in [Devin session](https://app.devin.ai/sessions/12d342073a484a8abfbb7ad53b78ccaf)