### PR TITLE
fix: emit missing tool-input-end in multi-chunk tool call streaming

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -992,6 +992,11 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                   toolCall.function?.arguments != null &&
                   isParsableJson(toolCall.function.arguments)
                 ) {
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: toolCall.id,
+                  });
+
                   // Only attach reasoning_details to the first tool call to avoid
                   // duplicating thinking blocks for parallel tool calls (Claude)
                   controller.enqueue({


### PR DESCRIPTION
## Summary
Adds the missing `tool-input-end` event in the multi-chunk tool call merge path in `doStream()`.

## Problem
The single-chunk tool call path correctly emits the full sequence:
```
tool-input-start → tool-input-delta → tool-input-end → tool-call
```

But the multi-chunk merge path was missing `tool-input-end`:
```
tool-input-delta → tool-call (no tool-input-end)
```

This inconsistency may cause downstream stream consumers (like the AI SDK's stream processor) to wait for the missing `tool-input-end` event before processing the `tool-call`, contributing to perceived streaming delays in multi-step tool calling scenarios.

## Change
Added `controller.enqueue({ type: 'tool-input-end', id: toolCall.id })` before the `tool-call` emission in the multi-chunk path, matching the single-chunk path's behavior.

## Related
Fixes #413