### PR TITLE
feat: expand supported audio formats

### DIFF
--- a/.changeset/clever-bananas-admire.md
+++ b/.changeset/clever-bananas-admire.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+expand supported audio formats

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -1,5 +1,6 @@
 import { ReasoningDetailType } from '../schemas/reasoning-details';
 import { convertToOpenRouterChatMessages } from './convert-to-openrouter-chat-messages';
+import { MIME_TO_FORMAT } from './file-url-utils';
 
 describe('user messages', () => {
   it('should convert image Uint8Array', async () => {
@@ -100,71 +101,12 @@ describe('user messages', () => {
     expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
   });
 
-  it('should convert audio Uint8Array to input_audio with mp3 format', async () => {
-    const result = convertToOpenRouterChatMessages([
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Listen to this' },
-          {
-            type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
-            mediaType: 'audio/mpeg',
-          },
-        ],
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Listen to this' },
-          {
-            type: 'input_audio',
-            input_audio: {
-              data: 'AAECAw==',
-              format: 'mp3',
-            },
-          },
-        ],
-      },
-    ]);
-  });
-
-  it('should convert audio Uint8Array to input_audio with wav format', async () => {
-    const result = convertToOpenRouterChatMessages([
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Listen to this' },
-          {
-            type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
-            mediaType: 'audio/wav',
-          },
-        ],
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Listen to this' },
-          {
-            type: 'input_audio',
-            input_audio: {
-              data: 'AAECAw==',
-              format: 'wav',
-            },
-          },
-        ],
-      },
-    ]);
-  });
-
-  it('should normalize audio/x-wav to wav format', async () => {
+  it.each(
+    Object.entries(MIME_TO_FORMAT).map(([mimeSubtype, format]) => [
+      `audio/${mimeSubtype}`,
+      format,
+    ]),
+  )('should convert %s to input_audio with %s format', (mediaType, expectedFormat) => {
     const result = convertToOpenRouterChatMessages([
       {
         role: 'user',
@@ -172,7 +114,7 @@ describe('user messages', () => {
           {
             type: 'file',
             data: new Uint8Array([0, 1, 2, 3]),
-            mediaType: 'audio/x-wav',
+            mediaType,
           },
         ],
       },
@@ -186,37 +128,7 @@ describe('user messages', () => {
             type: 'input_audio',
             input_audio: {
               data: 'AAECAw==',
-              format: 'wav',
-            },
-          },
-        ],
-      },
-    ]);
-  });
-
-  it('should support audio/mp3 MIME type (normalize to mp3)', async () => {
-    const result = convertToOpenRouterChatMessages([
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
-            mediaType: 'audio/mp3',
-          },
-        ],
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'input_audio',
-            input_audio: {
-              data: 'AAECAw==',
-              format: 'mp3',
+              format: expectedFormat,
             },
           },
         ],
@@ -310,12 +222,12 @@ describe('user messages', () => {
             {
               type: 'file',
               data: new Uint8Array([0, 1, 2, 3]),
-              mediaType: 'audio/ogg',
+              mediaType: 'audio/webm',
             },
           ],
         },
       ]),
-    ).toThrow(/Unsupported audio format: "audio\/ogg"/);
+    ).toThrow(/Unsupported audio format: "audio\/webm"/);
   });
 });
 

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -54,11 +54,26 @@ export interface ChatCompletionContentPartText {
   cache_control?: OpenRouterCacheControl;
 }
 
+/** https://openrouter.ai/docs/guides/overview/multimodal/audio */
+export const OPENROUTER_AUDIO_FORMATS = [
+  'wav',
+  'mp3',
+  'aiff',
+  'aac',
+  'ogg',
+  'flac',
+  'm4a',
+  'pcm16',
+  'pcm24',
+] as const;
+
+export type OpenRouterAudioFormat = (typeof OPENROUTER_AUDIO_FORMATS)[number];
+
 export interface ChatCompletionContentPartInputAudio {
   type: 'input_audio';
   input_audio: {
     data: string;
-    format: 'wav' | 'mp3';
+    format: OpenRouterAudioFormat;
   };
   cache_control?: OpenRouterCacheControl;
 }


### PR DESCRIPTION
## Description

Add support for all audio formats documented by OpenRouter:
- wav, mp3, aiff, aac, ogg, flac, m4a, pcm16, pcm24

Previously only mp3 and wav were supported.

Reference: https://openrouter.ai/docs/guides/overview/multimodal/audio

Changes:
- Define OPENROUTER_AUDIO_FORMATS const array as single source of truth
- Derive OpenRouterAudioFormat type from the array
- Add MIME type normalization for format variants (e.g., audio/vorbis → ogg)
- Update validation to accept all documented formats
- Parametrize and simplify tests to cover all formats efficiently

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file
