### PR TITLE
ci: Add PR snapshot workflow for easy testing

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,7 +4,12 @@ on:
   pull_request:
     branches: [dev-v6]
 
+concurrency:
+  group: snapshot-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

Adopts the **pkg-pr-new snapshot workflow** - a best practice used by [Effect-TS/effect](https://github.com/Effect-TS/effect/blob/main/.github/workflows/snapshot.yml) and other major TypeScript projects.

This automatically publishes installable snapshot packages for every PR, enabling contributors and users to easily test changes before release.

## Changes

- Creates `.github/workflows/snapshot.yml`
- Uses [pkg-pr-new](https://github.com/stackblitz-labs/pkg.pr.new) to publish snapshots
- Adds concurrency group to cancel outdated runs
- Posts/updates PR comment with installation instructions

## Usage

After merging, any PR to `dev-v6` will automatically get a comment with an install command:

```bash
npm i https://pkg.pr.new/@openrouter/ai-sdk-provider@123
# or
bun add https://pkg.pr.new/@openrouter/ai-sdk-provider@123
```

This eliminates the need to clone, build, and link locally just to test a PR.

## References

- Best practice pattern from: [Effect-TS/effect snapshot.yml](https://github.com/Effect-TS/effect/blob/main/.github/workflows/snapshot.yml)
- pkg-pr-new docs: https://github.com/stackblitz-labs/pkg.pr.new

Closes gap-980