### PR TITLE
feat: add e2e test for Google Gemini Computer Use with comprehensive mock tools

### DIFF
--- a/e2e/computer-use/index.test.ts
+++ b/e2e/computer-use/index.test.ts
@@ -1,0 +1,159 @@
+import { generateText } from 'ai';
+import { writeFile } from 'fs/promises';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+import {
+  clickAtTool,
+  dragAndDropTool,
+  goBackTool,
+  goForwardTool,
+  hoverAtTool,
+  keyCombinationTool,
+  navigateTool,
+  openWebBrowserTool,
+  scrollAtTool,
+  scrollDocumentTool,
+  searchTool,
+  typeTextAtTool,
+  wait5SecondsTool,
+} from './tools';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+describe('Computer Use E2E Tests', () => {
+  it('should handle computer use tools with Claude (preparing for Google Gemini Computer Use)', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+    });
+
+    const model = openrouter('anthropic/claude-3.5-sonnet', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      system:
+        'You are a browser automation assistant. You can control a web browser using various UI actions like clicking, typing, scrolling, and navigating. When given a task, use the appropriate tools to complete it.',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Open a web browser, navigate to google.com, and search for "OpenRouter AI".',
+        },
+      ],
+      tools: {
+        open_web_browser: openWebBrowserTool,
+        wait_5_seconds: wait5SecondsTool,
+        go_back: goBackTool,
+        go_forward: goForwardTool,
+        search: searchTool,
+        navigate: navigateTool,
+        click_at: clickAtTool,
+        hover_at: hoverAtTool,
+        type_text_at: typeTextAtTool,
+        key_combination: keyCombinationTool,
+        scroll_document: scrollDocumentTool,
+        scroll_at: scrollAtTool,
+        drag_and_drop: dragAndDropTool,
+      },
+    });
+
+    expect(response.text).toBeDefined();
+    expect(response.toolCalls).toBeDefined();
+    expect(response.toolCalls.length).toBeGreaterThan(0);
+
+    const toolCallNames = response.toolCalls.map((call) => call.toolName);
+    expect(toolCallNames).toContain('open_web_browser');
+
+    expect(response.usage).toBeDefined();
+
+    const providerMetadata = response.providerMetadata;
+    expect(providerMetadata?.openrouter).toMatchObject({
+      usage: expect.objectContaining({
+        promptTokens: expect.any(Number),
+        completionTokens: expect.any(Number),
+        totalTokens: expect.any(Number),
+      }),
+    });
+
+    await writeFile(
+      new URL('./output.ignore.json', import.meta.url),
+      JSON.stringify(
+        {
+          text: response.text,
+          toolCalls: response.toolCalls,
+          usage: response.usage,
+          providerMetadata: response.providerMetadata,
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it('should handle multi-step computer use interactions with Claude', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+    });
+
+    const model = openrouter('anthropic/claude-3.5-sonnet', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      system:
+        'You are a browser automation assistant. You can control a web browser using various UI actions. Complete tasks step by step.',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Navigate to example.com, scroll down the page, and click on a link.',
+        },
+      ],
+      tools: {
+        open_web_browser: openWebBrowserTool,
+        wait_5_seconds: wait5SecondsTool,
+        go_back: goBackTool,
+        go_forward: goForwardTool,
+        search: searchTool,
+        navigate: navigateTool,
+        click_at: clickAtTool,
+        hover_at: hoverAtTool,
+        type_text_at: typeTextAtTool,
+        key_combination: keyCombinationTool,
+        scroll_document: scrollDocumentTool,
+        scroll_at: scrollAtTool,
+        drag_and_drop: dragAndDropTool,
+      },
+    });
+
+    expect(response.text).toBeDefined();
+    expect(response.toolCalls).toBeDefined();
+    expect(response.toolCalls.length).toBeGreaterThan(0);
+
+    const toolCallNames = response.toolCalls.map((call) => call.toolName);
+    expect(toolCallNames).toContain('navigate');
+
+    await writeFile(
+      new URL('./output-multi-step.ignore.json', import.meta.url),
+      JSON.stringify(
+        {
+          text: response.text,
+          toolCalls: response.toolCalls,
+          usage: response.usage,
+        },
+        null,
+        2,
+      ),
+    );
+  });
+});

