### PR TITLE
feat: add openrouter.tools.webSearch() provider-defined tool (#474)

### DIFF
--- a/.changeset/web-search-provider-tool.md
+++ b/.changeset/web-search-provider-tool.md
@@ -1,0 +1,25 @@
+---
+"@openrouter/ai-sdk-provider": minor
+---
+
+Add `openrouter.tools.webSearch()` provider-defined tool for server-side web search
+
+- New `src/tool/web-search.ts` — web search tool factory using `createProviderToolFactory`
+- Updated `OpenRouterProvider` interface with `tools.webSearch` property
+- Updated `getArgs()` to map `LanguageModelV3ProviderTool` to OpenRouter API server tool format (`openrouter:web_search`)
+- Supports optional args: `maxResults`, `searchPrompt`, `engine` ('auto' | 'native' | 'exa')
+
+Usage:
+```ts
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { generateText } from 'ai';
+
+const openrouter = createOpenRouter();
+const result = await generateText({
+  model: openrouter('openai/gpt-4o'),
+  tools: {
+    web_search: openrouter.tools.webSearch({ maxResults: 5 }),
+  },
+  prompt: 'What are the latest news?',
+});
+```

--- a/e2e/issues/issue-474-web-search-server-tool.test.ts
+++ b/e2e/issues/issue-474-web-search-server-tool.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression test for GitHub issue #474
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/474
+ *
+ * Issue: "Support openrouter:web_search as a provider-exported tool"
+ *
+ * The OpenRouter provider did not export provider-defined tools, unlike
+ * @ai-sdk/openai, @ai-sdk/google, and @ai-sdk/anthropic. The getArgs()
+ * method filtered tools to only function tools, discarding any
+ * LanguageModelV3ProviderTool.
+ *
+ * This test verifies that openrouter.tools.webSearch() works end-to-end
+ * with both generateText and streamText, producing text with URL citations
+ * from the web search server tool.
+ */
+import { generateText, streamText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 120_000,
+});
+
+describe('Issue #474: openrouter:web_search provider tool', () => {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
+  });
+
+  describe('generateText with webSearch provider tool', () => {
+    it('should return text with web search results using default args', async () => {
+      const response = await generateText({
+        model: openrouter('openai/gpt-4o-mini'),
+        tools: {
+          web_search: openrouter.tools.webSearch({}),
+        },
+        prompt: 'What is the current population of Tokyo? Search the web.',
+      });
+
+      expect(response.text).toBeDefined();
+      expect(response.text.length).toBeGreaterThan(0);
+      expect(response.finishReason).toBeDefined();
+    });
+
+    it('should return text when webSearch is configured with maxResults and searchPrompt', async () => {
+      const response = await generateText({
+        model: openrouter('openai/gpt-4o-mini'),
+        tools: {
+          web_search: openrouter.tools.webSearch({
+            maxResults: 3,
+            searchPrompt: 'latest technology news',
+          }),
+        },
+        prompt: 'What are the latest technology headlines today?',
+      });
+
+      expect(response.text).toBeDefined();
+      expect(response.text.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('streamText with webSearch provider tool', () => {
+    it('should stream text with web search results', async () => {
+      const result = streamText({
+        model: openrouter('openai/gpt-4o-mini'),
+        tools: {
+          web_search: openrouter.tools.webSearch({}),
+        },
+        prompt:
+          'Search the web for the latest news about artificial intelligence.',
+      });
+
+      let fullText = '';
+      for await (const chunk of result.textStream) {
+        fullText += chunk;
+      }
+
+      expect(fullText.length).toBeGreaterThan(0);
+    });
+
+    it('should stream text with sources when using fullStream', async () => {
+      const result = streamText({
+        model: openrouter('openai/gpt-4o-mini'),
+        tools: {
+          web_search: openrouter.tools.webSearch({
+            engine: 'exa',
+          }),
+        },
+        prompt: 'Search the web: What is the capital of France?',
+      });
+
+      let hasText = false;
+      for await (const chunk of result.fullStream) {
+        if (chunk.type === 'text-delta') {
+          hasText = true;
+        }
+      }
+
+      expect(hasText).toBe(true);
+    });
+  });
+});

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -4,7 +4,7 @@ import type {
   LanguageModelV3CallOptions,
   LanguageModelV3Content,
   LanguageModelV3FinishReason,
-  LanguageModelV3FunctionTool,
+  LanguageModelV3ProviderTool,
   LanguageModelV3ResponseMetadata,
   LanguageModelV3StreamPart,
   LanguageModelV3Usage,
@@ -179,20 +179,22 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
     };
 
     if (tools && tools.length > 0) {
-      // TODO: support built-in tools
-      const mappedTools = tools
-        .filter(
-          (tool): tool is LanguageModelV3FunctionTool =>
-            tool.type === 'function',
-        )
-        .map((tool) => ({
-          type: 'function' as const,
-          function: {
-            name: tool.name,
-            description: tool.description,
-            parameters: tool.inputSchema,
-          },
-        }));
+      const mappedTools: Array<Record<string, unknown>> = [];
+
+      for (const tool of tools) {
+        if (tool.type === 'function') {
+          mappedTools.push({
+            type: 'function' as const,
+            function: {
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.inputSchema,
+            },
+          });
+        } else if (tool.type === 'provider') {
+          mappedTools.push(mapProviderTool(tool));
+        }
+      }
 
       return {
         ...baseArgs,
@@ -1230,4 +1232,39 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
       response: { headers: responseHeaders },
     };
   }
+}
+
+/**
+ * Maps a provider-defined tool to the OpenRouter API server tool format.
+ *
+ * Provider tool IDs follow the format `openrouter.<tool_name>`, which maps
+ * to `openrouter:<tool_name>` in the API request tools array.
+ */
+function mapProviderTool(
+  tool: LanguageModelV3ProviderTool,
+): Record<string, unknown> {
+  // Convert provider tool ID format (openrouter.web_search)
+  // to OpenRouter API format (openrouter:web_search)
+  const [provider, toolName] = tool.id.split('.');
+  const apiToolType = `${provider}:${toolName}`;
+
+  // Map camelCase args to snake_case for the API
+  const mappedArgs: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(tool.args)) {
+    if (value !== undefined) {
+      mappedArgs[camelToSnake(key)] = value;
+    }
+  }
+
+  return {
+    type: apiToolType,
+    ...mappedArgs,
+  };
+}
+
+/**
+ * Converts a camelCase string to snake_case.
+ */
+function camelToSnake(str: string): string {
+  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,6 @@
 import type { ProviderV3 } from '@ai-sdk/provider';
+import type { ProviderToolFactory } from '@ai-sdk/provider-utils';
+import type { Engine } from './types/openrouter-api-types';
 import type {
   OpenRouterChatModelId,
   OpenRouterChatSettings,
@@ -21,8 +23,22 @@ import { OpenRouterChatLanguageModel } from './chat';
 import { OpenRouterCompletionLanguageModel } from './completion';
 import { OpenRouterEmbeddingModel } from './embedding';
 import { OpenRouterImageModel } from './image';
+import { webSearch } from './tool/web-search';
 import { withUserAgentSuffix } from './utils/with-user-agent-suffix';
 import { VERSION } from './version';
+
+/**
+ * Configuration args for the web search provider tool.
+ * These are mapped to snake_case in the API request.
+ */
+type WebSearchToolArgs = {
+  /** Maximum number of search results to include */
+  maxResults?: number;
+  /** Custom search prompt to guide the search query */
+  searchPrompt?: string;
+  /** Search engine to use: 'auto', 'native', or 'exa' */
+  engine?: 'auto' | Engine;
+};
 
 export type { OpenRouterChatSettings, OpenRouterCompletionSettings };
 
@@ -85,6 +101,18 @@ Creates an OpenRouter image model for image generation.
     modelId: OpenRouterImageModelId,
     settings?: OpenRouterImageSettings,
   ): OpenRouterImageModel;
+
+  /**
+   * Provider-defined tools for OpenRouter server tools.
+   */
+  readonly tools: {
+    /**
+     * Creates an OpenRouter web search server tool.
+     *
+     * @see https://openrouter.ai/docs/guides/features/server-tools/web-search
+     */
+    webSearch: ProviderToolFactory<unknown, WebSearchToolArgs>;
+  };
 }
 
 export interface OpenRouterProviderSettings {
@@ -258,6 +286,9 @@ export function createOpenRouter(
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.embedding = createEmbeddingModel; // deprecated alias for v4 compatibility
   provider.imageModel = createImageModel;
+  provider.tools = {
+    webSearch: webSearch,
+  };
 
   return provider as OpenRouterProvider;
 }

--- a/src/tests/web-search-tool.test.ts
+++ b/src/tests/web-search-tool.test.ts
@@ -1,0 +1,319 @@
+import type { ModelMessage } from 'ai';
+
+import { createTestServer } from '@ai-sdk/test-server';
+import { streamText, tool } from 'ai';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { z } from 'zod/v4';
+import { createOpenRouter } from '../provider';
+
+const TEST_MESSAGES: ModelMessage[] = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+describe('web search provider tool', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: {
+        type: 'stream-chunks',
+        chunks: [],
+      },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('provider.tools.webSearch exists', () => {
+    it('should expose a webSearch tool factory on the provider', () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      expect(openrouter.tools).toBeDefined();
+      expect(openrouter.tools.webSearch).toBeDefined();
+      expect(typeof openrouter.tools.webSearch).toBe('function');
+    });
+  });
+
+  describe('provider tool in API request body', () => {
+    it('should map webSearch provider tool to openrouter:web_search in the tools array', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({}),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+          }),
+        ]),
+      );
+    });
+
+    it('should pass maxResults as max_results in the tool args', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({
+            maxResults: 5,
+          }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+            max_results: 5,
+          }),
+        ]),
+      );
+    });
+
+    it('should pass searchPrompt as search_prompt in the tool args', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({
+            searchPrompt: 'latest news',
+          }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+            search_prompt: 'latest news',
+          }),
+        ]),
+      );
+    });
+
+    it('should pass engine in the tool args', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({
+            engine: 'exa',
+          }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+            engine: 'exa',
+          }),
+        ]),
+      );
+    });
+
+    it('should pass all args together in the tool', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({
+            maxResults: 3,
+            searchPrompt: 'test query',
+            engine: 'native',
+          }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+            max_results: 3,
+            search_prompt: 'test query',
+            engine: 'native',
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle webSearch with no args (empty object)', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({}),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+          }),
+        ]),
+      );
+      // Should not have extra properties when no args are provided
+      const webSearchTool = body.tools.find(
+        (t: Record<string, unknown>) => t.type === 'openrouter:web_search',
+      );
+      expect(webSearchTool).toBeDefined();
+    });
+
+    it('should mix function tools and provider tools in the same request', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({}),
+          get_weather: tool({
+            description: 'Get weather for a location',
+            inputSchema: z.object({
+              location: z.string(),
+            }),
+          }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      // Should contain both the provider tool and the function tool
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+          }),
+          expect.objectContaining({
+            type: 'function',
+            function: expect.objectContaining({
+              name: 'get_weather',
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it('should default to tool_choice auto when only provider tools are present', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({}),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      // The AI SDK defaults toolChoice to 'auto' when tools are present
+      expect(body.tool_choice).toBe('auto');
+    });
+
+    it('should preserve existing plugins and web_search_options alongside provider tool', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o', {
+        plugins: [{ id: 'web' }],
+        web_search_options: { max_results: 10 },
+      });
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          web_search: openrouter.tools.webSearch({ maxResults: 5 }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      // Both the old settings and new provider tool should be present
+      expect(body.plugins).toEqual([{ id: 'web' }]);
+      expect(body.web_search_options).toEqual({ max_results: 10 });
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'openrouter:web_search',
+          }),
+        ]),
+      );
+    });
+
+    it('should send request with only function tools when no provider tools are present', async () => {
+      const openrouter = createOpenRouter({ apiKey: 'test' });
+      const model = openrouter('openai/gpt-4o');
+
+      await streamText({
+        model,
+        messages: TEST_MESSAGES,
+        tools: {
+          get_weather: tool({
+            description: 'Get weather',
+            inputSchema: z.object({
+              location: z.string(),
+            }),
+          }),
+        },
+      }).consumeStream();
+
+      const body = await server.calls[0]?.requestBodyJson;
+      expect(body.tools).toEqual([
+        expect.objectContaining({
+          type: 'function',
+          function: expect.objectContaining({
+            name: 'get_weather',
+            description: 'Get weather',
+          }),
+        }),
+      ]);
+      // Verify no provider tools leaked in
+      const providerTools = body.tools.filter(
+        (t: Record<string, unknown>) => t.type !== 'function',
+      );
+      expect(providerTools).toHaveLength(0);
+    });
+  });
+});

