### PR TITLE
docs: add examples for anthropic fine-grained tool streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,101 @@ await streamText({
   ],
 });
 ```
+## Anthropic Beta Features
+
+You can enable Anthropic beta features by passing custom headers through the OpenRouter SDK.
+
+### Fine-grained Tool Streaming
+
+[Fine-grained tool streaming](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/fine-grained-tool-streaming) allows streaming tool parameters without buffering, reducing latency for large schemas. This is particularly useful when working with large nested JSON structures.
+
+**Important:** This is a beta feature from Anthropic. Make sure to evaluate responses before using in production.
+
+#### Basic Usage
+
+```typescript
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { streamObject } from 'ai';
+
+const provider = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  headers: {
+    'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+  },
+});
+
+const model = provider.chat('anthropic/claude-sonnet-4');
+
+const result = await streamObject({
+  model,
+  schema: yourLargeSchema,
+  prompt: 'Generate a complex object...',
+});
+
+for await (const partialObject of result.partialObjectStream) {
+  console.log(partialObject);
+}
+```
+
+You can also pass the header at the request level:
+
+```typescript
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const provider = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const model = provider.chat('anthropic/claude-sonnet-4');
+
+await generateText({
+  model,
+  prompt: 'Hello',
+  headers: {
+    'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+  },
+});
+```
+
+**Note:** Fine-grained tool streaming is specific to Anthropic models. When using models from other providers, the header will be ignored.
+
+#### Use Case: Large Component Generation
+
+This feature is particularly beneficial when streaming large, nested JSON structures like UI component trees:
+
+```typescript
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { streamObject } from 'ai';
+import { z } from 'zod';
+
+const componentSchema = z.object({
+  type: z.string(),
+  props: z.record(z.any()),
+  children: z.array(z.lazy(() => componentSchema)).optional(),
+});
+
+const provider = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  headers: {
+    'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+  },
+});
+
+const model = provider.chat('anthropic/claude-sonnet-4');
+
+const result = await streamObject({
+  model,
+  schema: componentSchema,
+  prompt: 'Create a responsive dashboard layout',
+});
+
+for await (const partialComponent of result.partialObjectStream) {
+  console.log('Partial component:', partialComponent);
+}
+```
+
+
 
 ## Use Cases
 


### PR DESCRIPTION
# docs: add examples for anthropic fine-grained tool streaming

## Summary

Adds comprehensive documentation and usage examples for Anthropic's fine-grained tool streaming beta feature. This feature allows streaming tool parameters without buffering, reducing latency for large JSON schemas - particularly useful for Framer's Workshop plugin which generates complex UI component trees.

**Changes:**
- Added new "Anthropic Beta Features" section to README
- Included basic usage examples for provider-level and request-level header configuration
- Added practical use case example for large component generation
- Included appropriate warnings about beta feature status and production usage

## Review & Testing Checklist for Human

- [ ] **Verify examples work end-to-end**: Test the provided code examples with actual Anthropic models to ensure the header passthrough works correctly (depends on backend PR #8139 being merged)
- [ ] **Confirm beta header value**: Double-check that `fine-grained-tool-streaming-2025-05-14` matches the exact header value in Anthropic's current documentation
- [ ] **Validate AI SDK patterns**: Ensure the `streamObject` and `generateText` examples follow correct AI SDK conventions and that headers can be passed as shown

### Notes

This documentation change supports Framer's use case for generating complex UI components with real-time visual feedback. The examples depend on the corresponding backend changes in OpenRouterTeam/openrouter-web#8139 to actually function.

**Link to Devin session:** https://app.devin.ai/sessions/8c300615e12444d8ade75951ab7acc85  
**Requested by:** @louisgv