### PR TITLE
feat: add NVIDIA message adapter for video_url conversion

### DIFF
--- a/src/chat/convert-to-nvidia-messages.test.ts
+++ b/src/chat/convert-to-nvidia-messages.test.ts
@@ -1,0 +1,534 @@
+import type { OpenRouterChatCompletionsInput } from '../types/openrouter-chat-completions-input';
+import { convertToNvidiaMessages } from './convert-to-nvidia-messages';
+
+describe('convertToNvidiaMessages', () => {
+  describe('video conversion', () => {
+    it('should convert file parts with video media types to video_url format', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this video' },
+            {
+              type: 'file',
+              file: {
+                filename: 'sample.mp4',
+                file_data: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this video' },
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert file parts with video/webm media type to video_url format', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'sample.webm',
+                file_data: 'data:video/webm;base64,GkXfo59ChoEBQveBAULygQRC',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/webm;base64,GkXfo59ChoEBQveBAULygQRC',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert file parts with video/mov media type to video_url format', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'sample.mov',
+                file_data: 'data:video/mov;base64,AAAAHGZ0eXBxdA==',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/mov;base64,AAAAHGZ0eXBxdA==',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should preserve cache_control when converting video files', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'sample.mp4',
+                file_data: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('image pass-through', () => {
+    it('should pass through image_url parts unchanged', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should preserve cache_control on image_url parts', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+              },
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+              },
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('text pass-through', () => {
+    it('should pass through text parts unchanged', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello, world!' },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello, world!' },
+          ],
+        },
+      ]);
+    });
+
+    it('should preserve cache_control on text parts', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello, world!',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello, world!',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('unsupported file types', () => {
+    it('should convert non-video file parts to text with unsupported message', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'document.pdf',
+                file_data: 'data:application/pdf;base64,JVBERi0xLjQK',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: '[Unsupported file type: document.pdf]',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should preserve cache_control when converting unsupported files to text', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'data.csv',
+                file_data: 'data:text/csv;base64,bmFtZSxhZ2UK',
+              },
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: '[Unsupported file type: data.csv]',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('mixed content', () => {
+    it('should handle mixed text, image, and video content', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Compare these media files' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgo=',
+              },
+            },
+            {
+              type: 'file',
+              file: {
+                filename: 'video.mp4',
+                file_data: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Compare these media files' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgo=',
+              },
+            },
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('non-user messages', () => {
+    it('should pass through system messages unchanged', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+        },
+      ]);
+    });
+
+    it('should pass through assistant messages unchanged', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'assistant',
+          content: 'I can help you with that.',
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: 'I can help you with that.',
+        },
+      ]);
+    });
+
+    it('should pass through tool messages unchanged', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'tool',
+          tool_call_id: 'call-123',
+          content: 'Tool result',
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'tool',
+          tool_call_id: 'call-123',
+          content: 'Tool result',
+        },
+      ]);
+    });
+
+    it('should pass through user messages with string content unchanged', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'user',
+          content: 'Hello',
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: 'Hello',
+        },
+      ]);
+    });
+  });
+
+  describe('multiple messages', () => {
+    it('should handle multiple messages with different content types', () => {
+      const input: OpenRouterChatCompletionsInput = [
+        {
+          role: 'system',
+          content: 'You are a video analysis assistant.',
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Analyze this video' },
+            {
+              type: 'file',
+              file: {
+                filename: 'sample.mp4',
+                file_data: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: 'I can see the video.',
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What about this image?' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgo=',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToNvidiaMessages(input);
+
+      expect(result).toEqual([
+        {
+          role: 'system',
+          content: 'You are a video analysis assistant.',
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Analyze this video' },
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: 'I can see the video.',
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What about this image?' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgo=',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/src/chat/convert-to-nvidia-messages.ts
+++ b/src/chat/convert-to-nvidia-messages.ts
@@ -1,0 +1,130 @@
+import type { OpenRouterCacheControl } from '../types/openrouter-chat-completions-input';
+import type { OpenRouterChatCompletionsInput } from '../types/openrouter-chat-completions-input';
+
+export interface NvidiaChatCompletionContentPartVideo {
+  type: 'video_url';
+  video_url: {
+    url: string;
+  };
+  cache_control?: OpenRouterCacheControl;
+}
+
+export type NvidiaChatCompletionContentPart =
+  | {
+      type: 'text';
+      text: string;
+      cache_control?: OpenRouterCacheControl;
+    }
+  | {
+      type: 'image_url';
+      image_url: {
+        url: string;
+      };
+      cache_control?: OpenRouterCacheControl;
+    }
+  | NvidiaChatCompletionContentPartVideo;
+
+export type NvidiaChatCompletionMessageParam =
+  | {
+      role: 'system';
+      content: string;
+      cache_control?: OpenRouterCacheControl;
+    }
+  | {
+      role: 'user';
+      content: string | Array<NvidiaChatCompletionContentPart>;
+      cache_control?: OpenRouterCacheControl;
+    }
+  | {
+      role: 'assistant';
+      content?: string | null;
+      reasoning?: string | null;
+      tool_calls?: Array<{
+        type: 'function';
+        id: string;
+        function: {
+          arguments: string;
+          name: string;
+        };
+      }>;
+      cache_control?: OpenRouterCacheControl;
+    }
+  | {
+      role: 'tool';
+      content: string;
+      tool_call_id: string;
+      cache_control?: OpenRouterCacheControl;
+    };
+
+export type NvidiaChatCompletionsInput = Array<NvidiaChatCompletionMessageParam>;
+
+/**
+ * Converts OpenRouter message format to NVIDIA's expected format.
+ * 
+ * Key differences:
+ * - NVIDIA uses `video_url` type with `video_url: { url }` structure for videos
+ * - OpenRouter uses `file` type with `file: { filename, file_data }` structure
+ * 
+ * This adapter converts file content parts with video media types to NVIDIA's video_url format.
+ */
+export function convertToNvidiaMessages(
+  messages: OpenRouterChatCompletionsInput,
+): NvidiaChatCompletionsInput {
+  return messages.map((message) => {
+    if (message.role === 'user' && Array.isArray(message.content)) {
+      const convertedContent: Array<NvidiaChatCompletionContentPart> = message.content.map(
+        (part) => {
+          if (part.type === 'file') {
+            const fileData = part.file.file_data;
+            
+            const isVideo = fileData.match(/^data:(video\/[^;]+)/);
+            
+            if (isVideo) {
+              return {
+                type: 'video_url' as const,
+                video_url: {
+                  url: fileData,
+                },
+                cache_control: part.cache_control,
+              };
+            }
+            
+            return {
+              type: 'text' as const,
+              text: `[Unsupported file type: ${part.file.filename}]`,
+              cache_control: part.cache_control,
+            };
+          }
+          
+          if (part.type === 'image_url') {
+            return {
+              type: 'image_url' as const,
+              image_url: part.image_url,
+              cache_control: part.cache_control,
+            };
+          }
+          
+          if (part.type === 'text') {
+            return {
+              type: 'text' as const,
+              text: part.text,
+              cache_control: part.cache_control,
+            };
+          }
+          
+          return {
+            type: 'text' as const,
+            text: '',
+          };
+        },
+      );
+      
+      return {
+        ...message,
+        content: convertedContent,
+      };
+    }
+    
+    return message as NvidiaChatCompletionMessageParam;
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
 export * from './facade';
 export * from './provider';
 export * from './types';
+export {
+  convertToNvidiaMessages,
+  type NvidiaChatCompletionsInput,
+  type NvidiaChatCompletionMessageParam,
+  type NvidiaChatCompletionContentPart,
+  type NvidiaChatCompletionContentPartVideo,
+} from './chat/convert-to-nvidia-messages';


### PR DESCRIPTION
# feat: add NVIDIA message adapter for video_url conversion

## Summary
Added a new `convertToNvidiaMessages` adapter function that converts OpenRouter's message format to NVIDIA's expected format. The key difference is that NVIDIA uses `video_url` type with `{ video_url: { url } }` structure for videos, while OpenRouter uses `file` type with `{ file: { filename, file_data } }` structure.

**Changes:**
- Created `src/chat/convert-to-nvidia-messages.ts` with the adapter function and NVIDIA-specific types
- Added comprehensive unit tests covering video conversion, image/text pass-through, unsupported files, and mixed content
- Exported the adapter function and types from the main package index

**How it works:**
- Detects video files by checking if `file_data` starts with `data:video/`
- Converts video files to NVIDIA's `video_url` format
- Passes through `image_url` and `text` content parts unchanged
- Converts unsupported file types (PDFs, CSVs, etc.) to text placeholders: `[Unsupported file type: filename]`
- Preserves `cache_control` metadata throughout conversions

## Review & Testing Checklist for Human
This is a **YELLOW** risk PR - the implementation looks correct but needs real-world validation:

- [ ] **Test with actual NVIDIA API** - The adapter was only tested with unit tests. Please verify it works with real NVIDIA API calls (e.g., `nvidia/nemotron-nano-12b-v2-vl`)
- [ ] **Verify video format detection** - The regex `/^data:(video\/[^;]+)/` is used to detect videos. Confirm this works for all expected formats (mp4, webm, mov, etc.)
- [ ] **Confirm unsupported file behavior** - Non-video files are converted to text placeholders. Is this the desired behavior, or should we throw an error instead?

### Test Plan
```typescript
import { createOpenRouter, convertToNvidiaMessages } from '@openrouter/ai-sdk-provider';

const openrouter = createOpenRouter({ apiKey: 'your-key' });
const model = openrouter.chat('nvidia/nemotron-nano-12b-v2-vl');

// Test with a video file
const messages = convertToNvidiaMessages([
  {
    role: 'user',
    content: [
      { type: 'text', text: 'Describe this video' },
      {
        type: 'file',
        file: {
          filename: 'sample.mp4',
          file_data: 'data:video/mp4;base64,...'
        }
      }
    ]
  }
]);

const result = await generateText({ model, messages });
```

### Notes
- All existing tests pass (90/90 in both node and edge environments)
- TypeScript compilation passes with no errors
- The adapter is a pure transformation function with no side effects
- Session: https://app.devin.ai/sessions/f2781a1440f94f54a019d9ff76a47abb
- Requested by: Abhinav Pola (@abhinav-pola)