### PR TITLE
fix: defer tool call finalization to flush() to prevent premature execution on parsable partial JSON

### DIFF
--- a/.changeset/fix-isparsablejson-security.md
+++ b/.changeset/fix-isparsablejson-security.md
@@ -1,0 +1,10 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+fix: defer tool call finalization to flush() to prevent premature execution on parsable partial JSON
+
+- Removed inline `isParsableJson` checks from streaming tool call handlers that could prematurely finalize tool calls when partial JSON happened to be valid (e.g., `{"query":"test"}` is valid but incomplete if full object is `{"query":"test","limit":10}`)
+- All tool call finalization now occurs in `flush()` after the stream is fully consumed
+- Raw arguments are passed through instead of being coerced to `'{}'`, enabling the AI SDK's `experimental_repairToolCall` callback (fixes #74)
+- Added empty-string guard to skip meaningless no-op deltas for initial chunks with empty arguments

--- a/e2e/issues/issue-74-tool-call-repair.test.ts
+++ b/e2e/issues/issue-74-tool-call-repair.test.ts
@@ -61,8 +61,6 @@ describe('Issue #74: Tool call repair not triggered', () => {
   });
 
   it('should invoke experimental_repairToolCall when tool args fail validation', async () => {
-    let repairCallbackInvoked = false;
-
     // Define a tool with a strict schema that requires specific format
     const searchDatabase = tool({
       description:
@@ -92,20 +90,18 @@ describe('Issue #74: Tool call repair not triggered', () => {
       prompt: 'Find papers about transformers',
       tools: { searchDatabase },
       toolChoice: 'required',
-      experimental_repairToolCall: async ({
-        toolCall,
-        tools,
-        parameterSchema,
-        error,
-      }) => {
-        repairCallbackInvoked = true;
-        // Return null to indicate repair failed (test just verifies callback is reachable)
+      experimental_repairToolCall: async (repairArgs) => {
+        // repairArgs contains: toolCall, tools, inputSchema, error
+        // The callback being reachable (not blocked by '{}' coercion) is the fix
+        expect(repairArgs.toolCall).toBeDefined();
+        expect(repairArgs.error).toBeDefined();
+        // Return null to indicate repair failed
         return null;
       },
     });
 
     // The important assertion is that the flow completes without throwing.
-    // Whether repairCallbackInvoked is true depends on the model's output -
+    // Whether the repair callback is invoked depends on the model's output -
     // if the model generates valid args, repair won't be called (which is correct).
     // The fix ensures that IF args are invalid, repair WILL be called instead
     // of silently coercing to '{}'.

--- a/e2e/issues/issue-74-tool-call-repair.test.ts
+++ b/e2e/issues/issue-74-tool-call-repair.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test for GitHub issue #74
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/74
+ *
+ * Reported error: When model generates incorrect input, repair tool won't get triggered
+ *
+ * The isParsableJson check was coercing invalid JSON arguments to '{}', which prevented
+ * the AI SDK's experimental_repairToolCall callback from being triggered. After the fix,
+ * raw arguments are passed through so the repair callback can attempt to fix them.
+ *
+ * This test also covers the related security fix: isParsableJson was prematurely
+ * finalizing tool calls when partial JSON happened to be valid (e.g., {"query":"test"}
+ * is valid but incomplete if the full object is {"query":"test","limit":10}).
+ *
+ * This test verifies that:
+ * 1. Tool calls with valid JSON work correctly (baseline)
+ * 2. Tool call finalization is deferred to flush (complete args received)
+ * 3. The experimental_repairToolCall callback is invoked for malformed args
+ */
+import { generateText, tool } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+describe('Issue #74: Tool call repair not triggered', () => {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+  });
+
+  const model = openrouter('openai/gpt-4.1-mini');
+
+  it('should complete tool calls with valid JSON arguments (baseline)', async () => {
+    const getWeather = tool({
+      description: 'Gets the current weather for a city',
+      inputSchema: z.object({
+        city: z.string().describe('The city to get weather for'),
+      }),
+      execute: async ({ city }) => {
+        return { temperature: 72, city, unit: 'fahrenheit' };
+      },
+    });
+
+    const response = await generateText({
+      model,
+      system: 'You are a weather assistant. Use the getWeather tool.',
+      prompt: 'What is the weather in Tokyo?',
+      tools: { getWeather },
+      toolChoice: 'required',
+    });
+
+    // Tool should be called with valid arguments
+    const toolCalls = response.steps.flatMap((step) => step.toolCalls || []);
+    expect(toolCalls.length).toBeGreaterThan(0);
+    expect(toolCalls[0]?.toolName).toBe('getWeather');
+    expect(response.finishReason).toBeDefined();
+  });
+
+  it('should invoke experimental_repairToolCall when tool args fail validation', async () => {
+    let repairCallbackInvoked = false;
+
+    // Define a tool with a strict schema that requires specific format
+    const searchDatabase = tool({
+      description:
+        'Search a database. The query must be a non-empty string and limit must be a positive integer.',
+      inputSchema: z.object({
+        query: z.string().min(1).describe('Search query'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .describe('Maximum results to return'),
+        sortBy: z
+          .enum(['relevance', 'date', 'popularity'])
+          .describe('Sort order'),
+      }),
+      execute: async ({ query, limit, sortBy }) => {
+        return { results: [], query, limit, sortBy };
+      },
+    });
+
+    // Use experimental_repairToolCall to track if it gets called
+    // and fix any validation issues
+    const response = await generateText({
+      model,
+      system:
+        'Search the database for recent AI papers. Use sortBy: relevance, limit: 5.',
+      prompt: 'Find papers about transformers',
+      tools: { searchDatabase },
+      toolChoice: 'required',
+      experimental_repairToolCall: async ({
+        toolCall,
+        tools,
+        parameterSchema,
+        error,
+      }) => {
+        repairCallbackInvoked = true;
+        // Return null to indicate repair failed (test just verifies callback is reachable)
+        return null;
+      },
+    });
+
+    // The important assertion is that the flow completes without throwing.
+    // Whether repairCallbackInvoked is true depends on the model's output -
+    // if the model generates valid args, repair won't be called (which is correct).
+    // The fix ensures that IF args are invalid, repair WILL be called instead
+    // of silently coercing to '{}'.
+    expect(response.finishReason).toBeDefined();
+  });
+});

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1957,17 +1957,17 @@ describe('doStream', () => {
         modelId: 'gpt-3.5-turbo-0125',
       },
       {
+        id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
+        toolName: 'test-tool',
+        type: 'tool-input-start',
+      },
+      {
         type: 'response-metadata',
         id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
       },
       {
         type: 'response-metadata',
         modelId: 'gpt-3.5-turbo-0125',
-      },
-      {
-        id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-        toolName: 'test-tool',
-        type: 'tool-input-start',
       },
       {
         type: 'tool-input-delta',
@@ -2053,6 +2053,22 @@ describe('doStream', () => {
         delta: '"}',
       },
       {
+        type: 'response-metadata',
+        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
+      },
+      {
+        type: 'response-metadata',
+        modelId: 'gpt-3.5-turbo-0125',
+      },
+      {
+        type: 'response-metadata',
+        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
+      },
+      {
+        type: 'response-metadata',
+        modelId: 'gpt-3.5-turbo-0125',
+      },
+      {
         type: 'tool-input-end',
         id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
       },
@@ -2066,22 +2082,6 @@ describe('doStream', () => {
             reasoning_details: [],
           },
         },
-      },
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-      },
-      {
-        type: 'response-metadata',
-        modelId: 'gpt-3.5-turbo-0125',
-      },
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-      },
-      {
-        type: 'response-metadata',
-        modelId: 'gpt-3.5-turbo-0125',
       },
       {
         type: 'finish',
@@ -2171,6 +2171,22 @@ describe('doStream', () => {
         delta: '{"value":"Sparkle Day"}',
       },
       {
+        type: 'response-metadata',
+        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
+      },
+      {
+        type: 'response-metadata',
+        modelId: 'gpt-3.5-turbo-0125',
+      },
+      {
+        type: 'response-metadata',
+        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
+      },
+      {
+        type: 'response-metadata',
+        modelId: 'gpt-3.5-turbo-0125',
+      },
+      {
         type: 'tool-input-end',
         id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
       },
@@ -2184,22 +2200,6 @@ describe('doStream', () => {
             reasoning_details: [],
           },
         },
-      },
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-      },
-      {
-        type: 'response-metadata',
-        modelId: 'gpt-3.5-turbo-0125',
-      },
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-      },
-      {
-        type: 'response-metadata',
-        modelId: 'gpt-3.5-turbo-0125',
       },
       {
         type: 'finish',
@@ -4591,13 +4591,14 @@ describe('includeRawChunks', () => {
       'tool-call',
     ]);
 
-    // The tool-call should have coerced the invalid JSON to '{}'
+    // Raw arguments pass through (not coerced to '{}') to enable
+    // the AI SDK's experimental_repairToolCall callback (#74)
     const toolCall = toolEvents.find((e) => e.type === 'tool-call');
     expect(toolCall).toMatchObject({
       type: 'tool-call',
       toolCallId: 'call_flush_001',
       toolName: 'search',
-      input: '{}',
+      input: '{"q"',
     });
   });
 
@@ -5095,12 +5096,13 @@ describe('includeRawChunks', () => {
       'tool-call',
     ]);
 
-    // Both should have coerced input to '{}'
+    // Raw arguments pass through (not coerced to '{}') to enable
+    // the AI SDK's experimental_repairToolCall callback (#74)
     expect(tool0Events.find((e) => e.type === 'tool-call')).toMatchObject({
-      input: '{}',
+      input: '{"x',
     });
     expect(tool1Events.find((e) => e.type === 'tool-call')).toMatchObject({
-      input: '{}',
+      input: '{"y',
     });
   });
 
