### PR TITLE
Add changeset for #235 - thanks @smorimoto

### DIFF
--- a/.changeset/fix-file-annotation-text-optional.md
+++ b/.changeset/fix-file-annotation-text-optional.md
@@ -1,0 +1,9 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+fix: make text field optional in file annotation content schema
+
+When processing PDFs with the file-parser plugin using Mistral OCR, image elements in the response were failing validation. The schema required a `text` field on all content elements, but image elements (`type: "image_url"`) only have `image_url` data—no text. This made it impossible to process PDFs containing images.
+
+Thanks @smorimoto for the fix! (#235)


### PR DESCRIPTION
Adds a changeset for PR #235 which made the text field optional in file annotation content schema.

This fixes a validation error when the `file-parser` plugin processes PDFs containing images using the Mistral OCR engine.

Thanks @smorimoto for the fix!