### PR TITLE
Upgrade npm to support OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,8 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
npm v10.8.2 (bundled with Node 20.x) predates Trusted Publishing support. npm CLI v11.5.1+ is required for OIDC authentication with --provenance flag.

Evidence: CI publish failed with ENEEDAUTH despite id-token: write and correct workflow setup. npm fell back to token auth and found none.

Add explicit npm upgrade step before publish to ensure OIDC works.