### PR TITLE
feat: add supportsImageUrls property

### DIFF
--- a/.changeset/supports-image-urls.md
+++ b/.changeset/supports-image-urls.md
@@ -2,4 +2,4 @@
 "@openrouter/ai-sdk-provider": patch
 ---
 
-Add supportsImageUrls property and expand supportedUrls to accept any HTTP/HTTPS URL for images
+Add supportsImageUrls property to indicate image URL support for all models

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -63,7 +63,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
   readonly modelId: OpenRouterChatModelId;
   readonly supportsImageUrls = true;
   readonly supportedUrls: Record<string, RegExp[]> = {
-    'image/*': [/^data:image\/[a-zA-Z]+;base64,/, /^https?:\/\/.+/i],
+    'image/*': [
+      /^data:image\/[a-zA-Z]+;base64,/,
+      /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i,
+    ],
     // 'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],
   };

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -45,7 +45,10 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV2 {
   readonly modelId: OpenRouterCompletionModelId;
   readonly supportsImageUrls = true;
   readonly supportedUrls: Record<string, RegExp[]> = {
-    'image/*': [/^data:image\/[a-zA-Z]+;base64,/, /^https?:\/\/.+/i],
+    'image/*': [
+      /^data:image\/[a-zA-Z]+;base64,/,
+      /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i,
+    ],
     'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],
   };


### PR DESCRIPTION
## Description

Adds `supportsImageUrls = true` property to both `OpenRouterChatLanguageModel` and `OpenRouterCompletionLanguageModel` classes,

**Changes:**
- Added `readonly supportsImageUrls = true` to both model classes

**Human Review Checklist:**
- [ ] Verify `supportsImageUrls` is the correct property name (note: this is not part of the standard `LanguageModelV2` interface)

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

---

Requested by: shashank.goyal@openrouter.ai (@yogasanas)

[Link to Devin run](https://app.devin.ai/sessions/fcb1fee338994fe38c5d01a4978af568)