### PR TITLE
feat: add debug flag support for echo_upstream_body

### DIFF
--- a/.changeset/add-debug-flag.md
+++ b/.changeset/add-debug-flag.md
@@ -1,0 +1,10 @@
+---
+"@openrouter/ai-sdk-provider": minor
+---
+
+Add support for debug flag to echo upstream request body
+
+- Added `debug` option to `OpenRouterChatSettings` with `echo_upstream_body` boolean
+- The debug flag is passed through to the OpenRouter API in both streaming and non-streaming requests
+- Debug mode only works with streaming requests and returns the upstream request body (with sensitive data redacted) as the first chunk
+- Updated README with usage documentation

--- a/README.md
+++ b/README.md
@@ -170,6 +170,36 @@ await streamText({
 
 ## Use Cases
 
+### Debugging API Requests
+
+The provider supports a debug mode that echoes back the request body sent to the upstream provider. This is useful for troubleshooting and understanding how your requests are being processed. Note that debug mode only works with streaming requests.
+
+```typescript
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { streamText } from 'ai';
+
+const openrouter = createOpenRouter({ apiKey: 'your-api-key' });
+const model = openrouter('anthropic/claude-3.5-sonnet', {
+  debug: {
+    echo_upstream_body: true,
+  },
+});
+
+const result = await streamText({
+  model,
+  prompt: 'Hello, how are you?',
+});
+
+// The debug data is available in the stream's first chunk
+// and in the final response's providerMetadata
+for await (const chunk of result.fullStream) {
+  // Debug chunks have empty choices and contain debug.echo_upstream_body
+  console.log(chunk);
+}
+```
+
+The debug response will include the request body that was sent to the upstream provider, with sensitive data redacted (user IDs, base64 content, etc.). This helps you understand how OpenRouter transforms your request before sending it to the model provider.
+
 ### Usage Accounting
 
 The provider supports [OpenRouter usage accounting](https://openrouter.ai/docs/use-cases/usage-accounting), which allows you to track token usage details directly in your API responses, without making additional API calls.

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1556,4 +1556,96 @@ describe('doStream', () => {
       },
     });
   });
+
+  it('should pass debug settings', async () => {
+    prepareStreamResponse({ content: ['Hello'] });
+
+    const debugModel = provider.chat('anthropic/claude-3.5-sonnet', {
+      debug: {
+        echo_upstream_body: true,
+      },
+    });
+
+    await debugModel.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      stream: true,
+      stream_options: { include_usage: true },
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      debug: {
+        echo_upstream_body: true,
+      },
+    });
+  });
+});
+
+describe('debug settings', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+
+  function prepareJsonResponse({ content = '' }: { content?: string } = {}) {
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'anthropic/claude-3.5-sonnet',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content,
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 4,
+          total_tokens: 34,
+          completion_tokens: 30,
+        },
+      },
+    };
+  }
+
+  it('should pass debug settings in doGenerate', async () => {
+    prepareJsonResponse({ content: 'Hello!' });
+
+    const debugModel = provider.chat('anthropic/claude-3.5-sonnet', {
+      debug: {
+        echo_upstream_body: true,
+      },
+    });
+
+    await debugModel.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      debug: {
+        echo_upstream_body: true,
+      },
+    });
+  });
+
+  it('should not include debug when not set', async () => {
+    prepareJsonResponse({ content: 'Hello!' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    const requestBody = await server.calls[0]!.requestBodyJson;
+    expect(requestBody).not.toHaveProperty('debug');
+  });
 });

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -144,6 +144,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       web_search_options: this.settings.web_search_options,
       // Provider routing settings:
       provider: this.settings.provider,
+      // Debug settings:
+      debug: this.settings.debug,
 
       // extra body:
       ...this.config.extraBody,

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -82,6 +82,20 @@ monitor and detect abuse. Learn more.
   };
 
   /**
+   * Debug options for troubleshooting API requests.
+   * Only works with streaming requests.
+   * @see https://openrouter.ai/docs/api-reference/debugging
+   */
+  debug?: {
+    /**
+     * When true, echoes back the request body that was sent to the upstream provider.
+     * The debug data will be returned as the first chunk in the stream with a `debug.echo_upstream_body` field.
+     * Sensitive data like user IDs and base64 content will be redacted.
+     */
+    echo_upstream_body?: boolean;
+  };
+
+  /**
    * Provider routing preferences to control request routing behavior
    */
   provider?: {


### PR DESCRIPTION
## Description

Adds support for the `debug` flag. This allows users to pass `debug: { echo_upstream_body: true }` to echo back the request body sent to the upstream provider for troubleshooting purposes.

**Usage:**
```typescript
const model = openrouter('anthropic/claude-3.5-sonnet', {
  debug: {
    echo_upstream_body: true,
  },
});
```

The debug data is returned as the first chunk in streaming responses with sensitive data (user IDs, base64 content) redacted.

**Changes:**
- Added `debug` type definition to `OpenRouterChatSettings`
- Pass `debug` flag through to OpenRouter API in `getArgs()`
- Added README documentation with usage example
- Added unit tests for both `doGenerate` and `doStream`

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

## Review Notes

**Key areas to review:**
1. The debug flag is passed through to the API but response handling is server-side - tests only verify the flag is sent correctly
2. The JSDoc references a docs URL that may not be live yet (docs PR #9840 was pending)
3. No E2E test - would require real API call to verify debug response

---
Link to Devin run: https://app.devin.ai/sessions/ea090fab1ca749ecbc496a7fb2026bee
Requested by: John Krauss (john.krauss@openrouter.ai) (@talos)