### PR TITLE
feat: send tool name on tool messages to match OpenAI API spec

### DIFF
--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -709,6 +709,7 @@ describe('cache control', () => {
         role: 'tool',
         tool_call_id: 'call-123',
         content: JSON.stringify({ answer: 42 }),
+        name: 'calculator',
         cache_control: { type: 'ephemeral' },
       },
     ]);
@@ -2422,6 +2423,79 @@ describe('multimodal tool result content (issue #181)', () => {
       {
         type: 'image_url',
         image_url: { url: 'https://example.com/screenshot2.png' },
+      },
+    ]);
+  });
+});
+
+describe('tool messages', () => {
+  it('should include tool name from toolName', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-456',
+            toolName: 'get_weather',
+            output: {
+              type: 'text',
+              value: 'Sunny, 72°F',
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call-456',
+        content: 'Sunny, 72°F',
+        name: 'get_weather',
+      },
+    ]);
+  });
+
+  it('should include tool name for each tool result in a multi-tool response', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            output: {
+              type: 'text',
+              value: 'Sunny',
+            },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'get_time',
+            output: {
+              type: 'json',
+              value: { time: '12:00' },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call-1',
+        content: 'Sunny',
+        name: 'get_weather',
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call-2',
+        content: JSON.stringify({ time: '12:00' }),
+        name: 'get_time',
       },
     ]);
   });

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -344,6 +344,7 @@ export function convertToOpenRouterChatMessages(
             role: 'tool',
             tool_call_id: toolResponse.toolCallId,
             content,
+            name: toolResponse.toolName,
             cache_control:
               getCacheControl(providerOptions) ??
               getCacheControl(toolResponse.providerOptions),

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -101,5 +101,6 @@ export interface ChatCompletionToolMessageParam {
   role: 'tool';
   content: string | Array<ChatCompletionContentPart>;
   tool_call_id: string;
+  name?: string;
   cache_control?: OpenRouterCacheControl;
 }


### PR DESCRIPTION
## Description

Add optional `name` field to tool messages, matching the OpenAI API spec. The AI SDK provides `toolName` on tool result parts but it was not being forwarded in the converted messages. This change passes `toolResponse.toolName` as `name` on each tool message sent to the API.

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
