### PR TITLE
test: add e2e bug test for arcee-ai/trinity-mini tool calling with Together provider

### DIFF
--- a/.changeset/pr-277.md
+++ b/.changeset/pr-277.md
@@ -1,5 +1,0 @@
----
-"@openrouter/ai-sdk-provider": patch
----
-
-Add e2e bug test for arcee-ai/trinity-mini tool calling investigation


### PR DESCRIPTION
## Description

Adds a new e2e test to replicate tool calling behavior with the `arcee-ai/trinity-mini` model using only 'Together' as the provider. This test is for customer support investigation (aaru).

The test:
- Creates a simple weather tool using the AI SDK's `tool()` function
- Configures the model to use only the Together provider via `provider.only: ['Together']`
- Sends a prompt that should trigger tool calling
- Logs response details (text, tool calls, tool results, provider metadata) for debugging
- Verifies that the Together provider was used

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [ ] I have run `pnpm changeset` to create a changeset file

> **Note:** This is a test-only change for bug investigation. A changeset may not be required, or `pnpm changeset --empty` can be used.

## Human Review Checklist

- [ ] Verify this test reproduces the intended bug scenario for the customer support case
- [ ] Confirm if the console.log statements should remain for debugging or be removed
- [ ] Check if the test assertions are sufficient for the investigation

---

**Link to Devin run:** https://app.devin.ai/sessions/59746ec75e444164bf0258f8ce5711fa
**Requested by:** charles.rockhead@openrouter.ai (@charlesrockhead-OR)