### PR TITLE
fix: extract tool arguments from response.completed in streaming

### DIFF
--- a/.changeset/fix-streaming-tool-args.md
+++ b/.changeset/fix-streaming-tool-args.md
@@ -1,0 +1,7 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Fix streaming tool call arguments not being passed to execute function
+
+OpenRouter Responses API doesn't stream tool arguments via delta events - the complete arguments are only available in the final `response.completed` event. This fix extracts tool call arguments from that event when they weren't received during streaming.


### PR DESCRIPTION
## Description

OpenRouter Responses API doesn't stream tool arguments via `response.function_call_arguments.delta` events. The `arguments` field in `response.function_call_arguments.done` is empty, and the complete arguments are only available in the final `response.completed` event's output array.

This causes tool calls to fail with validation errors like:
```
Invalid input for tool weather: Type validation failed: Value: {}.
Error message: [{"expected":"string","code":"invalid_type","path":["location"],"message":"Required"}]
```

### Changes

- Accumulate argument deltas during streaming (in case a provider does send them)
- Track emitted tool calls to avoid duplicates  
- Extract tool call arguments from `response.completed` event's output array
- Only emit `tool-input-*` events when actual arguments are available

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file