### PR TITLE
feat: add 'minimal' to reasoning.effort type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,7 @@ export type OpenRouterProviderOptions = {
         max_tokens: number;
       }
     | {
-        effort: 'high' | 'medium' | 'low';
+        effort: 'high' | 'medium' | 'low' | 'minimal';
       }
   );
 


### PR DESCRIPTION
## Description

Adds `'minimal'` as a valid value for the `reasoning.effort` option, aligning the type definition with the OpenRouter SDK's `Effort` type which supports `'minimal' | 'low' | 'medium' | 'high'`.

This was discovered while investigating support for Together's `reasoning_effort` parameter. The existing `reasoning.effort` field already supports Together's documented values (`low`, `medium`, `high`), and this PR adds the additional `'minimal'` value that the OpenRouter SDK supports.

## Human Review Checklist

- [ ] Verify that `'minimal'` is actually supported by the OpenRouter API backend
- [ ] Confirm whether a changeset is needed for this type-only change

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [ ] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.

---

**Requested by:** Tomas Oliva (@ping-Toven)
**Link to Devin run:** https://app.devin.ai/sessions/38df2377475a49839bfd56a18f8ac23d