### PR TITLE
fix: make file content part fields optional and add file_id

### DIFF
--- a/.changeset/tiny-clouds-argue.md
+++ b/.changeset/tiny-clouds-argue.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Make file content part fields optional and add file_id support. The `filename` and `file_data` fields in `ChatCompletionContentPartFile` are now optional, and a new `file_id` field has been added for OpenAI file uploads support.

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -33,8 +33,9 @@ export type ChatCompletionContentPart =
 export interface ChatCompletionContentPartFile {
   type: 'file';
   file: {
-    filename: string;
-    file_data: string;
+    filename?: string;
+    file_data?: string;
+    file_id?: string;
   };
   cache_control?: OpenRouterCacheControl;
 }


### PR DESCRIPTION
## Description

Makes `filename` and `file_data` fields optional in `ChatCompletionContentPartFile` and adds `file_id` field for OpenAI file uploads support. This aligns the type with the API spec.

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.

---

Note: Tests and documentation are not applicable since this is a type-only change that makes fields optional (non-breaking).
