### PR TITLE
fix: include accumulated reasoning_details in reasoning-end event

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -822,6 +822,18 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                 controller.enqueue({
                   type: 'reasoning-end',
                   id: reasoningId || generateId(),
+                  // Include accumulated reasoning_details so the AI SDK can update
+                  // the reasoning part's providerMetadata with the correct signature.
+                  // The signature typically arrives in the last reasoning delta,
+                  // but reasoning-start only carries the first delta's metadata.
+                  providerMetadata:
+                    accumulatedReasoningDetails.length > 0
+                      ? {
+                          openrouter: {
+                            reasoning_details: accumulatedReasoningDetails,
+                          },
+                        }
+                      : undefined,
                 });
                 reasoningStarted = false; // Mark as ended so we don't end it again in flush
               }
@@ -1096,6 +1108,16 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               controller.enqueue({
                 type: 'reasoning-end',
                 id: reasoningId || generateId(),
+                // Include accumulated reasoning_details so the AI SDK can update
+                // the reasoning part's providerMetadata with the correct signature.
+                providerMetadata:
+                  accumulatedReasoningDetails.length > 0
+                    ? {
+                        openrouter: {
+                          reasoning_details: accumulatedReasoningDetails,
+                        },
+                      }
+                    : undefined,
               });
             }
             if (textStarted) {


### PR DESCRIPTION
## Summary

- Fixes multi-turn conversation failure with Anthropic models when the first turn is a text-only response (no tool calls)
- The `reasoning-end` stream event now includes accumulated `reasoning_details` (with signature) in `providerMetadata`
- The AI SDK already supports updating reasoning part's `providerMetadata` from `reasoning-end` (`reasoningPart.providerMetadata = chunk.providerMetadata ?? reasoningPart.providerMetadata`)

## Problem

When streaming a text-only response (no tool calls) with reasoning enabled:
1. `reasoning-start` is emitted on the first delta — carries only the first chunk's `reasoning_details` (no signature yet)
2. The Anthropic signature arrives in the **last** reasoning delta
3. `reasoning-end` was emitted **without** `providerMetadata`
4. The AI SDK uses `reasoning-end`'s `providerMetadata` to update the reasoning part, but since it was empty, the saved reasoning part had no valid signature
5. On the next turn, Anthropic rejects the request with `"Invalid signature in thinking block"`

For tool-call responses this wasn't an issue because accumulated `reasoning_details` were already attached to the first `tool-call` event.

## Fix

Include the accumulated `reasoning_details` (which correctly merges text and signature across all deltas) in the `reasoning-end` event's `providerMetadata`. This happens in two places:
1. When text content starts (reasoning ends before text begins)
2. In `flush` (reasoning ends when stream completes)

## Test plan

- [x] Added test: `should include accumulated reasoning_details with signature in reasoning-end providerMetadata for text-only responses`
- [x] All existing tests pass (node + edge: 210/210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)