### PR TITLE
Fix validation error for file parser image elements

### DIFF
--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -113,7 +113,7 @@ export const OpenRouterNonStreamChatCompletionResponseSchema = z.union([
                                 z
                                   .object({
                                     type: z.string(),
-                                    text: z.string(),
+                                    text: z.string().optional(),
                                   })
                                   .passthrough(),
                               )
@@ -237,7 +237,7 @@ export const OpenRouterStreamChatCompletionChunkSchema = z.union([
                                 z
                                   .object({
                                     type: z.string(),
-                                    text: z.string(),
+                                    text: z.string().optional(),
                                   })
                                   .passthrough(),
                               )


### PR DESCRIPTION
### Problem
When the `file-parser` plugin processes PDFs containing images using the Mistral OCR engine, it returns annotations with a `content` array that includes both text and image elements. Image elements have the structure `{"type":"image_url","image_url":{...}}` without a `text` property, causing validation failures.

### Solution
Make the `text` field optional in the file annotation content schema (lines 116 and 240 in `src/chat/schemas.ts`).

### Changes
- Modified `text: z.string()` to `text: z.string().optional()` in both non-stream and stream response schemas
- Allows the schema to accept both text elements with text content and image elements without text content

### Related
Builds upon #232 which added `.passthrough()` for forward compatibility.