### PR TITLE
feat: add video_url support for multimodal video content

### DIFF
--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -128,6 +128,21 @@ export function convertToOpenRouterChatMessages(
                   };
                 }
 
+                // Handle video files for video_url format
+                if (part.mediaType?.startsWith('video/')) {
+                  const url = getFileUrl({
+                    part,
+                    defaultMediaType: 'video/mp4',
+                  });
+                  return {
+                    type: 'video_url' as const,
+                    video_url: {
+                      url,
+                    },
+                    ...(cacheControl && { cache_control: cacheControl }),
+                  };
+                }
+
                 // Handle audio files for input_audio format
                 if (part.mediaType?.startsWith('audio/')) {
                   return {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -72,6 +72,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
       /^data:image\/[a-zA-Z]+;base64,/,
       /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i,
     ],
+    'video/*': [/^data:video\//, /^https?:\/\/.+$/],
+    'audio/*': [/^data:audio\//, /^https?:\/\/.+$/],
     // 'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],
   };

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -55,6 +55,8 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
       /^data:image\/[a-zA-Z]+;base64,/,
       /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i,
     ],
+    'video/*': [/^data:video\//, /^https?:\/\/.+$/],
+    'audio/*': [/^data:audio\//, /^https?:\/\/.+$/],
     'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],
   };

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -26,6 +26,7 @@ export interface ChatCompletionUserMessageParam {
 export type ChatCompletionContentPart =
   | ChatCompletionContentPartText
   | ChatCompletionContentPartImage
+  | ChatCompletionContentPartVideo
   | ChatCompletionContentPartFile
   | ChatCompletionContentPartInputAudio;
 
@@ -42,6 +43,15 @@ export interface ChatCompletionContentPartFile {
 export interface ChatCompletionContentPartImage {
   type: 'image_url';
   image_url: {
+    url: string;
+  };
+  cache_control?: OpenRouterCacheControl;
+}
+
+/** https://openrouter.ai/docs/guides/overview/multimodal/videos */
+export interface ChatCompletionContentPartVideo {
+  type: 'video_url';
+  video_url: {
     url: string;
   };
   cache_control?: OpenRouterCacheControl;


### PR DESCRIPTION
## Summary

Adds support for passing video URLs through to OpenRouter's `video_url` format, enabling multimodal video analysis (e.g., YouTube URLs via Gemini through OpenRouter).

## Problem

Without this change, the Vercel AI SDK downloads video URLs client-side (converting to base64) because `video/*` is not in the provider's `supportedUrls`. This breaks YouTube URL support since OpenRouter proxies to Google AI Studio, which natively handles YouTube URLs via `video_url` — but only if the URL is passed through as-is.

## Changes

1. **Added `video/*` and `audio/*` to `supportedUrls`** in both `chat/index.ts` and `completion/index.ts` — prevents the AI SDK from downloading video/audio URLs client-side
2. **Added `video_url` message format handler** in `convert-to-openrouter-chat-messages.ts` — converts `type: "file"` with `video/*` mediaType to OpenRouter's `{ type: "video_url", video_url: { url } }` format ([docs](https://openrouter.ai/docs/guides/overview/multimodal/videos))
3. **Added `ChatCompletionContentPartVideo` type** in `openrouter-chat-completions-input.ts`