### PR TITLE
feat: add support for reasoning effort values xhigh, minimal, none

### DIFF
--- a/.changeset/add-reasoning-effort-values.md
+++ b/.changeset/add-reasoning-effort-values.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Add support for reasoning effort values 'xhigh', 'minimal', and 'none' in the reasoning configuration type. Previously only 'high', 'medium', and 'low' were accepted.

--- a/e2e/issues/issue-391-reasoning-effort-values.test.ts
+++ b/e2e/issues/issue-391-reasoning-effort-values.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for GitHub issue #391
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/391
+ *
+ * Issue: "Add support for effort: none | minimal | xhigh"
+ *
+ * Issue thread timeline:
+ * - Feb 2, 2026: User reports that the SDK only supports effort values
+ *   'high', 'medium', 'low' but the OpenRouter API docs show additional
+ *   values: 'xhigh', 'minimal', 'none'.
+ * - Links to https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+ */
+import { generateText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+describe('Issue #391: reasoning effort xhigh, minimal, none values', () => {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+  });
+
+  it('should accept reasoning.effort xhigh without error', async () => {
+    const model = openrouter('openai/o3-mini', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is 2+2?',
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'xhigh',
+          },
+        },
+      },
+    });
+
+    expect(response.usage.totalTokens).toBeGreaterThan(0);
+    expect(response.finishReason).toBeDefined();
+  });
+
+  it('should accept reasoning.effort minimal without error', async () => {
+    const model = openrouter('openai/o3-mini', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is 2+2?',
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'minimal',
+          },
+        },
+      },
+    });
+
+    expect(response.usage.totalTokens).toBeGreaterThan(0);
+    expect(response.finishReason).toBeDefined();
+  });
+
+  it('should accept reasoning.effort none without error', async () => {
+    const model = openrouter('openai/o3-mini', {
+      usage: {
+        include: true,
+      },
+    });
+
+    const response = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is 2+2?',
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'none',
+          },
+        },
+      },
+    });
+
+    expect(response.usage.totalTokens).toBeGreaterThan(0);
+    expect(response.finishReason).toBeDefined();
+  });
+});

--- a/src/tests/provider-options.test.ts
+++ b/src/tests/provider-options.test.ts
@@ -69,4 +69,103 @@ describe('providerOptions', () => {
       stream: true,
     });
   });
+
+  it('should pass effort xhigh to API body', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: 'test',
+    });
+    const model = openrouter('openai/o3');
+
+    await streamText({
+      model: model,
+      messages: TEST_MESSAGES,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'xhigh',
+          },
+        },
+      },
+    }).consumeStream();
+
+    expect(await server.calls[0]?.requestBodyJson).toStrictEqual({
+      messages: [
+        {
+          content: 'Hello',
+          role: 'user',
+        },
+      ],
+      reasoning: {
+        effort: 'xhigh',
+      },
+      model: 'openai/o3',
+      stream: true,
+    });
+  });
+
+  it('should pass effort minimal to API body', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: 'test',
+    });
+    const model = openrouter('openai/o3');
+
+    await streamText({
+      model: model,
+      messages: TEST_MESSAGES,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'minimal',
+          },
+        },
+      },
+    }).consumeStream();
+
+    expect(await server.calls[0]?.requestBodyJson).toStrictEqual({
+      messages: [
+        {
+          content: 'Hello',
+          role: 'user',
+        },
+      ],
+      reasoning: {
+        effort: 'minimal',
+      },
+      model: 'openai/o3',
+      stream: true,
+    });
+  });
+
+  it('should pass effort none to API body', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: 'test',
+    });
+    const model = openrouter('openai/o3');
+
+    await streamText({
+      model: model,
+      messages: TEST_MESSAGES,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: 'none',
+          },
+        },
+      },
+    }).consumeStream();
+
+    expect(await server.calls[0]?.requestBodyJson).toStrictEqual({
+      messages: [
+        {
+          content: 'Hello',
+          role: 'user',
+        },
+      ],
+      reasoning: {
+        effort: 'none',
+      },
+      model: 'openai/o3',
+      stream: true,
+    });
+  });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,7 +21,7 @@ export type OpenRouterProviderOptions = {
         max_tokens: number;
       }
     | {
-        effort: 'high' | 'medium' | 'low';
+        effort: 'xhigh' | 'high' | 'medium' | 'low' | 'minimal' | 'none';
       }
   );
 


### PR DESCRIPTION
## Description

Closes #391.

Expands the `reasoning.effort` type in `OpenRouterProviderOptions` to include `'xhigh'`, `'minimal'`, and `'none'`, matching the full set of values supported by the OpenRouter API.

**Before:**
```ts
effort: 'high' | 'medium' | 'low'
```

**After:**
```ts
effort: 'xhigh' | 'high' | 'medium' | 'low' | 'minimal' | 'none'
```

This is a type-only change. The `reasoning` object is passed through directly to the API without SDK-side transformation, so no runtime logic changes were needed. Values were validated against the canonical source.

### Key things for review
- The core change is a single line in `src/types/index.ts` — verify the values match the API spec
- Unit tests verify each new value passes through to the request body via `providerOptions`
- E2E regression tests hit the live API with `openai/o3-mini` for each new value; they assert successful completion (`totalTokens > 0`) rather than non-empty text, since `xhigh` can allocate ~95% of tokens to reasoning

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

---

Link to Devin run: https://app.devin.ai/sessions/9d07f9411c0f41bf99e775de6dc4cd4e
Requested by: @robert-j-y