### PR TITLE
feat: add engine option to web_search_options

### DIFF
--- a/.changeset/add-web-search-engine-option.md
+++ b/.changeset/add-web-search-engine-option.md
@@ -1,0 +1,12 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Add `engine` option to `web_search_options` for specifying search engine
+
+Users can now specify which search engine to use for web search via `web_search_options.engine`:
+- `"native"`: Use provider's built-in web search
+- `"exa"`: Use Exa's search API  
+- `undefined`: Native if supported, otherwise Exa
+
+Thanks to @xdagiz for identifying this missing option in #182.

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -79,6 +79,14 @@ monitor and detect abuse. Learn more.
      * Custom search prompt to guide the search query
      */
     search_prompt?: string;
+    /**
+     * Search engine to use for web search
+     * - "native": Use provider's built-in web search
+     * - "exa": Use Exa's search API
+     * - undefined: Native if supported, otherwise Exa
+     * @see https://openrouter.ai/docs/features/web-search
+     */
+    engine?: models.Engine;
   };
 
   /**


### PR DESCRIPTION
# PR: feat: add engine option to web_search_options

## Summary

Adds the missing `engine` property to `web_search_options`, allowing users to specify which search engine to use for web search.

Based on the fix proposed by @xdagiz in #182, updated to use the SDK type for consistency.

## Problem

The `web_search_options` type was missing the `engine` property, causing TypeScript errors when users tried to specify which search engine to use:

```typescript
// This would cause a TypeScript error before this fix
const model = provider.chat('openai/gpt-4o', {
  web_search_options: {
    engine: 'native',  // Error: 'engine' does not exist
  },
});
```

## Solution

Add `engine?: models.Engine` to the `web_search_options` type definition:

```typescript
web_search_options?: {
  max_results?: number;
  search_prompt?: string;
  engine?: models.Engine;  // <-- Added
};
```

Using `models.Engine` from the SDK (rather than inline `'native' | 'exa'`) ensures:
1. Consistency with `plugins[].engine` which already uses `models.Engine`
2. Automatic updates if OpenRouter adds new engine options to the SDK

## Options

- `"native"`: Use provider's built-in web search
- `"exa"`: Use Exa's search API
- `undefined`: Native if supported, otherwise Exa

## Attribution

This fix is based on the work by @xdagiz in #182. The original PR was in a conflicting state and used inline literal types. This PR applies the same fix with:
- Rebased on current main (resolving conflicts)
- Uses `models.Engine` SDK type instead of inline literals
- Removes redundant `| undefined` for consistency with codebase style

Co-authored-by: Dagmawi Ali <xdagizjr2112@gmail.com>

Closes #182