--- a/src/tool/web-search.ts
+++ b/src/tool/web-search.ts
@@ -1,0 +1,52 @@
+import type { Engine } from '../types/openrouter-api-types';
+
+import { createProviderToolFactory } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+/**
+ * Input schema for the OpenRouter web search server tool.
+ *
+ * @see https://openrouter.ai/docs/guides/features/server-tools/web-search
+ */
+const webSearchInputSchema = z.object({
+  /** Search results returned by the server tool */
+  results: z.array(z.unknown()).optional(),
+});
+
+type WebSearchInput = z.infer<typeof webSearchInputSchema>;
+
+/**
+ * Configuration args for the web search provider tool.
+ * These are mapped to snake_case in the API request.
+ */
+type WebSearchArgs = {
+  /** Maximum number of search results to include */
+  maxResults?: number;
+  /** Custom search prompt to guide the search query */
+  searchPrompt?: string;
+  /** Search engine to use: 'auto', 'native', or 'exa' */
+  engine?: 'auto' | Engine;
+};
+
+/**
+ * Creates the `openrouter.tools.webSearch` provider tool factory.
+ *
+ * Usage:
+ * ```ts
+ * const openrouter = createOpenRouter();
+ * const result = await generateText({
+ *   model: openrouter('openai/gpt-4o'),
+ *   tools: {
+ *     web_search: openrouter.tools.webSearch({ maxResults: 5 }),
+ *   },
+ *   prompt: 'What are the latest news?',
+ * });
+ * ```
+ */
+export const webSearch = createProviderToolFactory<
+  WebSearchInput,
+  WebSearchArgs
+>({
+  id: 'openrouter.web_search',
+  inputSchema: webSearchInputSchema,
+});


