### PR TITLE
Remove @openrouter/sdk dependency

### DIFF
--- a/.changeset/remove-openrouter-sdk-dependency.md
+++ b/.changeset/remove-openrouter-sdk-dependency.md
@@ -1,0 +1,10 @@
+---
+"@openrouter/ai-sdk-provider": minor
+---
+
+Remove dependency on @openrouter/sdk
+
+This change removes the external dependency on `@openrouter/sdk` by inlining the necessary type definitions locally. The types are now defined in `src/types/openrouter-api-types.ts`.
+
+This reduces the package's dependency footprint and eliminates potential version conflicts with the SDK.
+

--- a/package.json
+++ b/package.json
@@ -84,8 +84,5 @@
   "keywords": [
     "ai"
   ],
-  "packageManager": "pnpm@10.12.4",
-  "dependencies": {
-    "@openrouter/sdk": "^0.1.27"
-  }
+  "packageManager": "pnpm@10.12.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ importers:
 
   .:
     dependencies:
-      '@openrouter/sdk':
-        specifier: ^0.1.27
-        version: 0.1.27
       zod:
         specifier: ^3.25.0 || ^4.0.0
         version: 4.3.5
@@ -615,9 +612,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@openrouter/sdk@0.1.27':
-    resolution: {integrity: sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -2133,10 +2127,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@openrouter/sdk@0.1.27':
-    dependencies:
-      zod: 4.3.5
 
   '@opentelemetry/api@1.9.0': {}
 

--- a/src/schemas/error-response.ts
+++ b/src/schemas/error-response.ts
@@ -1,10 +1,8 @@
-import type { ChatErrorError } from '@openrouter/sdk/models';
+import type { ChatErrorError } from '../types/openrouter-api-types';
 
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-// Use SDK's ChatErrorError type but wrap in response schema
-// SDK type: { code: string | number | null; message: string; param?: string | null; type?: string | null }
 export const OpenRouterErrorResponseSchema = z
   .object({
     error: z

--- a/src/types/openrouter-api-types.ts
+++ b/src/types/openrouter-api-types.ts
@@ -1,0 +1,69 @@
+/**
+ * OpenRouter API types - locally defined to avoid external SDK dependency.
+ * These types mirror the OpenRouter API specification.
+ */
+
+/**
+ * Error structure returned by OpenRouter API.
+ */
+export type ChatErrorError = {
+  code: string | number | null;
+  message: string;
+  param?: string | null | undefined;
+  type?: string | null | undefined;
+};
+
+/**
+ * Plugin identifier for web search functionality.
+ */
+export type IdWeb = 'web';
+
+/**
+ * Plugin identifier for file parsing functionality.
+ */
+export type IdFileParser = 'file-parser';
+
+/**
+ * Plugin identifier for content moderation.
+ */
+export type IdModeration = 'moderation';
+
+/**
+ * Search engine options for web search.
+ * Open enum - accepts known values or any string for forward compatibility.
+ */
+export type Engine = 'native' | 'exa' | (string & {});
+
+/**
+ * PDF processing engine options.
+ * Open enum - accepts known values or any string for forward compatibility.
+ */
+export type PdfEngine = 'mistral-ocr' | 'pdf-text' | 'native' | (string & {});
+
+/**
+ * Data collection preference for provider routing.
+ * Open enum - accepts known values or any string for forward compatibility.
+ */
+export type DataCollection = 'deny' | 'allow' | (string & {});
+
+/**
+ * Model quantization levels for provider filtering.
+ * Open enum - accepts known values or any string for forward compatibility.
+ */
+export type Quantization =
+  | 'int4'
+  | 'int8'
+  | 'fp4'
+  | 'fp6'
+  | 'fp8'
+  | 'fp16'
+  | 'bf16'
+  | 'fp32'
+  | 'unknown'
+  | (string & {});
+
+/**
+ * Provider sorting strategy options.
+ * Open enum - accepts known values or any string for forward compatibility.
+ */
+export type ProviderSort = 'price' | 'throughput' | 'latency' | (string & {});

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -1,5 +1,14 @@
-import type * as models from '@openrouter/sdk/models';
 import type { OpenRouterSharedSettings } from '..';
+import type {
+  DataCollection,
+  Engine,
+  IdFileParser,
+  IdModeration,
+  IdWeb,
+  PdfEngine,
+  ProviderSort,
+  Quantization,
+} from './openrouter-api-types';
 
 // https://openrouter.ai/api/v1/models
 export type OpenRouterChatModelId = string;
@@ -50,20 +59,20 @@ monitor and detect abuse. Learn more.
    */
   plugins?: Array<
     | {
-        id: models.IdWeb;
+        id: IdWeb;
         max_results?: number;
         search_prompt?: string;
-        engine?: models.Engine;
+        engine?: Engine;
       }
     | {
-        id: models.IdFileParser;
+        id: IdFileParser;
         max_files?: number;
         pdf?: {
-          engine?: models.PdfEngine;
+          engine?: PdfEngine;
         };
       }
     | {
-        id: models.IdModeration;
+        id: IdModeration;
       }
   >;
 
@@ -86,7 +95,7 @@ monitor and detect abuse. Learn more.
      * - undefined: Native if supported, otherwise Exa
      * @see https://openrouter.ai/docs/features/web-search
      */
-    engine?: models.Engine;
+    engine?: Engine;
   };
 
   /**
@@ -122,7 +131,7 @@ monitor and detect abuse. Learn more.
     /**
      * Control whether to use providers that may store data
      */
-    data_collection?: models.DataCollection;
+    data_collection?: DataCollection;
     /**
      * List of provider slugs to allow for this request
      */
@@ -134,11 +143,11 @@ monitor and detect abuse. Learn more.
     /**
      * List of quantization levels to filter by (e.g. ["int4", "int8"])
      */
-    quantizations?: Array<models.Quantization>;
+    quantizations?: Array<Quantization>;
     /**
      * Sort providers by price, throughput, or latency
      */
-    sort?: models.ProviderSort;
+    sort?: ProviderSort;
     /**
      * Maximum pricing you want to pay for this request
      */


### PR DESCRIPTION
## Description

This PR removes the external dependency on `@openrouter/sdk` by inlining the necessary type definitions locally in a new file `src/types/openrouter-api-types.ts`.

**Before:** Types like `ChatErrorError`, `IdWeb`, `Engine`, `DataCollection`, etc. were imported from `@openrouter/sdk/models`

**After:** These types are defined locally, reducing the package's dependency footprint and eliminating potential version conflicts with the SDK.

The types were cross-referenced against the [openrouter-web repo](https://github.com/OpenRouterTeam/openrouter-web) to ensure accuracy. Open enums use the `(string & {})` pattern for forward compatibility.

### Human Review Checklist
- [ ] Verify the type definitions in `src/types/openrouter-api-types.ts` match the OpenRouter API specification
- [ ] Confirm the open enum pattern is appropriate for forward compatibility

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests for my changes (if applicable) - N/A, type-only changes
- [ ] I have updated documentation (if applicable) - N/A

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

---

Link to Devin run: https://app.devin.ai/sessions/5c114cf0bab1422bacbc4194f5e1b491
Requested by: Robert Yeakel (@robert-j-y)