### PR TITLE
fix: OpenRouterProvider should extend ProviderV2 instead of LanguageModelV2

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2 } from '@ai-sdk/provider';
+import type { ProviderV2 } from '@ai-sdk/provider';
 import type {
   OpenRouterChatModelId,
   OpenRouterChatSettings,
@@ -14,7 +14,7 @@ import { OpenRouterCompletionLanguageModel } from './completion';
 
 export type { OpenRouterCompletionSettings };
 
-export interface OpenRouterProvider extends LanguageModelV2 {
+export interface OpenRouterProvider extends ProviderV2 {
   (
     modelId: OpenRouterChatModelId,
     settings?: OpenRouterCompletionSettings,


### PR DESCRIPTION
## Problem 
The `OpenRouterProvider` class was incorrectly extending `LanguageModelV2`, which is inconsistent with the pattern used by other AI SDK providers. All other provider classes in the ecosystem properly extend `ProviderV2` and their `createXxx` functions return their own `XxxProvider` instances.

## Solution
- Changed `OpenRouterProvider` to extend `ProviderV2` instead of `LanguageModelV2`
- This aligns the OpenRouter provider with the standard provider architecture used throughout the AI SDK ecosystem

## Impact
- ✅ Maintains consistency with other AI SDK providers
- ✅ Follows the established provider pattern where providers extend `ProviderV2`
- ✅ No breaking changes to the public API
- ✅ Improved type safety and IntelliSense support


## Change:
```js
export interface OpenRouterProvider extends LanguageModelV2 
// ⬇️
export interface OpenRouterProvider extends ProviderV2
```