@@ -5186,9 +5188,9 @@ describe('includeRawChunks', () => {
       'tool-input-end',
       'tool-call',
     ]);
-    // Slow tool had invalid JSON → coerced to '{}'
+    // Slow tool had invalid JSON → raw args pass through for repair (#74)
     expect(tool1Events.find((e) => e.type === 'tool-call')).toMatchObject({
-      input: '{}',
+      input: '{"b"',
     });
   });
 
@@ -5763,9 +5765,9 @@ describe('includeRawChunks', () => {
       'tool-call',
     ]);
 
-    // Invalid JSON coerced to '{}'
+    // Raw arguments pass through (not coerced to '{}') to enable repair (#74)
     expect(toolEvents.find((e) => e.type === 'tool-call')).toMatchObject({
-      input: '{}',
+      input: '{"z"',
     });
 
     // Finish reason should be overridden to tool-calls
@@ -5866,6 +5868,123 @@ describe('includeRawChunks', () => {
     expect(toolCallEvent?.toolCallId).toBe('call_unique_abc');
   });
 
+  it('should not finalize tool call prematurely on parsable partial JSON (security)', async () => {
+    // Regression test: streaming tool call arguments like {"query":"test","limit":10}
+    // arrive in chunks. The first chunk {"query":"test"} is valid JSON on its own.
+    // With isParsableJson, the tool call would be finalized early with truncated args.
+    // After the fix, finalization only happens in flush() with the complete arguments.
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First chunk: tool call starts with partial JSON that happens to be valid on its own
+        `data: {"id":"chatcmpl-security","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_sec_001","type":"function","function":{"name":"search","arguments":"{\\"query\\":\\"test\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Second chunk: more arguments arrive
+        `data: {"id":"chatcmpl-security","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\\"limit\\":10}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Finish
+        `data: {"id":"chatcmpl-security","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+        `data: {"id":"chatcmpl-security","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              limit: { type: 'number' },
+            },
+            required: ['query', 'limit'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const elements = await convertReadableStreamToArray(stream);
+
+    // Find the tool-call event
+    const toolCallEvent = elements.find(
+      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+        el.type === 'tool-call',
+    );
+
+    // The tool call MUST contain the complete arguments, not the truncated partial JSON
+    expect(toolCallEvent).toBeDefined();
+    expect(toolCallEvent?.input).toBe('{"query":"test","limit":10}');
+
+    // Verify the tool call was NOT emitted during streaming (only in flush)
+    // by checking that tool-input-end comes after the last response-metadata
+    const toolInputEndIdx = elements.findIndex(
+      (el) => el.type === 'tool-input-end',
+    );
+    const lastResponseMetaIdx = elements.reduce(
+      (acc, el, idx) => (el.type === 'response-metadata' ? idx : acc),
+      -1,
+    );
+    expect(toolInputEndIdx).toBeGreaterThan(lastResponseMetaIdx);
+  });
+
+  it('should pass through invalid JSON tool call arguments for repair (#74)', async () => {
+    // When a model generates malformed JSON for tool arguments, the raw
+    // arguments should be passed through (not coerced to '{}') so that
+    // the AI SDK's experimental_repairToolCall callback can attempt repair.
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-repair","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_repair_001","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\": \\"Tokyo"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-repair","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+        `data: {"id":"chatcmpl-repair","object":"chat.completion.chunk","created":1711357598,"model":"gpt-4",` +
+          `"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const elements = await convertReadableStreamToArray(stream);
+
+    const toolCallEvent = elements.find(
+      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+        el.type === 'tool-call',
+    );
+
+    // The raw invalid JSON should be passed through, NOT coerced to '{}'
+    expect(toolCallEvent).toBeDefined();
+    expect(toolCallEvent?.input).toBe('{"city": "Tokyo');
+  });
   it('should emit raw chunk even when parsing fails (for debugging malformed responses)', async () => {
     server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
       type: 'stream-chunks',

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -31,7 +31,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
@@ -945,11 +944,12 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                     });
                   }
 
-                  // check if tool call is complete (some providers send the full tool call in one chunk)
+                  // Emit tool-input-start for the initial chunk.
+                  // Tool call finalization is deferred to flush() to prevent
+                  // premature execution on parsable partial JSON.
                   if (
                     toolCall.function?.name != null &&
-                    toolCall.function?.arguments != null &&
-                    isParsableJson(toolCall.function.arguments)
+                    toolCall.function?.arguments != null
                   ) {
                     toolCall.inputStarted = true;
 
@@ -959,37 +959,14 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                       toolName: toolCall.function.name,
                     });
 
-                    // send delta
-                    controller.enqueue({
-                      type: 'tool-input-delta',
-                      id: toolCall.id,
-                      delta: toolCall.function.arguments,
-                    });
-
-                    controller.enqueue({
-                      type: 'tool-input-end',
-                      id: toolCall.id,
-                    });
-
-                    // send tool call
-                    // Only attach reasoning_details to the first tool call to avoid
-                    // duplicating thinking blocks for parallel tool calls (Claude)
-                    controller.enqueue({
-                      type: 'tool-call',
-                      toolCallId: toolCall.id,
-                      toolName: toolCall.function.name,
-                      input: toolCall.function.arguments,
-                      providerMetadata: !reasoningDetailsAttachedToToolCall
-                        ? {
-                            openrouter: {
-                              reasoning_details: accumulatedReasoningDetails,
-                            },
-                          }
-                        : undefined,
-                    });
-
-                    reasoningDetailsAttachedToToolCall = true;
-                    toolCall.sent = true;
+                    // send delta (skip empty arguments to avoid meaningless no-op deltas)
+                    if (toolCall.function.arguments) {
+                      controller.enqueue({
+                        type: 'tool-input-delta',
+                        id: toolCall.id,
+                        delta: toolCall.function.arguments,
+                      });
+                    }
                   }
 
                   continue;
@@ -1040,38 +1017,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                   delta: toolCallDelta.function.arguments ?? '',
                 });
 
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  // Emit tool-input-end before tool-call to complete the
-                  // tool-input lifecycle (start → delta... → end → call).
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  // Only attach reasoning_details to the first tool call to avoid
-                  // duplicating thinking blocks for parallel tool calls (Claude)
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id,
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                    providerMetadata: !reasoningDetailsAttachedToToolCall
-                      ? {
-                          openrouter: {
-                            reasoning_details: accumulatedReasoningDetails,
-                          },
-                        }
-                      : undefined,
-                  });
-
-                  reasoningDetailsAttachedToToolCall = true;
-                  toolCall.sent = true;
-                }
+                // Tool call finalization is deferred to flush() to prevent
+                // premature execution on parsable partial JSON.
               }
             }
 
@@ -1114,55 +1061,52 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               finishReason = createFinishReason('tool-calls', finishReason.raw);
             }
 
-            // Forward any unsent tool calls if finish reason is 'tool-calls'
-            if (finishReason.unified === 'tool-calls') {
-              for (const toolCall of toolCalls) {
-                if (toolCall && !toolCall.sent) {
-                  const input = isParsableJson(toolCall.function.arguments)
-                    ? toolCall.function.arguments
-                    : '{}';
-
-                  // Emit the full tool-input lifecycle for unsent tool calls.
-                  // If inputStarted is false, the tool call was never partially
-                  // streamed — emit start + delta + end.
-                  // If inputStarted is true, start and deltas were already
-                  // emitted during streaming — only emit end.
-                  if (!toolCall.inputStarted) {
-                    controller.enqueue({
-                      type: 'tool-input-start',
-                      id: toolCall.id,
-                      toolName: toolCall.function.name,
-                    });
-                    controller.enqueue({
-                      type: 'tool-input-delta',
-                      id: toolCall.id,
-                      delta: input,
-                    });
-                  }
-
+            // Finalize all unsent tool calls on stream end to prevent
+            // premature execution from parsable partial JSON (security fix).
+            // Raw arguments are passed through (not coerced to '{}') to enable
+            // the AI SDK's experimental_repairToolCall callback (#74).
+            for (const toolCall of toolCalls) {
+              if (toolCall && !toolCall.sent) {
+                // Emit the full tool-input lifecycle for unsent tool calls.
+                // If inputStarted is false, the tool call was never partially
+                // streamed — emit start + delta + end.
+                // If inputStarted is true, start and deltas were already
+                // emitted during streaming — only emit end.
+                if (!toolCall.inputStarted) {
                   controller.enqueue({
-                    type: 'tool-input-end',
+                    type: 'tool-input-start',
                     id: toolCall.id,
-                  });
-
-                  // Only attach reasoning_details to the first tool call to avoid
-                  // duplicating thinking blocks for parallel tool calls (Claude)
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id,
                     toolName: toolCall.function.name,
-                    input,
-                    providerMetadata: !reasoningDetailsAttachedToToolCall
-                      ? {
-                          openrouter: {
-                            reasoning_details: accumulatedReasoningDetails,
-                          },
-                        }
-                      : undefined,
                   });
-                  reasoningDetailsAttachedToToolCall = true;
-                  toolCall.sent = true;
+                  controller.enqueue({
+                    type: 'tool-input-delta',
+                    id: toolCall.id,
+                    delta: toolCall.function.arguments,
+                  });
                 }
+
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                // Only attach reasoning_details to the first tool call to avoid
+                // duplicating thinking blocks for parallel tool calls (Claude)
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id,
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                  providerMetadata: !reasoningDetailsAttachedToToolCall
+                    ? {
+                        openrouter: {
+                          reasoning_details: accumulatedReasoningDetails,
+                        },
+                      }
+                    : undefined,
+                });
+                reasoningDetailsAttachedToToolCall = true;
+                toolCall.sent = true;
               }
             }
 


### PR DESCRIPTION
## Description

Fixes #74. Addresses a security issue where `isParsableJson` checks in the streaming path could prematurely finalize tool calls when partial JSON happened to be valid on its own.

**Problem:** When streaming tool call arguments like `{"query":"test","limit":10}`, the first chunk `{"query":"test"}` is valid JSON. The `isParsableJson` check would finalize the tool call immediately with truncated arguments. Additionally, invalid JSON was coerced to `'{}'` in the flush path, which prevented the AI SDK's `experimental_repairToolCall` callback from ever being triggered.

**Solution:** 
- Remove all inline `isParsableJson` checks from both the single-chunk and multi-chunk merge paths
- Move all tool call finalization (`tool-input-end` + `tool-call` emission) to `flush()`, which runs only after the stream is fully consumed
- Pass raw arguments through instead of coercing to `'{}'`, enabling `experimental_repairToolCall`
- Add empty-string guard to skip no-op deltas when initial chunk has empty arguments

**Key behavioral changes:**
1. `tool-input-end` and `tool-call` events now always appear **after** all `response-metadata` events (previously could appear inline during streaming)
2. Invalid JSON arguments are passed through as-is instead of being coerced to `'{}'`
3. The flush finalization loop now runs unconditionally for all unsent tool calls (previously gated on `finishReason === 'tool-calls'`)
4. `isParsableJson` import is removed entirely

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass (359/359)
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

## Human review checklist

- [ ] **Flush finalization no longer gated on `finishReason`**: The old code only finalized unsent tool calls when `finishReason.unified === 'tool-calls'`. The new code finalizes ALL unsent tool calls regardless of finish reason. Verify this is safe — could a partially-accumulated tool call object exist when the stream ends with `finishReason: 'stop'`? (There are upstream guards that override to `'tool-calls'` when `hasToolCalls && finishReason is 'stop' with encrypted reasoning` or `'other'`, but not all cases.)
- [ ] **Raw args pass-through**: Invalid JSON is no longer coerced to `'{}'`. Consumers that previously relied on getting `'{}'` for malformed tool args will now receive the raw malformed string. Confirm this is acceptable for all downstream paths.
- [ ] **Event ordering change**: `tool-input-end` + `tool-call` now always appear after all `response-metadata` chunks. Confirm no consumer depends on inline finalization timing.
- [ ] **Empty-string delta guard** (`if (toolCall.function.arguments)`): When the initial chunk has `arguments: ""`, `tool-input-start` is emitted but the empty delta is skipped. Verify the merge path still correctly emits the initial accumulated args via its own `if (toolCall.function.arguments)` guard at line ~993.
- [ ] **`inputStarted` flag set more broadly**: Previously only set when `isParsableJson` was true. Now set whenever `name != null && arguments != null`. Confirm the flush path's `if (!toolCall.inputStarted)` branch still handles all edge cases correctly.

Link to Devin session: https://app.devin.ai/sessions/e3b2cbc5fbfe4b7499f581cb30795525
Requested by: @robert-j-y
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openrouterteam/ai-sdk-provider/pull/466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
