### PR TITLE
feat: add FileParser annotations support for Skip Parsing Costs

### DIFF
--- a/.changeset/add-file-annotations.md
+++ b/.changeset/add-file-annotations.md
@@ -1,0 +1,9 @@
+---
+"@openrouter/ai-sdk-provider": minor
+---
+
+Add support for FileParser annotations to enable "Skip Parsing Costs" feature
+
+- Annotations from file parsing are now exposed via `providerMetadata.openrouter.annotations`
+- Pass annotations back via `providerOptions.openrouter.annotations` to skip re-parsing costs
+- See https://openrouter.ai/docs/guides/overview/multimodal/pdfs#skip-parsing-costs

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -226,11 +226,14 @@ export function convertToOpenRouterChatMessages(
           }
         }
 
-        // Check message-level providerOptions for preserved reasoning_details
+        // Check message-level providerOptions for preserved reasoning_details and annotations
         const parsedProviderOptions =
           OpenRouterProviderOptionsSchema.safeParse(providerOptions);
         const messageReasoningDetails = parsedProviderOptions.success
           ? parsedProviderOptions.data?.openrouter?.reasoning_details
+          : undefined;
+        const messageAnnotations = parsedProviderOptions.success
+          ? parsedProviderOptions.data?.openrouter?.annotations
           : undefined;
 
         // Use message-level reasoning_details if available, otherwise use accumulated from parts
@@ -249,6 +252,7 @@ export function convertToOpenRouterChatMessages(
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           reasoning: reasoning || undefined,
           reasoning_details: finalReasoningDetails,
+          annotations: messageAnnotations,
           cache_control: getCacheControl(providerOptions),
         });
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -413,6 +413,20 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
       }
     }
 
+    // Extract file annotations to expose in providerMetadata
+    const fileAnnotations = choice.message.annotations?.filter(
+      (
+        a,
+      ): a is {
+        type: 'file';
+        file: {
+          hash: string;
+          name: string;
+          content?: Array<{ type: string; text?: string }>;
+        };
+      } => a.type === 'file',
+    );
+
     return {
       content,
       finishReason: mapOpenRouterFinishReason(choice.finish_reason),
@@ -422,6 +436,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
         openrouter: OpenRouterProviderMetadataSchema.parse({
           provider: response.provider ?? '',
           reasoning_details: choice.message.reasoning_details ?? [],
+          annotations:
+            fileAnnotations && fileAnnotations.length > 0
+              ? fileAnnotations
+              : undefined,
           usage: {
             promptTokens: usageInfo.inputTokens ?? 0,
             completionTokens: usageInfo.outputTokens ?? 0,

--- a/src/schemas/provider-metadata.ts
+++ b/src/schemas/provider-metadata.ts
@@ -2,12 +2,38 @@ import { z } from 'zod/v4';
 import { ReasoningDetailUnionSchema } from './reasoning-details';
 
 /**
+ * Schema for file annotations from FileParserPlugin
+ */
+export const FileAnnotationSchema = z.object({
+  type: z.literal('file'),
+  file: z
+    .object({
+      hash: z.string(),
+      name: z.string(),
+      content: z
+        .array(
+          z
+            .object({
+              type: z.string(),
+              text: z.string().optional(),
+            })
+            .passthrough(),
+        )
+        .optional(),
+    })
+    .passthrough(),
+});
+
+export type FileAnnotation = z.infer<typeof FileAnnotationSchema>;
+
+/**
  * Schema for OpenRouter provider metadata attached to responses
  */
 export const OpenRouterProviderMetadataSchema = z
   .object({
     provider: z.string(),
     reasoning_details: z.array(ReasoningDetailUnionSchema).optional(),
+    annotations: z.array(FileAnnotationSchema).optional(),
     usage: z
       .object({
         promptTokens: z.number(),
@@ -42,13 +68,14 @@ export type OpenRouterProviderMetadata = z.infer<
 >;
 
 /**
- * Schema for parsing provider options that may contain reasoning_details
+ * Schema for parsing provider options that may contain reasoning_details and annotations
  */
 export const OpenRouterProviderOptionsSchema = z
   .object({
     openrouter: z
       .object({
         reasoning_details: z.array(ReasoningDetailUnionSchema).optional(),
+        annotations: z.array(FileAnnotationSchema).optional(),
       })
       .optional(),
   })

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -1,3 +1,4 @@
+import type { FileAnnotation } from '@/src/schemas/provider-metadata';
 import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 
 // Type for OpenRouter Cache Control following Anthropic's pattern
@@ -67,6 +68,7 @@ export interface ChatCompletionAssistantMessageParam {
   content?: string | null;
   reasoning?: string | null;
   reasoning_details?: ReasoningDetailUnion[];
+  annotations?: FileAnnotation[];
   tool_calls?: Array<ChatCompletionMessageToolCall>;
   cache_control?: OpenRouterCacheControl;
 }


### PR DESCRIPTION
## Summary

- Expose file parsing annotations via `providerMetadata.openrouter.annotations`
- Accept annotations via `providerOptions.openrouter.annotations` for round-trip

Fixes #271

## Why

Customers using the "Skip Parsing Costs" feature (https://openrouter.ai/docs/guides/overview/multimodal/pdfs#skip-parsing-costs) couldn't access annotations through the AI SDK provider - they were parsed but not exposed.

## Usage

```typescript
import { openrouter } from '@openrouter/ai-sdk-provider';
import { generateText } from 'ai';

// First request - get annotations
const result = await generateText({
  model: openrouter('mistral/mistral-small-3.1-24b-instruct'),
  messages: [{
    role: 'user',
    content: [
      { type: 'text', text: 'Summarize this document' },
      { type: 'file', data: pdfBuffer, mimeType: 'application/pdf' }
    ]
  }]
});

// Extract annotations from response
const annotations = result.providerMetadata?.openrouter?.annotations;

// Follow-up request - skip parsing costs by passing annotations
const followUp = await generateText({
  model: openrouter('mistral/mistral-small-3.1-24b-instruct'),
  messages: [
    { role: 'user', content: [...] },
    { 
      role: 'assistant', 
      content: result.text,
      providerOptions: { openrouter: { annotations } }  // ~53% cost savings
    },
    { role: 'user', content: 'What about section 3?' }
  ]
});
```

## Changes

- `src/schemas/provider-metadata.ts` - Added `FileAnnotationSchema`, added `annotations` to metadata and options schemas
- `src/chat/index.ts` - Extract file annotations from response, expose in `providerMetadata.openrouter.annotations`
- `src/chat/convert-to-openrouter-chat-messages.ts` - Parse `providerOptions.openrouter.annotations`, include in outgoing requests
- `src/types/openrouter-chat-completions-input.ts` - Added `annotations` field to `ChatCompletionAssistantMessageParam`

## Testing

- All 99 unit tests pass
- Manual verification shows ~53% cost savings when annotations are passed