### PR TITLE
feat: accumulate file annotations in streaming responses

### DIFF
--- a/.changeset/streaming-file-annotations.md
+++ b/.changeset/streaming-file-annotations.md
@@ -1,0 +1,7 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+File annotations from FileParserPlugin are now available in streaming responses.
+If you use `streamText()` with PDFs or other files, you can now access parsed file content via `providerMetadata.openrouter.annotations` in the finish event.
+This was already available for non-streaming responses.

--- a/src/schemas/provider-metadata.ts
+++ b/src/schemas/provider-metadata.ts
@@ -4,25 +4,27 @@ import { ReasoningDetailUnionSchema } from './reasoning-details';
 /**
  * Schema for file annotations from FileParserPlugin
  */
-export const FileAnnotationSchema = z.object({
-  type: z.literal('file'),
-  file: z
-    .object({
-      hash: z.string(),
-      name: z.string(),
-      content: z
-        .array(
-          z
-            .object({
-              type: z.string(),
-              text: z.string().optional(),
-            })
-            .passthrough(),
-        )
-        .optional(),
-    })
-    .passthrough(),
-});
+export const FileAnnotationSchema = z
+  .object({
+    type: z.literal('file'),
+    file: z
+      .object({
+        hash: z.string(),
+        name: z.string(),
+        content: z
+          .array(
+            z
+              .object({
+                type: z.string(),
+                text: z.string().optional(),
+              })
+              .catchall(z.any()),
+          )
+          .optional(),
+      })
+      .catchall(z.any()),
+  })
+  .catchall(z.any());
 
 export type FileAnnotation = z.infer<typeof FileAnnotationSchema>;
 
@@ -41,14 +43,14 @@ export const OpenRouterProviderMetadataSchema = z
           .object({
             cachedTokens: z.number(),
           })
-          .passthrough()
+          .catchall(z.any())
           .optional(),
         completionTokens: z.number(),
         completionTokensDetails: z
           .object({
             reasoningTokens: z.number(),
           })
-          .passthrough()
+          .catchall(z.any())
           .optional(),
         totalTokens: z.number(),
         cost: z.number().optional(),
@@ -56,12 +58,12 @@ export const OpenRouterProviderMetadataSchema = z
           .object({
             upstreamInferenceCost: z.number(),
           })
-          .passthrough()
+          .catchall(z.any())
           .optional(),
       })
-      .passthrough(),
+      .catchall(z.any()),
   })
-  .passthrough();
+  .catchall(z.any());
 
 export type OpenRouterProviderMetadata = z.infer<
   typeof OpenRouterProviderMetadataSchema


### PR DESCRIPTION
## Summary

Enables file annotations from FileParserPlugin to be captured during streaming and exposed in `providerMetadata`.

**Depends on:** #293
**Fixes:** #290 

### Changes

- Accumulate file annotations during `doStream` transform
- Expose accumulated annotations in finish event's `providerMetadata.openrouter.annotations`
- Add tests for single and multiple file annotation streaming

### Use Case

This enables PDF workflows that need annotation passthrough in streaming responses. When using FileParserPlugin with `streamText`, the parsed file annotations are now available in the final response metadata.

### Quality Impact

| Dimension | Change | Reason |
|-----------|--------|--------|
| **Flexibility** | ↑ Improved | File annotations now available in streaming (previously only in non-streaming) |
| **Consistency** | ↑ Improved | Streaming and non-streaming responses have consistent annotation exposure |

### Testing

- 2 new tests for file annotation streaming
- All 134 tests pass