### PR TITLE
fix: duplicate reasoning_details handling in multi-turn tool calls

### DIFF
--- a/.changeset/fix-reasoning-deduplication.md
+++ b/.changeset/fix-reasoning-deduplication.md
@@ -1,0 +1,11 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Fix the reasoning_details duplication issue with multi-turn tool calls. When multiple tool calls were made with reasoning enabled, the same reasoning_details would be attached to each tool call, causing duplicates when sent back in conversation history. This led to `finishReason: "unknown"`, empty `totalUsage` in responses and API errors form Claude.
+
+The fix:
+- Remove reasoning_details accumulation from reasoning parts (which can be corrupted/partial during streaming)
+- Only accumulate reasoning_details from tool-call parts
+- Implement smart deduplication based on provider-specific unique identifiers (signature for Claude, id/data for Gemini)
+- Support both Claude (Anthropic) and Gemini (Google) reasoning formats

--- a/e2e/reasoning-multiturn/index.test.ts
+++ b/e2e/reasoning-multiturn/index.test.ts
@@ -66,4 +66,177 @@ describe('Vercel AI SDK tools call with reasoning', () => {
 
     await stream.consumeStream();
   });
+
+  it('should handle parallel tool calls with reasoning (deduplication test)', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+      extraBody: {
+        reasoning: {
+          exclude: false,
+          max_tokens: 3500,
+        },
+      },
+    });
+
+    const model = openrouter('anthropic/claude-sonnet-4.5');
+
+    let finishEventCount = 0;
+    let hasReasoningDetails = false;
+
+    const stream = streamText({
+      system:
+        'You are a helpful assistant with SQL query capabilities. You can execute multiple queries in parallel.',
+      model,
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Please execute 2 parallel SQL queries: SELECT 1 and SELECT 2. Use the execute_query tool for both.',
+        },
+      ],
+      maxOutputTokens: 64000,
+      stopWhen: stepCountIs(3),
+      tools: {
+        execute_query: tool({
+          description: 'Executes a SQL query and returns the result',
+          inputSchema: z.object({
+            query: z.string().describe('The SQL query to execute'),
+          }),
+          execute: async ({ query }) => {
+            return {
+              result: `Executed: ${query}`,
+              rows: [{ value: query.includes('1') ? 1 : 2 }],
+            };
+          },
+        }),
+      },
+      onError: (e: unknown) => {
+        writeOutputJsonFile({
+          fileName: 'error-parallel.ignore.json',
+          fileData: e,
+          baseUrl: import.meta.url,
+        });
+        expect(e).toBeUndefined();
+      },
+      onStepFinish: async (event) => {
+        await writeOutputJsonFile({
+          fileName: `finish-parallel-${finishEventCount}.ignore.json`,
+          fileData: event,
+          baseUrl: import.meta.url,
+        });
+
+        finishEventCount++;
+
+        // Check if reasoning_details exist in providerMetadata
+        if (event.providerMetadata?.openrouter?.reasoning_details) {
+          hasReasoningDetails = true;
+        }
+
+        // Verify finishReason is not 'unknown'
+        expect(event.finishReason).not.toBe('unknown');
+
+        // Verify usage is not empty
+        expect(event.usage).toBeDefined();
+        expect(event.usage.totalTokens).toBeGreaterThan(0);
+      },
+    });
+
+    await stream.consumeStream();
+
+    // Verify we got finish events and reasoning was present
+    expect(finishEventCount).toBeGreaterThan(0);
+    expect(hasReasoningDetails).toBe(true);
+  });
+
+  it('should handle sequential tool calls with reasoning (preservation test)', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+      extraBody: {
+        reasoning: {
+          exclude: false,
+          max_tokens: 3500,
+        },
+      },
+    });
+
+    const model = openrouter('anthropic/claude-sonnet-4.5');
+
+    let finishEventCount = 0;
+    let reasoningDetailsCount = 0;
+
+    const stream = streamText({
+      system:
+        'You are a helpful assistant. You will be asked to perform multiple sequential tasks. Call one tool, wait for the result, then call the next tool based on the result.',
+      model,
+      messages: [
+        {
+          role: 'user',
+          content:
+            'First, search for "user data" using search_data. Then, based on the result, analyze it using analyze_data.',
+        },
+      ],
+      maxOutputTokens: 64000,
+      stopWhen: stepCountIs(5),
+      tools: {
+        search_data: tool({
+          description: 'Searches for data based on a query',
+          inputSchema: z.object({
+            query: z.string().describe('The search query'),
+          }),
+          execute: async ({ query }) => {
+            return { found: true, data: `Results for "${query}"`, count: 42 };
+          },
+        }),
+        analyze_data: tool({
+          description: 'Analyzes data and provides insights',
+          inputSchema: z.object({
+            data: z.string().describe('The data to analyze'),
+          }),
+          execute: async ({ data }) => {
+            return {
+              analysis: `Analyzed: ${data}`,
+              insights: ['Pattern A', 'Pattern B'],
+            };
+          },
+        }),
+      },
+      onError: (e: unknown) => {
+        writeOutputJsonFile({
+          fileName: 'error-sequential.ignore.json',
+          fileData: e,
+          baseUrl: import.meta.url,
+        });
+        expect(e).toBeUndefined();
+      },
+      onStepFinish: async (event) => {
+        await writeOutputJsonFile({
+          fileName: `finish-sequential-${finishEventCount}.ignore.json`,
+          fileData: event,
+          baseUrl: import.meta.url,
+        });
+
+        finishEventCount++;
+
+        // Count reasoning_details occurrences
+        if (event.providerMetadata?.openrouter?.reasoning_details) {
+          reasoningDetailsCount++;
+        }
+
+        // Verify finishReason is not 'unknown'
+        expect(event.finishReason).not.toBe('unknown');
+
+        // Verify usage is not empty
+        expect(event.usage).toBeDefined();
+        expect(event.usage.totalTokens).toBeGreaterThan(0);
+      },
+    });
+
+    await stream.consumeStream();
+
+    // Verify we got multiple finish events with reasoning
+    expect(finishEventCount).toBeGreaterThan(1);
+    expect(reasoningDetailsCount).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Description
- Removed reasoning_details accumulation from reasoning parts to prevent corruption during streaming.
- Introduced deduplication of reasoning_details based on unique identifiers for Claude and Gemini formats.
- Enhanced tests to cover parallel and sequential tool call scenarios.
- Tested for Gemini (google/gemini-3-pro-preview) and Claude (anthropic/claude-sonnet-4.5)

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.

## Related issues
#245 
#253 
#207 
