### PR TITLE
feat: support Anthropic eager_input_streaming via tool providerOptions (#443)

### DIFF
--- a/.changeset/eager-input-streaming.md
+++ b/.changeset/eager-input-streaming.md
@@ -1,0 +1,7 @@
+---
+"@openrouter/ai-sdk-provider": minor
+---
+
+feat: support Anthropic eager_input_streaming parameter via tool providerOptions
+
+Tools can now pass `eager_input_streaming: true` through `providerOptions.openrouter.eager_input_streaming` to enable Anthropic's fine-grained tool streaming, reducing latency for large tool outputs.

--- a/e2e/issues/issue-443-eager-input-streaming.test.ts
+++ b/e2e/issues/issue-443-eager-input-streaming.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Regression test for GitHub issue #443
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/443
+ *
+ * Issue: Anthropic's eager_input_streaming parameter is not passed through
+ * when tools are sent to the OpenRouter API. This parameter enables
+ * fine-grained tool streaming, reducing latency for large tool outputs.
+ *
+ * Model: anthropic/claude-sonnet-4 (or any Anthropic model with tool use)
+ *
+ * This test verifies that eager_input_streaming from tool.providerOptions.openrouter
+ * is correctly included in the request body sent to the OpenRouter API.
+ */
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+
+import { createTestServer } from '@ai-sdk/test-server';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.mock('@/src/version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const TEST_PROMPT: LanguageModelV3Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'What is the weather in Tokyo?' }],
+  },
+];
+
+const provider = createOpenRouter({
+  apiKey: 'test-api-key',
+  compatibility: 'strict',
+});
+
+describe('Issue #443: Anthropic eager_input_streaming support', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-443',
+          object: 'chat.completion',
+          created: 1711357598,
+          model: 'anthropic/claude-sonnet-4',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'The weather in Tokyo is sunny.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 20,
+            completion_tokens: 10,
+            total_tokens: 30,
+          },
+        },
+      },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  it('should include eager_input_streaming in request body when set via tool providerOptions', async () => {
+    const model = provider.chat('anthropic/claude-sonnet-4');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the current weather in a given location',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              location: {
+                type: 'string',
+                description: 'The city name',
+              },
+            },
+            required: ['location'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+          providerOptions: {
+            openrouter: {
+              eager_input_streaming: true,
+            },
+          },
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<Record<string, unknown>>;
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toHaveProperty('eager_input_streaming', true);
+    expect(tools[0]).toHaveProperty('type', 'function');
+    expect(tools[0]).toHaveProperty('function');
+  });
+
+  it('should not include eager_input_streaming when not set in providerOptions', async () => {
+    const model = provider.chat('anthropic/claude-sonnet-4');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the current weather in a given location',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              location: { type: 'string' },
+            },
+            required: ['location'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<Record<string, unknown>>;
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).not.toHaveProperty('eager_input_streaming');
+  });
+
+  it('should support per-tool eager_input_streaming with mixed tools', async () => {
+    const model = provider.chat('anthropic/claude-sonnet-4');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description:
+            'Get weather (large output, benefits from eager streaming)',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+            required: ['location'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+          providerOptions: {
+            openrouter: {
+              eager_input_streaming: true,
+            },
+          },
+        },
+        {
+          type: 'function',
+          name: 'get_time',
+          description:
+            'Get current time (small output, no need for eager streaming)',
+          inputSchema: {
+            type: 'object',
+            properties: { timezone: { type: 'string' } },
+            required: ['timezone'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<Record<string, unknown>>;
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toHaveProperty('eager_input_streaming', true);
+    expect(tools[1]).not.toHaveProperty('eager_input_streaming');
+  });
+});

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -807,6 +807,132 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass eager_input_streaming from tool providerOptions to request body', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'get-weather',
+          description: 'Get the weather',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+            required: ['location'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+          providerOptions: {
+            openrouter: {
+              eager_input_streaming: true,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+      model: 'anthropic/claude-3.5-sonnet',
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'get-weather',
+            description: 'Get the weather',
+            parameters: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+          eager_input_streaming: true,
+        },
+      ],
+    });
+  });
+
+  it('should not include eager_input_streaming when not set in tool providerOptions', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          description: 'Test tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools[0]).not.toHaveProperty('eager_input_streaming');
+  });
+
+  it('should handle mixed tools with and without eager_input_streaming', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'eager-tool',
+          description: 'Tool with eager streaming',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+          providerOptions: {
+            openrouter: {
+              eager_input_streaming: true,
+            },
+          },
+        },
+        {
+          type: 'function',
+          name: 'normal-tool',
+          description: 'Tool without eager streaming',
+          inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'number' } },
+            required: ['id'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toHaveProperty('eager_input_streaming', true);
+    expect(tools[1]).not.toHaveProperty('eager_input_streaming');
+  });
+
   it('should send both response_format and tools when both are present', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -182,6 +182,11 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
 
       for (const tool of tools) {
         if (tool.type === 'function') {
+          const openrouterOptions = tool.providerOptions?.openrouter as
+            | Record<string, unknown>
+            | undefined;
+          const eagerInputStreaming = openrouterOptions?.eager_input_streaming;
+
           mappedTools.push({
             type: 'function' as const,
             function: {
@@ -189,6 +194,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               description: tool.description,
               parameters: tool.inputSchema,
             },
+            ...(eagerInputStreaming != null && {
+              eager_input_streaming: eagerInputStreaming,
+            }),
           });
         } else if (tool.type === 'provider') {
           mappedTools.push(mapProviderTool(tool));


### PR DESCRIPTION
## Description

Adds support for Anthropic's `eager_input_streaming` parameter on per-tool basis. Tools can now pass this through `providerOptions.openrouter.eager_input_streaming` to enable fine-grained tool streaming, reducing latency for large tool outputs.

**Implementation:** In `getArgs()`, the tool mapping now reads `eager_input_streaming` from `tool.providerOptions?.openrouter` and conditionally includes it on the mapped tool object sent to the API.

**Companion PR:** Requires [openrouter-web#17532](https://github.com/OpenRouterTeam/openrouter-web/pull/17532) for the API to pass the parameter through to Anthropic.

### Key areas for review

- **`src/chat/index.ts:189-191`** — Uses `as Record<string, unknown> | undefined` to narrow the `openrouter` provider options. Verify this is acceptable vs. other approaches.
- **Conditional spread pattern (`!= null`)** — `eager_input_streaming: false` would still be included in the request body. This is intentional (explicit false should be sent), but worth confirming.
- **Scope** — Only `eager_input_streaming` is extracted from tool providerOptions. If more per-tool options are needed in the future, this pattern would need to be extended.

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass (360/360)
- [x] I have added tests for my changes (3 unit tests + 3 e2e regression tests)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file (minor)

Link to Devin session: https://app.devin.ai/sessions/e3b2cbc5fbfe4b7499f581cb30795525
Requested by: @robert-j-y