### PR TITLE
fix: guard __PACKAGE_VERSION__ to avoid ReferenceError in tests

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
 // Version string of this package injected at build time.
 declare const __PACKAGE_VERSION__: string | undefined;
 export const VERSION: string =
-  __PACKAGE_VERSION__ === undefined ? '0.0.0-test' : __PACKAGE_VERSION__;
+  typeof __PACKAGE_VERSION__ === 'undefined' ? '0.0.0-test' : __PACKAGE_VERSION__;


### PR DESCRIPTION
# fix: guard __PACKAGE_VERSION__ to avoid ReferenceError in tests

## Summary
Fixed a `ReferenceError: __PACKAGE_VERSION__ is not defined` that was preventing e2e tests from running. Changed the version check in `src/version.ts` from `__PACKAGE_VERSION__ === undefined` to `typeof __PACKAGE_VERSION__ === 'undefined'` to safely handle cases where the global constant doesn't exist (e.g., when running tests directly from TypeScript source without going through the build process).

**Technical details:**
- `__PACKAGE_VERSION__` is injected by tsup during builds via the `define` option
- When vitest runs tests directly from source (especially e2e tests), this global doesn't exist
- The old code threw a ReferenceError when trying to access the undefined variable
- The new code uses `typeof` which safely returns `'undefined'` without throwing

## Review & Testing Checklist for Human
- [ ] **Verify e2e tests run successfully** - Run `pnpm run test:e2e` and confirm tests execute without the ReferenceError (note: there's one flaky test in `pdf-blob/index.test.ts` that fails due to OCR misreading - this is unrelated to this fix)
- [ ] **Confirm build behavior unchanged** - Run `pnpm build` and verify the built output still contains the correct package version (not '0.0.0-test')
- [ ] **Review the flaky test** - The `sending large pdf base64 blob with FileParserPlugin` test fails intermittently because the AI model misreads "LARGE-M9N3T" as "LARGE-MNGT" or "LARGE-MN3T". Should this test be made more lenient or is this a real issue to investigate?

### Test Plan
1. Run `pnpm typecheck` - should pass ✓
2. Run `pnpm test` - should pass ✓  
3. Run `pnpm run test:e2e` - should run without ReferenceError (may have 1 flaky test failure unrelated to this fix)
4. Run `pnpm build` and verify dist/index.js contains the real version number

### Notes
- All unit, node, and edge tests pass
- E2e tests now run successfully (previously blocked by ReferenceError)
- One pre-existing flaky e2e test unrelated to this change
- Session: https://app.devin.ai/sessions/a5cfef70be7c413b82cb44b273281534
- Requested by: Tom Aylott (@subtleGradient)