### PR DESCRIPTION
## Description

Closes #474. Adds provider-defined tool support to the OpenRouter AI SDK provider, starting with `openrouter:web_search`.

Previously, `getArgs()` in `src/chat/index.ts` filtered tools to only `type === 'function'`, silently discarding any `LanguageModelV3ProviderTool`. This PR:

1. **New `src/tool/web-search.ts`** — Web search tool factory using `createProviderToolFactory` from `@ai-sdk/provider-utils` with tool ID `openrouter.web_search`
2. **Updated `src/provider.ts`** — Adds `tools.webSearch` to the `OpenRouterProvider` interface and factory
3. **Updated `src/chat/index.ts`** — Replaces the function-tools-only filter with a loop that handles both `function` and `provider` tool types. Adds `mapProviderTool()` (converts `openrouter.web_search` → `openrouter:web_search`) and `camelToSnake()` helpers.

**Before:**
```ts
// No way to use provider tools — they were silently dropped
```

**After:**
```ts
const openrouter = createOpenRouter();
const result = await generateText({
  model: openrouter('openai/gpt-4o'),
  tools: {
    web_search: openrouter.tools.webSearch({ maxResults: 5, searchPrompt: 'query', engine: 'exa' }),
  },
  prompt: 'What are the latest news?',
});
```

Existing `plugins` and `web_search_options` model settings remain fully functional alongside the new provider tool.

### Reviewer notes

- `WebSearchArgs` type is defined in both `src/tool/web-search.ts` and `src/provider.ts` — verify these stay in sync (the provider interface one is used for the public `ProviderToolFactory` type parameter)
- `tool.id.split('.')` in `mapProviderTool` assumes a single dot separator — safe given the AI SDK's `${string}.${string}` type constraint, but worth verifying
- `camelToSnake()` uses a simple regex that handles `maxResults` → `max_results` correctly but would mangle consecutive uppercase letters (e.g. `maxURLResults`). Fine for the current arg set but would need revisiting if args with acronyms are added
- Tools that are neither `function` nor `provider` (e.g. `dynamic`) are silently skipped — same behavior as before for unknown types
- The e2e tests hit the live OpenRouter API and require `OPENROUTER_API_KEY` / `OPENROUTER_API_BASE` env vars

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass (370/370)
- [x] I have added tests for my changes (11 unit tests + 4 e2e tests)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file (minor)

Link to Devin session: https://app.devin.ai/sessions/9f20494f08f14fadaf9a47fd2fbd6916
Requested by: @robert-j-y