### PR TITLE
fix: change ai peer dependency from exact 6.0.3 to ^6.0.0

### DIFF
--- a/.changeset/lemon-jokes-taste.md
+++ b/.changeset/lemon-jokes-taste.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Fix ai peer dependency from exact version 6.0.3 to ^6.0.0

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "ai": "6.0.3",
+    "ai": "^6.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "engines": {


### PR DESCRIPTION
## Description

Fix ai peer dependency from exact version `6.0.3` to `^6.0.0` to allow compatibility with all AI SDK 6.x versions as originally intended in the v2.0.0 release.

The v2.0.0 release notes stated the package requires `ai@^6.0.0`, but the published package has an exact peer dependency pin to `6.0.3`, causing npm to reject installation when users have any other 6.x version installed.

Fixes #335

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests for my changes (if applicable) - N/A, this is a package.json metadata fix
- [ ] I have updated documentation (if applicable) - N/A, no documentation changes needed

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file
