### PR TITLE
fix: add the missing search engine options in the web search options

### DIFF
--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -57,6 +57,10 @@ monitor and detect abuse. Learn more.
      * Custom search prompt to guide the search query
      */
     search_prompt?: string;
+    /**
+     * Search engine to use (default: `exa`)
+     */
+    engine?: 'native' | 'exa' | undefined;
   }>;
 
   /**
@@ -71,6 +75,14 @@ monitor and detect abuse. Learn more.
      * Custom search prompt to guide the search query
      */
     search_prompt?: string;
+    /**
+     * Determines which search engine to use
+     * • "native" — use provider’s `built-in` web search
+     * • "exa" — use `Exa's` search API
+     * • undefined — native if supported, otherwise `Exa`
+     * @see https://openrouter.ai/docs/features/web-search
+     */
+    engine?: 'native' | 'exa' | undefined;
   };
 
   /**


### PR DESCRIPTION
This PR adds the `engine?: 'native' | 'exa'` property to the web plugin’s TypeScript definition, allowing users to explicitly force using native-search or Exa search. By default, the behavior stays the same: if engine is not specified, OpenRouter will use native search when supported, otherwise fall back to Exa. This also fixes TS errors when passing engine in plugin configs.