### PR TITLE
feat: add user-agent header for provider version

### DIFF
--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -518,7 +518,7 @@ describe('doGenerate', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
-      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
+      'user-agent': 'ai-sdk/openrouter/0.0.0-test',
     });
   });
 
@@ -1429,7 +1429,7 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
-      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
+      'user-agent': 'ai-sdk/openrouter/0.0.0-test',
     });
   });
 

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -8,6 +8,12 @@ import {
 import { createOpenRouter } from '../provider';
 import { ReasoningDetailType } from '../schemas/reasoning-details';
 import type { ImageResponse } from '../schemas/image';
+import { vi } from 'vitest';
+
+vi.mock('@/src/version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -512,6 +518,7 @@ describe('doGenerate', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
     });
   });
 
@@ -1422,6 +1429,7 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
     });
   });
 

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -5,6 +5,12 @@ import {
   createTestServer,
 } from '@ai-sdk/provider-utils/test';
 import { createOpenRouter } from '../provider';
+import { vi } from 'vitest';
+
+vi.mock('@/src/version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -222,6 +228,7 @@ describe('doGenerate', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
     });
   });
 });
@@ -437,6 +444,7 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
     });
   });
 

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -228,7 +228,7 @@ describe('doGenerate', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
-      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
+      'user-agent': 'ai-sdk/openrouter/0.0.0-test',
     });
   });
 });
@@ -444,7 +444,7 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
-      'user-agent': 'ai-sdk-openrouter/0.0.0-test',
+      'user-agent': 'ai-sdk/openrouter/0.0.0-test',
     });
   });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -114,7 +114,7 @@ export function createOpenRouter(
     })}`,
     ...options.headers,
   },
-  `ai-sdk-openrouter/${VERSION}`,
+  `ai-sdk/openrouter/${VERSION}`,
   ));
 
   const createChatModel = (

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -11,6 +11,8 @@ import type {
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils';
 import { OpenRouterChatLanguageModel } from './chat';
 import { OpenRouterCompletionLanguageModel } from './completion';
+import { VERSION } from './version';
+import { withUserAgentSuffix } from './utils/with-user-agent-suffix';
 
 export type { OpenRouterCompletionSettings };
 
@@ -103,14 +105,17 @@ export function createOpenRouter(
   // we default to compatible, because strict breaks providers like Groq:
   const compatibility = options.compatibility ?? 'compatible';
 
-  const getHeaders = () => ({
+  const getHeaders = () => (
+    withUserAgentSuffix({
     Authorization: `Bearer ${loadApiKey({
       apiKey: options.apiKey,
       environmentVariableName: 'OPENROUTER_API_KEY',
       description: 'OpenRouter',
     })}`,
     ...options.headers,
-  });
+  },
+  `ai-sdk-openrouter/${VERSION}`,
+  ));
 
   const createChatModel = (
     modelId: OpenRouterChatModelId,

--- a/src/utils/remove-undefined.ts
+++ b/src/utils/remove-undefined.ts
@@ -1,0 +1,12 @@
+/**
+ * Removes entries from a record where the value is null or undefined.
+ * @param record - The input object whose entries may be null or undefined.
+ * @returns A new object containing only entries with non-null and non-undefined values.
+ */
+export function removeUndefinedEntries<T>(
+    record: Record<string, T | undefined>,
+  ): Record<string, T> {
+    return Object.fromEntries(
+      Object.entries(record).filter(([, value]) => value !== null),
+    ) as Record<string, T>
+  }

--- a/src/utils/with-user-agent-suffix.ts
+++ b/src/utils/with-user-agent-suffix.ts
@@ -1,0 +1,30 @@
+import { removeUndefinedEntries } from '@/src/utils/remove-undefined'
+
+/**
+ * Appends suffix parts to the `user-agent` header.
+ * If a `user-agent` header already exists, the suffix parts are appended to it.
+ * If no `user-agent` header exists, a new one is created with the suffix parts.
+ * Automatically removes undefined entries from the headers.
+ *
+ * @param headers - The original headers.
+ * @param userAgentSuffixParts - The parts to append to the `user-agent` header.
+ * @returns The new headers with the `user-agent` header set or updated.
+ */
+export function withUserAgentSuffix(
+  headers: HeadersInit | Record<string, string | undefined> | undefined,
+  ...userAgentSuffixParts: string[]
+): Record<string, string> {
+  const cleanedHeaders = removeUndefinedEntries(
+    (headers as Record<string, string | undefined>) ?? {},
+  )
+
+  const currentUserAgentHeader = cleanedHeaders['user-agent'] || ''
+  const newUserAgent = [currentUserAgentHeader, ...userAgentSuffixParts]
+    .filter(Boolean)
+    .join(' ')
+
+  return {
+    ...cleanedHeaders,
+    'user-agent': newUserAgent,
+  }
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined
+export const VERSION: string =
+  __PACKAGE_VERSION__ === undefined ? '0.0.0-test' : __PACKAGE_VERSION__

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from 'tsup';
+import { readFileSync } from 'node:fs' 
+
+const package_ = JSON.parse(
+  readFileSync(new URL('package.json', import.meta.url), 'utf8'),
+)
 
 export default defineConfig([
   {
@@ -6,6 +11,9 @@ export default defineConfig([
     format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(package_.version),
+    },
   },
   {
     entry: ['src/internal/index.ts'],
@@ -13,5 +21,8 @@ export default defineConfig([
     format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(package_.version),
+    },
   },
 ]);

--- a/vitest.edge.config.ts
+++ b/vitest.edge.config.ts
@@ -1,5 +1,6 @@
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+import packageJson from './package.json'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,5 +9,8 @@ export default defineConfig({
     environment: 'edge-runtime',
     globals: true,
     include: ['./src/**/*.test.ts'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
   },
 });

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -1,5 +1,6 @@
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+import packageJson from './package.json'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,5 +9,8 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['./src/**/*.test.ts'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
   },
 });


### PR DESCRIPTION
We have started to add package versions of providers we support in AI-SDK. This change is to ensure we pass the provider version of OpenRouter too when someones uses it.

See pull https://github.com/vercel/ai/pull/8703 for more information.

## Manual Verification
- updated test files `src/chat/index.test.ts` and `src/completion/index.test.ts`
- ran `pnpm typecheck`
- ran `pnpm build`
- ran `pnpm test`

Let me know if any questions!