### PR TITLE
test: add e2e tests for reasoning.effort parameter

### DIFF
--- a/e2e/reasoning-effort.test.ts
+++ b/e2e/reasoning-effort.test.ts
@@ -1,0 +1,139 @@
+import { generateText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+describe('Reasoning effort parameter', () => {
+  it('should work with reasoning.effort set to low', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+    });
+
+    const model = openrouter('anthropic/claude-sonnet-4', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is 2+2? Think through this step by step.',
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'low',
+          },
+        },
+      },
+    });
+
+    expect(response.text).toBeTruthy();
+    expect(response.text.length).toBeGreaterThan(0);
+
+    expect(response.usage.totalTokens).toBeGreaterThan(0);
+
+    expect(response.providerMetadata?.openrouter).toMatchObject({
+      usage: expect.objectContaining({
+        promptTokens: expect.any(Number),
+        completionTokens: expect.any(Number),
+        totalTokens: expect.any(Number),
+      }),
+    });
+  });
+
+  it('should work with reasoning.effort set to medium', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+    });
+
+    const model = openrouter('anthropic/claude-sonnet-4', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is the capital of France? Explain your reasoning.',
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'medium',
+          },
+        },
+      },
+    });
+
+    expect(response.text).toBeTruthy();
+    expect(response.text.length).toBeGreaterThan(0);
+
+    expect(response.usage.totalTokens).toBeGreaterThan(0);
+
+    expect(response.providerMetadata?.openrouter).toMatchObject({
+      usage: expect.objectContaining({
+        promptTokens: expect.any(Number),
+        completionTokens: expect.any(Number),
+        totalTokens: expect.any(Number),
+      }),
+    });
+  });
+
+  it('should work with reasoning.effort set to high', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+    });
+
+    const model = openrouter('anthropic/claude-sonnet-4', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Solve this problem: If a train leaves station A at 60 mph and another train leaves station B at 80 mph, and they are 420 miles apart, when will they meet?',
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      },
+    });
+
+    expect(response.text).toBeTruthy();
+    expect(response.text.length).toBeGreaterThan(0);
+
+    expect(response.usage.totalTokens).toBeGreaterThan(0);
+
+    expect(response.providerMetadata?.openrouter).toMatchObject({
+      usage: expect.objectContaining({
+        promptTokens: expect.any(Number),
+        completionTokens: expect.any(Number),
+        totalTokens: expect.any(Number),
+      }),
+    });
+  });
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,6 +1,7 @@
 import { config } from 'dotenv';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
 
 const envPath = new URL('./.env.e2e', import.meta.url);
 
@@ -12,5 +13,8 @@ export default defineConfig(() => ({
     globals: true,
     env: config({ path: envPath.pathname }).parsed,
     include: ['./e2e/**/*.test.ts'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
   },
 }));


### PR DESCRIPTION
# test: add e2e tests for reasoning.effort parameter

## Summary
This PR adds comprehensive end-to-end tests for the `reasoning.effort` parameter in the OpenRouter AI SDK provider. The tests validate that the `effort` parameter (with values `low`, `medium`, and `high`) can be configured via `providerOptions.openrouter.reasoning.effort` and that responses are properly structured with usage accounting.

Additionally, this PR fixes a bug in `vitest.e2e.config.ts` where `__PACKAGE_VERSION__` was not defined, which was causing all e2e tests to fail during local development.

**Changes:**
- Added `e2e/reasoning-effort.test.ts` with three test cases covering low, medium, and high effort levels
- Fixed `vitest.e2e.config.ts` to include `__PACKAGE_VERSION__` define (matching the pattern in `vitest.node.config.ts`)

## Review & Testing Checklist for Human

- [ ] **Verify e2e tests pass in CI** - I was unable to run these tests locally due to missing API keys. Please confirm they pass in CI with proper environment variables configured.
- [ ] **Validate reasoning.effort is sent to API correctly** - The tests verify response structure but don't explicitly confirm the `effort` parameter is being transmitted to OpenRouter's API. Consider checking API logs or traces to verify the parameter is included in requests.
- [ ] **Confirm vitest.e2e.config.ts fix doesn't break existing tests** - This fix resolves a `__PACKAGE_VERSION__` error that was affecting all e2e tests. Verify other e2e tests still work correctly.
- [ ] **Consider test coverage** - The current tests only validate basic response structure and usage accounting. You may want to add assertions that verify different effort levels produce measurably different behavior (e.g., different reasoning token counts).

### Test Plan
1. Run `pnpm test:e2e e2e/reasoning-effort.test.ts` in an environment with proper API keys
2. Verify all three test cases pass (low, medium, high effort)
3. Run the full e2e test suite to ensure the vitest config fix doesn't break other tests
4. Optionally: Inspect API request logs to confirm the `reasoning.effort` parameter is being sent correctly

### Notes
- This addresses the issue raised in the Slack thread where a user reported that `reasoningEffort` wasn't being parsed correctly from the AI SDK
- The correct usage is `providerOptions.openrouter.reasoning.effort` (not `providerOptions.openai.reasoning_effort`)
- Session: https://app.devin.ai/sessions/866bd658284e4381ac80004ce4373c64
- Requested by: Louis Vichy (lab) (@louisgv)