### PR TITLE
fix: handle tool calls with missing arguments field (#287)

### DIFF
--- a/.changeset/fix-tool-calls-missing-arguments.md
+++ b/.changeset/fix-tool-calls-missing-arguments.md
@@ -1,0 +1,7 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+fix: handle tool calls with missing arguments field (#287)
+
+Made the arguments field optional in the tool_calls schema and default to '{}' (empty JSON object) when missing. This handles cases where upstream providers may omit the arguments field for tools with no parameters.

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -529,7 +529,7 @@ describe('doGenerate', () => {
     );
   });
 
-  it('should handle tool calls with missing arguments field (Anthropic Haiku)', async () => {
+  it('should default to empty JSON object when tool call arguments field is missing', async () => {
     prepareJsonResponse({
       content: '',
       tool_calls: [
@@ -538,7 +538,6 @@ describe('doGenerate', () => {
           type: 'function',
           function: {
             name: 'get_current_time',
-            // arguments field is omitted - some models like Anthropic Haiku do this
           },
         },
       ],
@@ -549,7 +548,6 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    // Should default to empty JSON object when arguments is missing
     expect(result.content).toContainEqual(
       expect.objectContaining({
         type: 'tool-call',

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -390,7 +390,6 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
           type: 'tool-call' as const,
           toolCallId: toolCall.id ?? generateId(),
           toolName: toolCall.function.name,
-          // Some models (e.g., Anthropic Haiku) may omit arguments field when there are no arguments
           input: toolCall.function.arguments ?? '{}',
           providerMetadata: !reasoningDetailsAttachedToToolCall
             ? {

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -62,8 +62,6 @@ export const OpenRouterNonStreamChatCompletionResponseSchema = z.union([
                       function: z
                         .object({
                           name: z.string(),
-                          // Some models (e.g., Anthropic Haiku) may omit arguments field
-                          // when there are no arguments to pass
                           arguments: z.string().optional(),
                         })
                         .passthrough(),


### PR DESCRIPTION
## Description

Fixes #287 - Some upstream providers may omit the `arguments` field in tool calls when there are no arguments to pass. This caused `AI_TypeValidationError` because the schema required `arguments` to be a string.

**Changes:**
- Made `arguments` field optional in the non-streaming tool_calls schema (`z.string().optional()`)
- Default to `'{}'` (empty JSON object) when `arguments` is missing in `doGenerate`
- Added test case for tool calls without arguments field

**Note:** The streaming code path already handles this case with `arguments: z.string().nullish()` in the schema and `?? ''` fallback in the transform logic.

### Updates since last revision
- Removed model-specific references (unvalidated claims about specific models)
- Renamed test to be behavior-focused: "should default to empty JSON object when tool call arguments field is missing"
- Added changeset for release

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.

### Human Review Checklist

- [ ] Verify the default value `'{}'` is appropriate (valid JSON representing empty object/no arguments)
- [ ] Note: streaming path uses `?? ''` while non-streaming uses `?? '{}'` - confirm this inconsistency is intentional
- [ ] Confirm no other code paths access `toolCall.function.arguments` without null handling

---

*This PR was created with assistance from [Devin](https://app.devin.ai/sessions/8157ac0a12f84c6b92804a1654a75662), requested by @robert-j-y*