--- a/e2e/computer-use/tools.ts
+++ b/e2e/computer-use/tools.ts
@@ -1,0 +1,229 @@
+import { tool } from 'ai';
+import { z } from 'zod/v4';
+
+export const openWebBrowserTool = tool({
+  description: 'Opens the web browser.',
+  inputSchema: z.object({}),
+  execute: async () => {
+    return {
+      success: true,
+      message: 'Web browser opened successfully',
+    };
+  },
+});
+
+export const wait5SecondsTool = tool({
+  description:
+    'Pauses execution for 5 seconds to allow dynamic content to load or animations to complete.',
+  inputSchema: z.object({}),
+  execute: async () => {
+    return {
+      success: true,
+      message: 'Waited 5 seconds',
+    };
+  },
+});
+
+export const goBackTool = tool({
+  description: "Navigates to the previous page in the browser's history.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    return {
+      success: true,
+      message: 'Navigated back successfully',
+    };
+  },
+});
+
+export const goForwardTool = tool({
+  description: "Navigates to the next page in the browser's history.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    return {
+      success: true,
+      message: 'Navigated forward successfully',
+    };
+  },
+});
+
+export const searchTool = tool({
+  description:
+    "Navigates to the default search engine's homepage (e.g., Google). Useful for starting a new search task.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    return {
+      success: true,
+      message: 'Navigated to search engine',
+    };
+  },
+});
+
+export const navigateTool = tool({
+  description: 'Navigates the browser directly to the specified URL.',
+  inputSchema: z.object({
+    url: z.string().describe('The URL to navigate to'),
+  }),
+  execute: async ({ url }) => {
+    return {
+      success: true,
+      message: `Navigated to ${url}`,
+      url,
+    };
+  },
+});
+
+export const clickAtTool = tool({
+  description:
+    'Clicks at a specific coordinate on the webpage. The x and y values are based on a 1000x1000 grid and are scaled to the screen dimensions.',
+  inputSchema: z.object({
+    x: z.number().min(0).max(999).describe('X coordinate (0-999)'),
+    y: z.number().min(0).max(999).describe('Y coordinate (0-999)'),
+  }),
+  execute: async ({ x, y }) => {
+    return {
+      success: true,
+      message: `Clicked at coordinates (${x}, ${y})`,
+      x,
+      y,
+    };
+  },
+});
+
+export const hoverAtTool = tool({
+  description:
+    'Hovers the mouse at a specific coordinate on the webpage. Useful for revealing sub-menus. x and y are based on a 1000x1000 grid.',
+  inputSchema: z.object({
+    x: z.number().min(0).max(999).describe('X coordinate (0-999)'),
+    y: z.number().min(0).max(999).describe('Y coordinate (0-999)'),
+  }),
+  execute: async ({ x, y }) => {
+    return {
+      success: true,
+      message: `Hovered at coordinates (${x}, ${y})`,
+      x,
+      y,
+    };
+  },
+});
+
+export const typeTextAtTool = tool({
+  description:
+    'Types text at a specific coordinate, defaults to clearing the field first and pressing ENTER after typing, but these can be disabled. x and y are based on a 1000x1000 grid.',
+  inputSchema: z.object({
+    x: z.number().min(0).max(999).describe('X coordinate (0-999)'),
+    y: z.number().min(0).max(999).describe('Y coordinate (0-999)'),
+    text: z.string().describe('The text to type'),
+    press_enter: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Whether to press ENTER after typing'),
+    clear_before_typing: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Whether to clear the field before typing'),
+  }),
+  execute: async ({ x, y, text, press_enter, clear_before_typing }) => {
+    return {
+      success: true,
+      message: `Typed "${text}" at coordinates (${x}, ${y})`,
+      x,
+      y,
+      text,
+      press_enter,
+      clear_before_typing,
+    };
+  },
+});
+
+export const keyCombinationTool = tool({
+  description:
+    'Press keyboard keys or combinations, such as "Control+C" or "Enter". Useful for triggering actions (like submitting a form with "Enter") or clipboard operations.',
+  inputSchema: z.object({
+    keys: z
+      .string()
+      .describe('The keys to press (e.g., "enter", "control+c")'),
+  }),
+  execute: async ({ keys }) => {
+    return {
+      success: true,
+      message: `Pressed key combination: ${keys}`,
+      keys,
+    };
+  },
+});
+
+export const scrollDocumentTool = tool({
+  description: 'Scrolls the entire webpage "up", "down", "left", or "right".',
+  inputSchema: z.object({
+    direction: z
+      .enum(['up', 'down', 'left', 'right'])
+      .describe('The direction to scroll'),
+  }),
+  execute: async ({ direction }) => {
+    return {
+      success: true,
+      message: `Scrolled document ${direction}`,
+      direction,
+    };
+  },
+});
+
+export const scrollAtTool = tool({
+  description:
+    'Scrolls a specific element or area at coordinate (x, y) in the specified direction by a certain magnitude. Coordinates and magnitude (default 800) are based on a 1000x1000 grid.',
+  inputSchema: z.object({
+    x: z.number().min(0).max(999).describe('X coordinate (0-999)'),
+    y: z.number().min(0).max(999).describe('Y coordinate (0-999)'),
+    direction: z
+      .enum(['up', 'down', 'left', 'right'])
+      .describe('The direction to scroll'),
+    magnitude: z
+      .number()
+      .min(0)
+      .max(999)
+      .optional()
+      .default(800)
+      .describe('The scroll magnitude (0-999, default 800)'),
+  }),
+  execute: async ({ x, y, direction, magnitude }) => {
+    return {
+      success: true,
+      message: `Scrolled ${direction} at coordinates (${x}, ${y}) with magnitude ${magnitude}`,
+      x,
+      y,
+      direction,
+      magnitude,
+    };
+  },
+});
+
+export const dragAndDropTool = tool({
+  description:
+    'Drags an element from a starting coordinate (x, y) and drops it at a destination coordinate (destination_x, destination_y). All coordinates are based on a 1000x1000 grid.',
+  inputSchema: z.object({
+    x: z.number().min(0).max(999).describe('Starting X coordinate (0-999)'),
+    y: z.number().min(0).max(999).describe('Starting Y coordinate (0-999)'),
+    destination_x: z
+      .number()
+      .min(0)
+      .max(999)
+      .describe('Destination X coordinate (0-999)'),
+    destination_y: z
+      .number()
+      .min(0)
+      .max(999)
+      .describe('Destination Y coordinate (0-999)'),
+  }),
+  execute: async ({ x, y, destination_x, destination_y }) => {
+    return {
+      success: true,
+      message: `Dragged from (${x}, ${y}) to (${destination_x}, ${destination_y})`,
+      x,
+      y,
+      destination_x,
+      destination_y,
+    };
+  },
+});


