### PR TITLE
Restore NPM_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,3 +36,4 @@ jobs:
           publish: pnpm changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

Restore `NPM_TOKEN` environment variable to the publish workflow. The token is needed for npm authentication while `--provenance` flag uses OIDC for cryptographic attestations.

## Changes

- Add `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` back to changesets action environment
- Remove `.npmrc` experiment (didn't work - changesets looks for `~/.npmrc`, not repo `.npmrc`)
- Keep `--provenance` flag for OIDC attestations

## How it Works

- **Authentication**: `NPM_TOKEN` secret (may be configured at org level)
- **Provenance**: `--provenance` flag + `id-token: write` permission uses OIDC
- **Both work together**: Token authenticates the publish, OIDC signs/attests the package

## Context

Previous attempts to use pure OIDC without a token failed with E404 errors. npm's OIDC support is specifically for provenance attestations, not for replacing token-based authentication entirely.