### PR TITLE
Switch from NPM_TOKEN to OIDC authentication for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,4 +36,3 @@ jobs:
           publish: pnpm changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e": "vitest --config vitest.e2e.config.ts --run",
     "changeset": "changeset",
     "changeset-version": "changeset version",
-    "changeset-publish": "pnpm build && pnpm test && changeset publish"
+    "changeset-publish": "pnpm build && pnpm test && changeset publish --provenance"
   },
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
- Remove NPM_TOKEN from publish workflow env - Add --provenance flag to changeset-publish script - Rely on id-token: write permission for OIDC authentication - This enables provenance attestations and eliminates token management