### PR TITLE
fix: defer OPENROUTER_API_KEY loading to model creation time

### DIFF
--- a/src/openrouter-provider.ts
+++ b/src/openrouter-provider.ts
@@ -131,20 +131,22 @@ export function createOpenRouter(options: OpenRouterProviderSettings = {}): Open
   // are accessed through this single URL. OpenRouter handles routing to the appropriate backend.
   const baseURL = withoutTrailingSlash(options.baseURL) ?? 'https://openrouter.ai/api/v1';
 
-  // Use AI SDK's loadApiKey utility for consistent API key handling across providers.
-  // This supports both explicit apiKey option and OPENROUTER_API_KEY environment variable.
-  const apiKey = loadApiKey({
-    apiKey: options.apiKey,
-    environmentVariableName: 'OPENROUTER_API_KEY',
-    description: 'OpenRouter',
-  });
-
   // Factory function to create model config - called fresh for each model instance
-  // to ensure isolation and allow for future per-model customization
+  // to ensure isolation and allow for future per-model customization.
+  // API key loading is deferred to model creation time so environment variables
+  // set after provider creation are properly read.
   const createModelConfig = (): OpenRouterModelConfig => ({
     provider: 'openrouter',
     baseURL,
-    apiKey,
+    // Use AI SDK's loadApiKey utility for consistent API key handling across providers.
+    // This supports both explicit apiKey option and OPENROUTER_API_KEY environment variable.
+    // Loading at model creation time (not provider creation) ensures env vars set after
+    // module load are picked up, matching v1 behavior.
+    apiKey: loadApiKey({
+      apiKey: options.apiKey,
+      environmentVariableName: 'OPENROUTER_API_KEY',
+      description: 'OpenRouter',
+    }),
     // Use AI SDK's generateId for consistent ID generation across the SDK ecosystem
     generateId: options.generateId ?? generateId,
     fetch: options.fetch,


### PR DESCRIPTION
## Summary

- Fixes OPENROUTER_API_KEY environment variable not being read in v2
- Defers `loadApiKey` call from provider creation time to model creation time, matching v1 behavior

## Problem

In v1, `loadApiKey` was called lazily inside `getHeaders()` at request time. In v2, it was called at provider creation time (when `createOpenRouter()` runs), meaning environment variables set after module load were not picked up.

This caused issues when users set `OPENROUTER_API_KEY` after importing the provider:

```ts
import { openrouter } from '@openrouter/ai-sdk-provider';
process.env.OPENROUTER_API_KEY = 'sk-...'; // Too late - provider already created
```

## Solution

Move `loadApiKey` into `createModelConfig()` so it's called when a model is created, not when the provider is created. This matches v1 behavior and allows env vars to be set after the provider module is imported.