### PR TITLE
feat: add ttl support to cache_control for Anthropic caching

### DIFF
--- a/e2e/cache-control.test.ts
+++ b/e2e/cache-control.test.ts
@@ -56,6 +56,7 @@ async function callLLM() {
               openrouter: {
                 cache_control: {
                   type: 'ephemeral',
+                  ttl: '5m',
                 },
               },
             },

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -557,4 +557,113 @@ describe('cache control', () => {
       },
     ]);
   });
+
+  it('should pass cache control with ttl from system message provider metadata', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'system',
+        content: 'System prompt',
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral', ttl: '5m' },
+          },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'system',
+        content: 'System prompt',
+        cache_control: { type: 'ephemeral', ttl: '5m' },
+      },
+    ]);
+  });
+
+  it('should pass cache control with ttl from user message content part', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerOptions: {
+              openrouter: {
+                cache_control: { type: 'ephemeral', ttl: '1h' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should pass cache control with ttl 5m from assistant message', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Assistant response' }],
+        providerOptions: {
+          openrouter: {
+            cacheControl: { type: 'ephemeral', ttl: '5m' },
+          },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Assistant response',
+        cache_control: { type: 'ephemeral', ttl: '5m' },
+      },
+    ]);
+  });
+
+  it('should pass cache control with ttl 1h from tool message', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool-call-1',
+            toolName: 'test-tool',
+            output: {
+              type: 'json',
+              value: { result: 'Tool result' },
+            },
+            providerOptions: {
+              anthropic: {
+                cache_control: { type: 'ephemeral', ttl: '1h' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'tool-call-1',
+        content: JSON.stringify({ result: 'Tool result' }),
+        cache_control: { type: 'ephemeral', ttl: '1h' },
+      },
+    ]);
+  });
 });

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -15,7 +15,7 @@ import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 import { getFileUrl } from './file-url-utils';
 import { isUrl } from './is-url';
 
-// Type for OpenRouter Cache Control following Anthropic's pattern (important-comment)
+// Type for OpenRouter Cache Control following Anthropic's pattern
 export type OpenRouterCacheControl = { type: 'ephemeral'; ttl?: '5m' | '1h' };
 
 function getCacheControl(

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -15,8 +15,8 @@ import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 import { getFileUrl } from './file-url-utils';
 import { isUrl } from './is-url';
 
-// Type for OpenRouter Cache Control following Anthropic's pattern
-export type OpenRouterCacheControl = { type: 'ephemeral' };
+// Type for OpenRouter Cache Control following Anthropic's pattern (important-comment)
+export type OpenRouterCacheControl = { type: 'ephemeral'; ttl?: '5m' | '1h' };
 
 function getCacheControl(
   providerMetadata: SharedV2ProviderMetadata | undefined,

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -1,6 +1,6 @@
 import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 
-// Type for OpenRouter Cache Control following Anthropic's pattern (important-comment)
+// Type for OpenRouter Cache Control following Anthropic's pattern
 export type OpenRouterCacheControl = { type: 'ephemeral'; ttl?: '5m' | '1h' };
 
 export type OpenRouterChatCompletionsInput = Array<ChatCompletionMessageParam>;

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -1,7 +1,7 @@
 import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 
-// Type for OpenRouter Cache Control following Anthropic's pattern
-export type OpenRouterCacheControl = { type: 'ephemeral' };
+// Type for OpenRouter Cache Control following Anthropic's pattern (important-comment)
+export type OpenRouterCacheControl = { type: 'ephemeral'; ttl?: '5m' | '1h' };
 
 export type OpenRouterChatCompletionsInput = Array<ChatCompletionMessageParam>;
 


### PR DESCRIPTION
# feat: add ttl support to cache_control for Anthropic caching

## Summary
Adds support for Anthropic's `ttl` (time-to-live) field in `cache_control` to enable time-based cache control with values `"5m"` (5 minutes) and `"1h"` (1 hour).

**Changes:**
- Updated `OpenRouterCacheControl` type to include optional `ttl?: '5m' | '1h'` field in both type definition locations
- Added comprehensive unit tests covering ttl usage across all message types (system, user, assistant, tool)
- Updated E2E test to include ttl in cache_control usage
- All existing functionality preserved - ttl is optional and backward compatible

The backend already supports ttl filtering via the `supportsExplicitCacheControlTTL` flag, so this change enables the SDK to pass through ttl values that were previously unsupported.

## Review & Testing Checklist for Human

- [ ] **Verify TTL values work end-to-end**: Test actual API calls with `ttl: '5m'` and `ttl: '1h'` to ensure caching behavior is correct
- [ ] **Test invalid TTL rejection**: Confirm that invalid ttl values (e.g., `'10m'`, `'2h'`) are properly rejected by the backend
- [ ] **Verify provider filtering**: Test that TTL field is correctly filtered out for providers that don't support `supportsExplicitCacheControlTTL`

### Notes
- The `getCacheControl` function uses type casting which automatically passes through the ttl field once types are updated
- TTL values `'5m'` and `'1h'` match the backend's `AnthropicCacheControlTTL` enum exactly
- All 73 tests pass including 4 new ttl-specific test cases

**Link to Devin run:** https://app.devin.ai/sessions/bafd0bd2d70745ada3c0036137251ecb  
**Requested by:** @jakobcastro