### PR TITLE
feat: add temperature and other common settings to model-level configuration

### DIFF
--- a/.changeset/ten-geese-cheat.md
+++ b/.changeset/ten-geese-cheat.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+feat: add temperature and other common settings to model-level configuration

--- a/e2e/issues/issue-387-temperature-settings.test.ts
+++ b/e2e/issues/issue-387-temperature-settings.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for GitHub issue #387
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/387
+ *
+ * Issue: "Support temperature settings in OpenRouterChatSettings. (Missing)"
+ *
+ * User report:
+ * - Model: "google/gemini-3-flash-preview"
+ * - User wants to pass temperature: 0 in model settings
+ * - TypeScript error: temperature is not a valid property
+ *
+ * Code from issue:
+ * ```typescript
+ * const openrouterModel = openrouter('google/gemini-3-flash-preview', {
+ *   reasoning: { effort: 'medium' },
+ *   usage: { include: true },
+ *   provider: { sort: 'latency' },
+ *   temperature: 0 // This triggers typescript error
+ * })
+ * ```
+ */
+import { generateText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+describe('Issue #387: temperature settings in OpenRouterChatSettings', () => {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+  });
+
+  it('should accept temperature in model settings (exact code from issue)', async () => {
+    // This is the exact code pattern from the issue report
+    const openrouterModel = openrouter('google/gemini-3-flash-preview', {
+      reasoning: { effort: 'medium' },
+      usage: { include: true },
+      provider: { sort: 'latency' },
+      temperature: 0, // This should NOT trigger typescript error
+    });
+
+    const result = await generateText({
+      model: openrouterModel,
+      prompt: 'What is 2+2? Answer with just the number.',
+    });
+
+    expect(result.text).toBeDefined();
+    expect(result.text.length).toBeGreaterThan(0);
+  });
+
+  it('should use model-level temperature when call-level temperature is not provided', async () => {
+    const model = openrouter('google/gemini-3-flash-preview', {
+      temperature: 0,
+    });
+
+    // Make multiple calls with temperature 0 - should get consistent results
+    const results = await Promise.all([
+      generateText({
+        model,
+        prompt: 'What is 2+2? Answer with just the number.',
+      }),
+      generateText({
+        model,
+        prompt: 'What is 2+2? Answer with just the number.',
+      }),
+    ]);
+
+    // With temperature 0, results should be deterministic
+    expect(results[0].text).toBeDefined();
+    expect(results[1].text).toBeDefined();
+    // Both should contain "4"
+    expect(results[0].text).toContain('4');
+    expect(results[1].text).toContain('4');
+  });
+
+  it('should allow call-level temperature to override model-level temperature', async () => {
+    const model = openrouter('google/gemini-3-flash-preview', {
+      temperature: 0, // Model default
+    });
+
+    // Call with higher temperature should work
+    const result = await generateText({
+      model,
+      prompt: 'What is 2+2? Answer with just the number.',
+      temperature: 0.5, // Override model default
+    });
+
+    expect(result.text).toBeDefined();
+    expect(result.text.length).toBeGreaterThan(0);
+  });
+
+  it('should support other common settings at model level', async () => {
+    // Test that other common settings can also be passed at model level
+    const model = openrouter('google/gemini-3-flash-preview', {
+      temperature: 0,
+      topP: 0.9,
+      topK: 40,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      maxTokens: 100,
+    });
+
+    const result = await generateText({
+      model,
+      prompt: 'What is 2+2? Answer with just the number.',
+    });
+
+    expect(result.text).toBeDefined();
+    expect(result.text.length).toBeGreaterThan(0);
+  });
+});

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -127,12 +127,12 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
       user: this.settings.user,
       parallel_tool_calls: this.settings.parallelToolCalls,
 
-      // standardized settings:
-      max_tokens: maxOutputTokens,
-      temperature,
-      top_p: topP,
-      frequency_penalty: frequencyPenalty,
-      presence_penalty: presencePenalty,
+      // standardized settings (call-level options override model-level settings):
+      max_tokens: maxOutputTokens ?? this.settings.maxTokens,
+      temperature: temperature ?? this.settings.temperature,
+      top_p: topP ?? this.settings.topP,
+      frequency_penalty: frequencyPenalty ?? this.settings.frequencyPenalty,
+      presence_penalty: presencePenalty ?? this.settings.presencePenalty,
       seed,
 
       stop: stopSequences,
