### PR TITLE
fix: extend signature validation to cover Gemini format (issue #418)

### DIFF
--- a/.changeset/fix-gemini-thought-signature.md
+++ b/.changeset/fix-gemini-thought-signature.md
@@ -1,0 +1,7 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Fix Gemini "Corrupted thought signature" error in multi-turn conversations (issue #418)
+
+Extend signature validation to also cover google-gemini-v1 format. Previously, only Anthropic-format reasoning entries were validated for signatures. Gemini extended thinking also uses signed thought tokens, and corrupted/missing signatures now get stripped before being sent back to the API.

--- a/e2e/issues/issue-418-gemini-thought-signature.test.ts
+++ b/e2e/issues/issue-418-gemini-thought-signature.test.ts
@@ -4,13 +4,15 @@
  *
  * Reported error: Multi-turn conversations with Gemini extended thinking
  * intermittently fail with "Corrupted thought signature" (INVALID_ARGUMENT 400).
- * Google signs the thought tokens in the response, and if those signatures are
- * lost or corrupted during message roundtripping (DB storage, JSON serialization,
- * field-level pruning), the SDK sends them back as-is and Google rejects.
+ * Google internally signs thought tokens — unlike Anthropic, the SDK `signature`
+ * field is NOT used. Any modification during roundtripping (DB storage, JSON
+ * serialization, field reordering, encoding changes) can corrupt the internal
+ * signing, and Google rejects with INVALID_ARGUMENT.
  *
- * The fix: extend the signature validation (previously Anthropic-only) to also
- * cover google-gemini-v1 format — strip reasoning.text entries that lack a valid
- * signature before sending them back to the API.
+ * The fix: add google-gemini-v1 to the signature-required format check. Since
+ * Gemini reasoning.text entries never have an SDK `signature` field, they are
+ * always stripped on roundtrip. This is intentional defensive behavior — the
+ * SDK cannot verify whether the text survived roundtripping intact.
  */
 import type { UIMessage } from 'ai';
 

--- a/e2e/issues/issue-418-gemini-thought-signature.test.ts
+++ b/e2e/issues/issue-418-gemini-thought-signature.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Regression test for GitHub Issue #418 — Gemini corrupted thought signature
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/418
+ *
+ * Reported error: Multi-turn conversations with Gemini extended thinking
+ * intermittently fail with "Corrupted thought signature" (INVALID_ARGUMENT 400).
+ * Google signs the thought tokens in the response, and if those signatures are
+ * lost or corrupted during message roundtripping (DB storage, JSON serialization,
+ * field-level pruning), the SDK sends them back as-is and Google rejects.
+ *
+ * The fix: extend the signature validation (previously Anthropic-only) to also
+ * cover google-gemini-v1 format — strip reasoning.text entries that lack a valid
+ * signature before sending them back to the API.
+ */
+import type { UIMessage } from 'ai';
+
+import { convertToModelMessages, readUIMessageStream, streamText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 120_000,
+});
+
+describe('Issue #418: Gemini multi-turn should succeed when thought signatures are stripped', () => {
+  const provider = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+  });
+
+  it('should handle multi-turn when Gemini thought signatures are stripped from UIMessages', async () => {
+    const model = provider.chat('google/gemini-2.5-flash', {
+      reasoning: { effort: 'low' },
+    });
+
+    // Turn 1: Get a real response with reasoning from Gemini
+    const turn1 = streamText({
+      model,
+      messages: [{ role: 'user', content: 'What is 2+2? Be brief.' }],
+    });
+
+    const uiMessageStream = turn1.toUIMessageStream();
+    const uiMessages: UIMessage[] = [];
+    for await (const message of readUIMessageStream({
+      stream: uiMessageStream,
+    })) {
+      uiMessages.push(message);
+    }
+
+    const assistantMessage = uiMessages.find((m) => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+
+    // Simulate DB serialization that STRIPS signatures.
+    // This is the exact scenario from issue #418: an app stores messages,
+    // the signature field is lost (null fields dropped, ORM strips unknown
+    // fields, custom pruning), and the next turn fails with
+    // "Corrupted thought signature".
+    const stored: UIMessage[] = JSON.parse(JSON.stringify(uiMessages));
+    for (const msg of stored) {
+      for (const part of msg.parts) {
+        if (part.type === 'reasoning' && part.providerMetadata) {
+          const openrouter = part.providerMetadata.openrouter;
+          if (
+            typeof openrouter !== 'object' ||
+            openrouter === null ||
+            !('reasoning_details' in openrouter)
+          ) {
+            continue;
+          }
+          const details = openrouter.reasoning_details;
+          if (Array.isArray(details)) {
+            for (const detail of details) {
+              if (
+                typeof detail === 'object' &&
+                detail !== null &&
+                'signature' in detail
+              ) {
+                // Simulate signature being lost during serialization
+                delete detail.signature;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Turn 2: Use the signature-stripped messages for a follow-up.
+    // WITHOUT the fix, this would fail with:
+    //   "Corrupted thought signature" (INVALID_ARGUMENT 400)
+    // WITH the fix, the SDK strips the signatureless Gemini reasoning entries
+    // and the request succeeds.
+    const turn2 = streamText({
+      model,
+      messages: [
+        ...(await convertToModelMessages(stored)),
+        { role: 'user', content: 'Now what is 3+3?' },
+      ],
+    });
+
+    let turn2Text = '';
+    for await (const chunk of turn2.fullStream) {
+      if (chunk.type === 'text-delta') {
+        turn2Text += chunk.text;
+      }
+    }
+
+    // If we get here without an error, the fix is working
+    expect(turn2Text.length).toBeGreaterThan(0);
+  });
+
+  it('should handle multi-turn when Gemini providerMetadata is entirely removed', async () => {
+    const model = provider.chat('google/gemini-2.5-flash', {
+      reasoning: { effort: 'low' },
+    });
+
+    // Turn 1: Get a real response with reasoning
+    const turn1 = streamText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is the capital of France? Be brief.',
+        },
+      ],
+    });
+
+    const turn1Response = await turn1.response;
+    const turn1Messages = turn1Response.messages;
+    expect(turn1Messages.length).toBeGreaterThan(0);
+
+    // Simulate an app that strips ALL providerOptions from assistant messages
+    const strippedMessages = JSON.parse(JSON.stringify(turn1Messages));
+    for (const msg of strippedMessages) {
+      if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          if (part.type === 'reasoning') {
+            delete part.providerOptions;
+          }
+        }
+      }
+      delete msg.providerOptions;
+    }
+
+    // Turn 2: Continue with stripped messages.
+    // WITHOUT the fix, reasoning text without reasoning_details could cause
+    // "Corrupted thought signature" when Gemini tries to validate the thought.
+    // WITH the fix, reasoning is dropped when reasoning_details is absent.
+    const turn2 = streamText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: 'What is the capital of France? Be brief.',
+        },
+        ...strippedMessages,
+        { role: 'user', content: 'And Germany?' },
+      ],
+    });
+
+    let turn2Text = '';
+    for await (const chunk of turn2.fullStream) {
+      if (chunk.type === 'text-delta') {
+        turn2Text += chunk.text;
+      }
+    }
+
+    expect(turn2Text.length).toBeGreaterThan(0);
+  });
+});

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -274,16 +274,18 @@ export function convertToOpenRouterChatMessages(
             ? messageReasoningDetails
             : findFirstReasoningDetails(content);
 
-        // Strip Anthropic-format reasoning.text entries that lack a valid
-        // signature. When providerMetadata is partially lost during message
-        // serialization, custom pruning, or DB storage (e.g., null/undefined
-        // fields dropped), reasoning_details may survive but their text
-        // entries may lose the `signature` field. Sending these back causes
-        // Anthropic to reject with "Invalid signature in thinking block"
-        // (issue #423/#439).
+        // Strip reasoning.text entries that lack a valid signature for
+        // formats that use signed thought tokens. When providerMetadata is
+        // partially lost during message serialization, custom pruning, or
+        // DB storage (e.g., null/undefined fields dropped),
+        // reasoning_details may survive but their text entries may lose the
+        // `signature` field. Sending these back causes the upstream provider
+        // to reject:
+        //   - Anthropic: "Invalid signature in thinking block" (issue #423)
+        //   - Google Gemini: "Corrupted thought signature" (issue #418)
         //
-        // Only Anthropic-format text entries cause this error — other formats
-        // and non-text detail types pass through unchanged.
+        // Formats that use signatures: Anthropic Claude and Google Gemini.
+        // Other formats and non-text detail types pass through unchanged.
         //
         // This runs BEFORE deduplication so that signatureless entries are
         // never registered in the tracker — otherwise a signatureless entry
@@ -295,7 +297,10 @@ export function convertToOpenRouterChatMessages(
               return true;
             }
             const format = detail.format ?? DEFAULT_REASONING_FORMAT;
-            if (format !== ReasoningFormat.AnthropicClaudeV1) {
+            if (
+              format !== ReasoningFormat.AnthropicClaudeV1 &&
+              format !== ReasoningFormat.GoogleGeminiV1
+            ) {
               return true;
             }
             return !!detail.signature;
@@ -311,7 +316,7 @@ export function convertToOpenRouterChatMessages(
             if (logger !== false && typeof logger !== 'function') {
               // biome-ignore lint/suspicious/noConsole: intentional warning for stripped reasoning data
               console.warn(
-                '[openrouter] Some reasoning_details entries were removed because they were missing signatures. See https://github.com/OpenRouterTeam/ai-sdk-provider/issues/423 for more details.',
+                '[openrouter] Some reasoning_details entries were removed because they were missing signatures. See https://github.com/OpenRouterTeam/ai-sdk-provider/issues/423 and https://github.com/OpenRouterTeam/ai-sdk-provider/issues/418 for more details.',
               );
             }
           }

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -274,18 +274,25 @@ export function convertToOpenRouterChatMessages(
             ? messageReasoningDetails
             : findFirstReasoningDetails(content);
 
-        // Strip reasoning.text entries that lack a valid signature for
-        // formats that use signed thought tokens. When providerMetadata is
-        // partially lost during message serialization, custom pruning, or
-        // DB storage (e.g., null/undefined fields dropped),
-        // reasoning_details may survive but their text entries may lose the
-        // `signature` field. Sending these back causes the upstream provider
-        // to reject:
-        //   - Anthropic: "Invalid signature in thinking block" (issue #423)
-        //   - Google Gemini: "Corrupted thought signature" (issue #418)
+        // Strip reasoning.text entries that would cause signature errors
+        // when sent back to the upstream provider.
         //
-        // Formats that use signatures: Anthropic Claude and Google Gemini.
-        // Other formats and non-text detail types pass through unchanged.
+        // Anthropic (issue #423): Uses an explicit `signature` field on
+        // reasoning.text entries. When the signature is lost during message
+        // serialization, custom pruning, or DB storage, sending the entry
+        // back causes "Invalid signature in thinking block".
+        //
+        // Google Gemini (issue #418): Does NOT use the SDK `signature`
+        // field, but Google internally signs thought tokens. When
+        // reasoning text is modified during roundtripping (serialization,
+        // encoding changes, field reordering), Google rejects with
+        // "Corrupted thought signature". Since the SDK cannot verify
+        // whether the text is intact, Gemini reasoning.text entries are
+        // always stripped on roundtrip — the encrypted reasoning blob
+        // (reasoning.encrypted) handles multi-turn continuity instead.
+        //
+        // Other formats (OpenAI, xAI, Azure) and non-text detail types
+        // pass through unchanged.
         //
         // This runs BEFORE deduplication so that signatureless entries are
         // never registered in the tracker — otherwise a signatureless entry

--- a/src/chat/signature-roundtrip.test.ts
+++ b/src/chat/signature-roundtrip.test.ts
@@ -247,10 +247,13 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
 
   // === ADVERSARIAL EDGE CASES ===
 
-  it('should strip Google Gemini reasoning.text without signatures (issue #418)', () => {
-    // Google Gemini extended thinking uses signed thought tokens.
-    // When signatures are lost during serialization (DB storage, JSON round-trip),
-    // sending them back causes Google to reject with "Corrupted thought signature".
+  it('should strip Google Gemini reasoning.text on roundtrip (issue #418)', () => {
+    // Google Gemini does NOT use the SDK `signature` field, but Google
+    // internally signs thought tokens. Any modification during roundtripping
+    // causes "Corrupted thought signature" (INVALID_ARGUMENT 400).
+    // Since the SDK cannot verify text integrity, Gemini reasoning.text
+    // entries are always stripped. Multi-turn continuity uses
+    // reasoning.encrypted instead.
     const result = convertToOpenRouterChatMessages([
       {
         role: 'user',
@@ -282,13 +285,15 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
 
     const assistantMsg = result.find((m) => m.role === 'assistant');
     expect(assistantMsg).toBeDefined();
-    // Gemini reasoning.text without signature should be stripped to prevent
-    // "Corrupted thought signature" errors
+    // Gemini reasoning.text is always stripped to prevent
+    // "Corrupted thought signature" errors on roundtrip
     expect(assistantMsg!.reasoning_details).toBeUndefined();
     expect(assistantMsg!.reasoning).toBeUndefined();
   });
 
-  it('should preserve Google Gemini reasoning.text when signature is present', () => {
+  it('should preserve Google Gemini reasoning.text if it has an explicit signature', () => {
+    // Hypothetical future case: if Gemini ever adds SDK-level signatures,
+    // entries with valid signatures should be preserved.
     const result = convertToOpenRouterChatMessages([
       {
         role: 'user',
@@ -413,8 +418,8 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
 
   it('should strip both Anthropic and Gemini reasoning.text without signatures in mixed array', () => {
     // Edge case: mixed-format reasoning_details in one message.
-    // Both Anthropic and Gemini use signed thought tokens —
-    // entries without signatures should be stripped for both formats.
+    // Anthropic entries without signatures are stripped (lost during serialization).
+    // Gemini entries are always stripped (no SDK signature field).
     const result = convertToOpenRouterChatMessages([
       {
         role: 'user',

--- a/src/chat/signature-roundtrip.test.ts
+++ b/src/chat/signature-roundtrip.test.ts
@@ -247,9 +247,10 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
 
   // === ADVERSARIAL EDGE CASES ===
 
-  it('should preserve Google Gemini reasoning.text without signatures (non-Anthropic models do not use signatures)', () => {
-    // Google Gemini reasoning doesn't use signatures at all.
-    // The filter must NOT strip non-Anthropic reasoning.text entries.
+  it('should strip Google Gemini reasoning.text without signatures (issue #418)', () => {
+    // Google Gemini extended thinking uses signed thought tokens.
+    // When signatures are lost during serialization (DB storage, JSON round-trip),
+    // sending them back causes Google to reject with "Corrupted thought signature".
     const result = convertToOpenRouterChatMessages([
       {
         role: 'user',
@@ -281,12 +282,51 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
 
     const assistantMsg = result.find((m) => m.role === 'assistant');
     expect(assistantMsg).toBeDefined();
-    // Google Gemini reasoning.text should be preserved even without a signature
+    // Gemini reasoning.text without signature should be stripped to prevent
+    // "Corrupted thought signature" errors
+    expect(assistantMsg!.reasoning_details).toBeUndefined();
+    expect(assistantMsg!.reasoning).toBeUndefined();
+  });
+
+  it('should preserve Google Gemini reasoning.text when signature is present', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'What is 2+2?' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Simple arithmetic.',
+            providerOptions: {
+              openrouter: {
+                reasoning_details: [
+                  {
+                    type: ReasoningDetailType.Text,
+                    text: 'Simple arithmetic.',
+                    signature: FAKE_SIGNATURE,
+                    format: 'google-gemini-v1',
+                    index: 0,
+                  },
+                ],
+              },
+            },
+          },
+          { type: 'text', text: 'The answer is 4.' },
+        ],
+      },
+    ]);
+
+    const assistantMsg = result.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
     expect(assistantMsg!.reasoning).toBe('Simple arithmetic.');
     expect(assistantMsg!.reasoning_details).toHaveLength(1);
     expect(assistantMsg!.reasoning_details![0]).toMatchObject({
       type: ReasoningDetailType.Text,
       text: 'Simple arithmetic.',
+      signature: FAKE_SIGNATURE,
       format: 'google-gemini-v1',
     });
   });
@@ -371,9 +411,10 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
     });
   });
 
-  it('should strip Anthropic reasoning.text without signature but keep Gemini reasoning.text in mixed array', () => {
+  it('should strip both Anthropic and Gemini reasoning.text without signatures in mixed array', () => {
     // Edge case: mixed-format reasoning_details in one message.
-    // This could happen if a conversation switches models mid-stream.
+    // Both Anthropic and Gemini use signed thought tokens —
+    // entries without signatures should be stripped for both formats.
     const result = convertToOpenRouterChatMessages([
       {
         role: 'user',
@@ -398,7 +439,7 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
                   {
                     type: ReasoningDetailType.Text,
                     text: 'Gemini thinking.',
-                    // No signature — Gemini format, should be KEPT
+                    // No signature — Gemini format, should also be stripped
                     format: 'google-gemini-v1',
                     index: 1,
                   },
@@ -413,12 +454,58 @@ describe('Issue #423/#439: reasoning signature in multi-turn messages', () => {
 
     const assistantMsg = result.find((m) => m.role === 'assistant');
     expect(assistantMsg).toBeDefined();
-    // The Anthropic entry should be stripped, the Gemini entry preserved
+    // Both entries should be stripped — neither has a valid signature
+    expect(assistantMsg!.reasoning_details).toBeUndefined();
+    expect(assistantMsg!.reasoning).toBeUndefined();
+  });
+
+  it('should keep signed entries and strip unsigned ones in mixed Anthropic/Gemini array', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Anthropic thinking. Gemini thinking.',
+            providerOptions: {
+              openrouter: {
+                reasoning_details: [
+                  {
+                    type: ReasoningDetailType.Text,
+                    text: 'Anthropic thinking.',
+                    signature: FAKE_SIGNATURE,
+                    format: 'anthropic-claude-v1',
+                    index: 0,
+                  },
+                  {
+                    type: ReasoningDetailType.Text,
+                    text: 'Gemini thinking.',
+                    // No signature — should be stripped
+                    format: 'google-gemini-v1',
+                    index: 1,
+                  },
+                ],
+              },
+            },
+          },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    ]);
+
+    const assistantMsg = result.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    // Only the signed Anthropic entry should survive
     expect(assistantMsg!.reasoning_details).toHaveLength(1);
     expect(assistantMsg!.reasoning_details![0]).toMatchObject({
       type: ReasoningDetailType.Text,
-      text: 'Gemini thinking.',
-      format: 'google-gemini-v1',
+      text: 'Anthropic thinking.',
+      signature: FAKE_SIGNATURE,
+      format: 'anthropic-claude-v1',
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #418 — multi-turn conversations with Gemini extended thinking intermittently fail with "Corrupted thought signature" (INVALID_ARGUMENT 400).

**Root cause:** The signature validation filter in `convert-to-openrouter-chat-messages.ts` only checked `anthropic-claude-v1` format entries. Unlike Anthropic (which uses an explicit SDK `signature` field), Google Gemini internally signs thought tokens — the SDK has no `signature` field for Gemini entries at all. When reasoning text is modified during roundtripping (DB storage, JSON serialization, field reordering, encoding changes), the internal signing is corrupted and Google rejects the request.

**Fix:** Add `ReasoningFormat.GoogleGeminiV1` to the signature-required format check. Since Gemini reasoning.text entries never carry an SDK `signature` field, they are always stripped on roundtrip. This is intentional defensive behavior — the SDK cannot verify whether the text survived roundtripping intact, and `reasoning.encrypted` handles multi-turn continuity instead.

### Key changes
- `src/chat/convert-to-openrouter-chat-messages.ts` — extend filter condition from Anthropic-only to Anthropic + Gemini; updated comments documenting the different signing mechanisms
- `src/chat/signature-roundtrip.test.ts` — Gemini text entries now expected to be stripped; added positive test for hypothetical signed Gemini entries; added mixed-format edge cases (strip both unsigned, keep signed + strip unsigned)
- `e2e/issues/issue-418-gemini-thought-signature.test.ts` — e2e regression test (mirrors issue-423 pattern with Gemini model)

### Human review checklist (investigated via live API calls)

- [x] **Gemini does NOT use the SDK `signature` field.** Live API calls to `google/gemini-2.5-flash` and `google/gemini-2.5-pro-preview` confirm: reasoning_details contain `reasoning.text` with `format: "google-gemini-v1"` but no `signature` field. Google signs thought tokens internally. This means the fix strips ALL Gemini reasoning.text on roundtrip — this is the intended behavior.
- [x] **Other formats do NOT use signatures and pass through unchanged.** Verified: OpenAI (`openai/o4-mini`) returns only `reasoning.encrypted` (no text entries at all). xAI (`x-ai/grok-3-mini`) returns both `reasoning.text` (no signature) and `reasoning.encrypted`. Neither format matches the Anthropic/Gemini check, so they pass through unaffected.
- [x] **e2e test model returns reasoning.** `google/gemini-2.5-flash` with `reasoning.effort: "low"` returns reasoning_details with `google-gemini-v1` format text entries.

### Remaining reviewer considerations
- [ ] Confirm that stripping Gemini reasoning.text is acceptable given that `reasoning.encrypted` preserves multi-turn continuity
- [ ] xAI (`xai-responses-v1`) also returns `reasoning.text` without signatures but is NOT stripped by this fix — verify xAI doesn't have similar internal signing issues (no reports of this so far)

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

Link to Devin session: https://app.devin.ai/sessions/489dd1bcc293415c84b3253397954e88
Requested by: @robert-j-y