### PR TITLE
Add minimal .npmrc to force OIDC authentication

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
- Create .npmrc with only registry URL
- No auth token configured, forcing npm to use OIDC
- Test if npm will use OIDC token from GitHub Actions id-token permission
- If successful, this eliminates need for NPM_TOKEN secret