### PR DESCRIPTION
# feat: add e2e test for Google Gemini Computer Use with comprehensive mock tools

## Summary

This PR adds E2E test infrastructure for Google's Gemini Computer Use API by implementing all 13 UI action mock tools specified in the [Google Computer Use documentation](https://ai.google.dev/gemini-api/docs/computer-use#implement-computer-use) and creating tests that demonstrate tool integration.

**Important Note**: Since `google/gemini-2.5-computer-use-preview-10-2025` is not yet available on OpenRouter, the tests currently use `anthropic/claude-3.5-sonnet` as a proxy model. The tests will need to be updated when the Google model becomes available.

### Changes
- Created `e2e/computer-use/tools.ts` with mock implementations of all 13 Computer Use UI actions:
  - `open_web_browser`, `wait_5_seconds`, `go_back`, `go_forward`, `search`, `navigate`
  - `click_at`, `hover_at`, `type_text_at`, `key_combination`
  - `scroll_document`, `scroll_at`, `drag_and_drop`
- Created `e2e/computer-use/index.test.ts` with two test cases demonstrating tool usage
- All mock tools follow the schema specifications from Google's documentation
- Tests verify tool calls, usage metadata, and provider metadata tracking

## Review & Testing Checklist for Human

**Risk Level: 🟡 Yellow** - Tests pass but use proxy model; schema accuracy needs verification

- [ ] **Verify tool schemas match Google's Computer Use API spec** - Cross-reference each tool's input schema in `tools.ts` against the [official documentation table](https://ai.google.dev/gemini-api/docs/computer-use#implement-computer-use). Pay special attention to coordinate ranges (0-999), optional parameters, and default values.
- [ ] **Confirm mock tool approach is appropriate** - The mock tools return success messages without performing actual actions. Decide if this is sufficient or if integration with a real browser automation library is needed.
- [ ] **Plan for model availability** - When `google/gemini-2.5-computer-use-preview-10-2025` becomes available on OpenRouter, update the test to use the actual model and verify behavior matches expectations.

### Test Plan
1. Run the E2E tests: `pnpm test:e2e e2e/computer-use`
2. Verify both tests pass and tool calls are executed
3. Check generated output files: `e2e/computer-use/output.ignore.json` and `e2e/computer-use/output-multi-step.ignore.json`

### Notes
- All 13 UI actions from the Google Computer Use documentation are implemented as mock tools
- Tests currently use Claude 3.5 Sonnet as a proxy since the target Google model isn't available yet
- The tool schemas are based on the Google documentation dated 2025-10-24 UTC
- Tests write output to `.ignore.json` files for manual inspection

**Session**: [https://app.devin.ai/sessions/8efb8d5fd0544a7aa0b4007db15d213a](https://app.devin.ai/sessions/8efb8d5fd0544a7aa0b4007db15d213a)  
**Requested by**: Abhinav Pola (@abhinav-pola)