@@ -152,7 +152,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               }
             : { type: 'json_object' }
           : undefined,
-      top_k: topK,
+      top_k: topK ?? this.settings.topK,
 
       // messages:
       messages: convertToOpenRouterChatMessages(prompt),

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -123,17 +123,17 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
       suffix: this.settings.suffix,
       user: this.settings.user,
 
-      // standardized settings:
-      max_tokens: maxOutputTokens,
-      temperature,
-      top_p: topP,
-      frequency_penalty: frequencyPenalty,
-      presence_penalty: presencePenalty,
+      // standardized settings (call-level options override model-level settings):
+      max_tokens: maxOutputTokens ?? this.settings.maxTokens,
+      temperature: temperature ?? this.settings.temperature,
+      top_p: topP ?? this.settings.topP,
+      frequency_penalty: frequencyPenalty ?? this.settings.frequencyPenalty,
+      presence_penalty: presencePenalty ?? this.settings.presencePenalty,
       seed,
 
       stop: stopSequences,
       response_format: responseFormat,
-      top_k: topK,
+      top_k: topK ?? this.settings.topK,
 
       // prompt:
       prompt: completionPrompt,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,46 @@ export type OpenRouterSharedSettings = OpenRouterProviderOptions & {
      */
     include: boolean;
   };
+
+  /**
+   * Default temperature for model calls. Controls randomness in the output.
+   * Can be overridden at call time via generateText/streamText options.
+   * Range: 0 to 2, where 0 is deterministic and higher values are more random.
+   */
+  temperature?: number;
+
+  /**
+   * Default top-p (nucleus sampling) for model calls.
+   * Can be overridden at call time via generateText/streamText options.
+   * Range: 0 to 1.
+   */
+  topP?: number;
+
+  /**
+   * Default top-k sampling for model calls.
+   * Can be overridden at call time via generateText/streamText options.
+   */
+  topK?: number;
+
+  /**
+   * Default frequency penalty for model calls.
+   * Can be overridden at call time via generateText/streamText options.
+   * Range: -2 to 2.
+   */
+  frequencyPenalty?: number;
+
+  /**
+   * Default presence penalty for model calls.
+   * Can be overridden at call time via generateText/streamText options.
+   * Range: -2 to 2.
+   */
+  presencePenalty?: number;
+
+  /**
+   * Default maximum number of tokens to generate.
+   * Can be overridden at call time via generateText/streamText options.
+   */
+  maxTokens?: number;
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes #387

Adds support for setting default values for common model parameters at model creation time. Previously, settings like `temperature` could only be passed at call time via `generateText`/`streamText`. Now users can set defaults when creating the model:

```typescript
// Before: TypeScript error - temperature not allowed
const model = openrouter('google/gemini-3-flash-preview', {
  temperature: 0 // ❌ Error
});

// After: Works correctly
const model = openrouter('google/gemini-3-flash-preview', {
  temperature: 0,
  topP: 0.9,
  maxTokens: 100,
});
```

Call-level options still override model-level settings when provided.

### New settings added to `OpenRouterSharedSettings`:
- `temperature` - Controls randomness (0-2)
- `topP` - Nucleus sampling (0-1)
- `topK` - Top-k sampling
- `frequencyPenalty` - Penalize repeated tokens (-2 to 2)
- `presencePenalty` - Penalize tokens based on presence (-2 to 2)
- `maxTokens` - Maximum tokens to generate

### Key areas for review:
- Nullish coalescing (`??`) is used so call-level `undefined` falls back to model settings, but explicit values always win
- Both chat and completion models implement the same fallback logic
- Regression test uses exact code pattern from issue #387

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

---

**Link to Devin run:** https://app.devin.ai/sessions/ad14476ac9334b8a962f771f56e48975
**Requested by:** Robert Yeakel (@robert-j-y)