### PR TITLE
fix: populate usage.raw with OpenRouter raw usage accounting object

### DIFF
--- a/.changeset/funny-cameras-kiss.md
+++ b/.changeset/funny-cameras-kiss.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Populate usage.raw with OpenRouter raw usage accounting object in finish step

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -266,6 +266,11 @@ describe('doGenerate', () => {
         text: undefined,
         reasoning: undefined,
       },
+      raw: {
+        prompt_tokens: 20,
+        total_tokens: 25,
+        completion_tokens: 5,
+      },
     });
   });
 
@@ -962,6 +967,11 @@ describe('doStream', () => {
             text: undefined,
             reasoning: undefined,
           },
+          raw: {
+            prompt_tokens: 17,
+            total_tokens: 244,
+            completion_tokens: 227,
+          },
         },
       },
     ]);
@@ -1554,6 +1564,11 @@ describe('doStream', () => {
             text: undefined,
             reasoning: undefined,
           },
+          raw: {
+            prompt_tokens: 53,
+            completion_tokens: 17,
+            total_tokens: 70,
+          },
         },
       },
     ]);
@@ -1667,6 +1682,11 @@ describe('doStream', () => {
             total: 17,
             text: undefined,
             reasoning: undefined,
+          },
+          raw: {
+            prompt_tokens: 53,
+            completion_tokens: 17,
+            total_tokens: 70,
           },
         },
       },
@@ -1801,6 +1821,11 @@ describe('doStream', () => {
             text: undefined,
             reasoning: undefined,
           },
+          raw: {
+            prompt_tokens: 53,
+            completion_tokens: 17,
+            total_tokens: 70,
+          },
         },
       },
     ]);
@@ -1853,6 +1878,7 @@ describe('doStream', () => {
             text: undefined,
             reasoning: undefined,
           },
+          raw: undefined,
         },
       },
     ]);
@@ -1893,6 +1919,7 @@ describe('doStream', () => {
           text: undefined,
           reasoning: undefined,
         },
+        raw: undefined,
       },
     });
   });

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1,4 +1,5 @@
 import type {
+  JSONObject,
   LanguageModelV3,
   LanguageModelV3CallOptions,
   LanguageModelV3Content,
@@ -288,6 +289,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               response.usage.completion_tokens_details?.reasoning_tokens ??
               undefined,
           },
+          raw: response.usage as JSONObject,
         }
       : {
           inputTokens: {
@@ -301,6 +303,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
             text: undefined,
             reasoning: undefined,
           },
+          raw: undefined,
         };
 
     const reasoningDetails = choice.message.reasoning_details ?? [];
@@ -589,10 +592,14 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
         text: undefined,
         reasoning: undefined,
       },
+      raw: undefined,
     };
 
     // Track provider-specific usage information
     const openrouterUsage: Partial<OpenRouterUsageAccounting> = {};
+
+    // Track raw usage from the API response for usage.raw
+    let rawUsage: JSONObject | undefined;
 
     // Track reasoning details to preserve for multi-turn conversations
     const accumulatedReasoningDetails: ReasoningDetailUnion[] = [];
@@ -659,6 +666,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
             if (value.usage != null) {
               usage.inputTokens.total = value.usage.prompt_tokens;
               usage.outputTokens.total = value.usage.completion_tokens;
+
+              // Store raw usage from the API response (cast to JSONObject since schema uses passthrough)
+              rawUsage = value.usage as JSONObject;
 
               // Collect OpenRouter specific usage information
               openrouterUsage.promptTokens = value.usage.prompt_tokens;
@@ -1106,6 +1116,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
             if (accumulatedFileAnnotations.length > 0) {
               openrouterMetadata.annotations = accumulatedFileAnnotations;
             }
+
+            // Set raw usage before emitting finish event
+            usage.raw = rawUsage;
 
             controller.enqueue({
               type: 'finish',

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -138,6 +138,11 @@ describe('doGenerate', () => {
         text: undefined,
         reasoning: undefined,
       },
+      raw: {
+        prompt_tokens: 20,
+        total_tokens: 25,
+        completion_tokens: 5,
+      },
     });
   });
 
@@ -352,6 +357,11 @@ describe('doStream', () => {
             text: undefined,
             reasoning: undefined,
           },
+          raw: {
+            prompt_tokens: 10,
+            completion_tokens: 362,
+            total_tokens: 372,
+          },
         },
       },
     ]);
@@ -484,6 +494,7 @@ describe('doStream', () => {
             text: undefined,
             reasoning: undefined,
           },
+          raw: undefined,
         },
       },
     ]);
@@ -523,6 +534,7 @@ describe('doStream', () => {
           text: undefined,
           reasoning: undefined,
         },
+        raw: undefined,
       },
     });
   });


### PR DESCRIPTION
## Description

Fixes #347 - `usage.raw` was always `undefined` in the finish step when using OpenRouter with AI SDK v6.

This PR adds the `raw` field to the usage object in both chat and completion models, for both streaming (`doStream`) and non-streaming (`doGenerate`) calls. The `raw` field contains the original snake_case usage data from the OpenRouter API response, following the AI SDK v6 convention used by other providers like OpenAI and Anthropic.

**Before:**
```typescript
const result = await generateText({ model, prompt: "Hello" });
console.log(result.usage.raw); // undefined
```

**After:**
```typescript
const result = await generateText({ model, prompt: "Hello" });
console.log(result.usage.raw); 
// { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30, cost: 0.0015, ... }
```

Users now get both:
- `usage.raw` - original snake_case format (standard AI SDK v6 convention)
- `providerMetadata.openrouter.usage` - camelCase transformed version (unchanged, for backward compatibility)

### Human Review Checklist
- [ ] Verify the type casting `as JSONObject` in `src/chat/index.ts` (lines 292, 670) and `src/completion/index.ts` (lines 220, 311) is appropriate - this is needed because Zod's `.passthrough()` results in `unknown` type values
- [ ] Confirm the `rawUsage` variable tracking in streaming methods correctly captures usage data before the finish event

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

---

Link to Devin run: https://app.devin.ai/sessions/68b91f45046a491598cc2ac2dca46153
Requested by: Robert Yeakel (@robert-j-y)