### PR TITLE
fix: override finishReason to tool-calls for Gemini 3 thoughtSignature

### DIFF
--- a/.changeset/gemini3-thoughtsig-fix.md
+++ b/.changeset/gemini3-thoughtsig-fix.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Fix Gemini 3 tool-call conversations stopping prematurely when thoughtSignature (encrypted reasoning) is present. Override finishReason from 'stop' to 'tool-calls' when tool calls and encrypted reasoning are detected.

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -429,17 +429,16 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
     // Fix for Gemini 3 thoughtSignature: when there are tool calls with encrypted
     // reasoning (thoughtSignature), the model returns 'stop' but expects continuation.
     // Override to 'tool-calls' so the SDK knows to continue the conversation.
-    const hasToolCalls = choice.message.tool_calls && choice.message.tool_calls.length > 0;
+    const hasToolCalls =
+      choice.message.tool_calls && choice.message.tool_calls.length > 0;
     const hasEncryptedReasoning = reasoningDetails.some(
-      (d) => d.type === ReasoningDetailType.Encrypted && d.data
+      (d) => d.type === ReasoningDetailType.Encrypted && d.data,
     );
-    const shouldOverrideFinishReason = 
-      hasToolCalls && 
-      hasEncryptedReasoning && 
-      choice.finish_reason === 'stop';
-    
-    const effectiveFinishReason = shouldOverrideFinishReason 
-      ? 'tool-calls' 
+    const shouldOverrideFinishReason =
+      hasToolCalls && hasEncryptedReasoning && choice.finish_reason === 'stop';
+
+    const effectiveFinishReason = shouldOverrideFinishReason
+      ? 'tool-calls'
       : mapOpenRouterFinishReason(choice.finish_reason);
 
     return {
@@ -973,12 +972,16 @@ export class OpenRouterChatLanguageModel implements LanguageModelV2 {
             // Override to 'tool-calls' so the SDK knows to continue the conversation.
             const hasToolCalls = toolCalls.length > 0;
             const hasEncryptedReasoning = accumulatedReasoningDetails.some(
-              (d) => d.type === ReasoningDetailType.Encrypted && d.data
+              (d) => d.type === ReasoningDetailType.Encrypted && d.data,
             );
-            if (hasToolCalls && hasEncryptedReasoning && finishReason === 'stop') {
+            if (
+              hasToolCalls &&
+              hasEncryptedReasoning &&
+              finishReason === 'stop'
+            ) {
               finishReason = 'tool-calls';
             }
-            
+
             // Forward any unsent tool calls if finish reason is 'tool-calls'
             if (finishReason === 'tool-calls') {
               for (const toolCall of toolCalls) {


### PR DESCRIPTION
## Summary
- Fixes Gemini 3 tool-call conversations stopping prematurely when thoughtSignature (encrypted reasoning) is present
- When the model returns `finish_reason='stop'` but has tool calls and encrypted reasoning, override to `tool-calls` so the SDK continues
## Problem
Gemini 3 with thinking enabled returns `finish_reason: "stop"` when making tool calls with encrypted reasoning (thoughtSignature). This causes AI SDK consumers to not continue the conversation after tool execution.
## Solution
Detect the pattern (tool calls + encrypted reasoning + stop) and override finishReason to `tool-calls` in both:
- `doGenerate` (non-streaming)
- `doStream` (streaming) flush handler