### PR TITLE
fix: stop attaching accumulated reasoning_details to reasoning-delta events (#413)

### DIFF
--- a/.changeset/fix-413-reasoning-metadata-bloat.md
+++ b/.changeset/fix-413-reasoning-metadata-bloat.md
@@ -1,0 +1,13 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+fix: stop attaching accumulated reasoning_details to reasoning-delta events (#413)
+
+Previously, each reasoning-delta chunk carried a full snapshot of all
+accumulatedReasoningDetails in its providerMetadata. For N reasoning
+chunks, this caused O(N²) total payload size.
+
+reasoning-start and reasoning-delta events no longer carry providerMetadata.
+The full accumulated reasoning_details are still available on reasoning-end,
+tool-call, and finish events (unchanged).

--- a/e2e/issues/issue-413-reasoning-metadata-bloat.test.ts
+++ b/e2e/issues/issue-413-reasoning-metadata-bloat.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Regression test for GitHub issue #413 (reasoning metadata bloat)
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/413
+ *
+ * Issue: Each reasoning-delta SSE event carried a full snapshot of all
+ * accumulatedReasoningDetails in its providerMetadata. For N reasoning
+ * chunks, total serialized payload grew O(N²) instead of O(N).
+ *
+ * Fix: reasoning-start and reasoning-delta events no longer carry
+ * providerMetadata. The full accumulated reasoning_details are still
+ * available on reasoning-end, tool-call, and finish events.
+ */
+import type {
+  LanguageModelV3Prompt,
+  LanguageModelV3StreamPart,
+} from '@ai-sdk/provider';
+
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { createOpenRouter } from '@/src';
+import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
+
+vi.mock('@/src/version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const TEST_PROMPT: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Think step by step.' }] },
+];
+
+const provider = createOpenRouter({
+  apiKey: 'test-api-key',
+  compatibility: 'strict',
+});
+
+describe('Issue #413: reasoning metadata bloat in streaming', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  /**
+   * Build SSE chunks that simulate N reasoning_details deltas followed by
+   * a text delta and a finish event.
+   */
+  function buildReasoningChunks(count: number): string[] {
+    const id = 'chatcmpl-413-bloat';
+    const base = `"object":"chat.completion.chunk","created":1711357598,"model":"anthropic/claude-3.5-sonnet","system_fingerprint":"fp_test"`;
+    const chunks: string[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const isFirst = i === 0;
+      const rolePart = isFirst ? `"role":"assistant","content":"",` : '';
+      chunks.push(
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{${rolePart}"reasoning_details":[{"type":"${ReasoningDetailType.Text}","text":"Step ${i + 1}. "}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+      );
+    }
+
+    // Text content delta
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"content":"The answer is 42."},"logprobs":null,"finish_reason":null}]}\n\n`,
+    );
+
+    // Finish
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}\n\n`,
+    );
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":${count + 5},"total_tokens":${count + 15}}}\n\n`,
+    );
+    chunks.push('data: [DONE]\n\n');
+
+    return chunks;
+  }
+
+  it('should not attach providerMetadata to reasoning-delta events', async () => {
+    const N = 20;
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildReasoningChunks(N),
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const reasoningDeltas = elements.filter(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-delta',
+    );
+
+    expect(reasoningDeltas).toHaveLength(N);
+
+    // No reasoning-delta should carry providerMetadata
+    for (const delta of reasoningDeltas) {
+      expect(delta.providerMetadata).toBeUndefined();
+    }
+  });
+
+  it('should not attach providerMetadata to reasoning-start events', async () => {
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildReasoningChunks(5),
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const reasoningStart = elements.find(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-start',
+    );
+
+    expect(reasoningStart).toBeDefined();
+    expect(reasoningStart?.providerMetadata).toBeUndefined();
+  });
+
+  it('should preserve accumulated reasoning_details on reasoning-end', async () => {
+    const N = 5;
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildReasoningChunks(N),
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const reasoningEnd = elements.find(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-end',
+    );
+
+    expect(reasoningEnd).toBeDefined();
+    expect(reasoningEnd?.providerMetadata).toBeDefined();
+
+    const details = (
+      reasoningEnd?.providerMetadata?.openrouter as {
+        reasoning_details?: Array<{ type: string; text?: string }>;
+      }
+    )?.reasoning_details;
+
+    // All N reasoning chunks should be merged into accumulated details
+    expect(details).toBeDefined();
+    // Consecutive text details are merged, so we get 1 merged entry
+    expect(details).toHaveLength(1);
+    expect(details?.[0]?.type).toBe(ReasoningDetailType.Text);
+  });
+
+  it('should preserve accumulated reasoning_details on finish event', async () => {
+    const N = 5;
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildReasoningChunks(N),
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const finishEvent = elements.find(
+      (el: LanguageModelV3StreamPart) => el.type === 'finish',
+    );
+
+    expect(finishEvent).toBeDefined();
+    expect(finishEvent?.providerMetadata).toBeDefined();
+
+    const details = (
+      finishEvent?.providerMetadata?.openrouter as {
+        reasoning_details?: Array<{ type: string; text?: string }>;
+      }
+    )?.reasoning_details;
+
+    expect(details).toBeDefined();
+    // Consecutive text details are merged
+    expect(details).toHaveLength(1);
+    expect(details?.[0]?.type).toBe(ReasoningDetailType.Text);
+  });
+
+  it('should produce total payload proportional to N, not N²', async () => {
+    const N = 20;
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildReasoningChunks(N),
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    // Serialize all stream parts to measure total payload size
+    const totalBytes = elements.reduce(
+      (sum: number, el: LanguageModelV3StreamPart) =>
+        sum + JSON.stringify(el).length,
+      0,
+    );
+
+    // With the fix, total size should be roughly linear in N.
+    // Each reasoning-delta is ~80 bytes, plus overhead for start/end/finish/text.
+    // A generous linear threshold: 300 * N bytes should be plenty.
+    // Before the fix, 20 chunks produced ~10,500 bytes (quadratic).
+    // After the fix, 20 chunks produce ~3,000 bytes (linear).
+    const linearThreshold = 300 * N;
+    expect(totalBytes).toBeLessThan(linearThreshold);
+  });
+
+  it('should handle single reasoning chunk without metadata bloat', async () => {
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildReasoningChunks(1),
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const reasoningDeltas = elements.filter(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-delta',
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas[0]?.providerMetadata).toBeUndefined();
+
+    // reasoning-end should still have metadata
+    const reasoningEnd = elements.find(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-end',
+    );
+    expect(reasoningEnd?.providerMetadata).toBeDefined();
+  });
+
+  it('should handle mixed reasoning detail types without metadata on deltas', async () => {
+    const id = 'chatcmpl-413-mixed';
+    const base = `"object":"chat.completion.chunk","created":1711357598,"model":"anthropic/claude-3.5-sonnet","system_fingerprint":"fp_test"`;
+
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: [
+        // Text reasoning
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_details":[{"type":"${ReasoningDetailType.Text}","text":"Thinking..."}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+        // Summary reasoning
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":"Summarized thought"}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+        // Encrypted reasoning (no delta emitted, just accumulated)
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Encrypted}","data":"opaque"}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+        // Text content
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"content":"Done."},"logprobs":null,"finish_reason":null}]}\n\n`,
+        // Finish
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}\n\n`,
+        `data: {"id":"${id}",${base},"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":15,"total_tokens":25}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const model = provider.chat('anthropic/claude-3.5-sonnet');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    // Text + Summary produce deltas; Encrypted does not
+    const reasoningDeltas = elements.filter(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-delta',
+    );
+    expect(reasoningDeltas).toHaveLength(2);
+
+    // No delta should carry providerMetadata
+    for (const delta of reasoningDeltas) {
+      expect(delta.providerMetadata).toBeUndefined();
+    }
+
+    // reasoning-end should have all 3 types accumulated
+    const reasoningEnd = elements.find(
+      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-end',
+    );
+    const details = (
+      reasoningEnd?.providerMetadata?.openrouter as {
+        reasoning_details?: Array<{ type: string }>;
+      }
+    )?.reasoning_details;
+
+    expect(details).toHaveLength(3);
+  });
+});

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1614,43 +1614,13 @@ describe('doStream', () => {
     expect(reasoningDeltas).not.toContain('This should be ignored...');
     expect(reasoningDeltas).not.toContain('Also ignored');
 
-    // Verify that reasoning-delta chunks include providerMetadata with reasoning_details
+    // reasoning-delta events should NOT carry providerMetadata (fix for #413
+    // payload bloat). The full accumulated reasoning_details are available on
+    // reasoning-end, tool-call, and finish events instead.
     const reasoningDeltaElements = elements.filter(isReasoningDeltaPart);
 
-    // First delta should have reasoning_details from first chunk
-    expect(reasoningDeltaElements[0]?.providerMetadata).toEqual({
-      openrouter: {
-        reasoning_details: [
-          {
-            type: ReasoningDetailType.Text,
-            text: 'Let me think about this...',
-          },
-        ],
-      },
-    });
-
-    // Second delta (summary) has accumulated snapshot including encrypted
-    // (encrypted is accumulated but doesn't produce a delta)
-    expect(reasoningDeltaElements[1]?.providerMetadata).toEqual({
-      openrouter: {
-        reasoning_details: [
-          {
-            type: ReasoningDetailType.Text,
-            text: 'Let me think about this...',
-          },
-          {
-            type: ReasoningDetailType.Summary,
-            summary: 'User wants a greeting',
-          },
-          {
-            type: ReasoningDetailType.Encrypted,
-            data: 'secret',
-          },
-        ],
-      },
-    });
-
-    // Third delta (from reasoning field only) should not have providerMetadata
+    expect(reasoningDeltaElements[0]?.providerMetadata).toBeUndefined();
+    expect(reasoningDeltaElements[1]?.providerMetadata).toBeUndefined();
     expect(reasoningDeltaElements[2]?.providerMetadata).toBeUndefined();
   });
 
@@ -1696,33 +1666,11 @@ describe('doStream', () => {
     // Only 2 deltas: text + summary. Encrypted details don't produce deltas.
     expect(reasoningDeltaElements).toHaveLength(2);
 
-    // Verify each delta has the correct reasoning_details in providerMetadata
-    expect(reasoningDeltaElements[0]?.providerMetadata).toEqual({
-      openrouter: {
-        reasoning_details: [
-          {
-            type: ReasoningDetailType.Text,
-            text: 'First reasoning chunk',
-          },
-        ],
-      },
-    });
-
-    // Second delta has accumulated snapshot: text + summary
-    expect(reasoningDeltaElements[1]?.providerMetadata).toEqual({
-      openrouter: {
-        reasoning_details: [
-          {
-            type: ReasoningDetailType.Text,
-            text: 'First reasoning chunk',
-          },
-          {
-            type: ReasoningDetailType.Summary,
-            summary: 'Summary reasoning',
-          },
-        ],
-      },
-    });
+    // reasoning-delta events should NOT carry providerMetadata (fix for #413
+    // payload bloat). The full accumulated reasoning_details are available on
+    // reasoning-end and finish events instead.
+    expect(reasoningDeltaElements[0]?.providerMetadata).toBeUndefined();
+    expect(reasoningDeltaElements[1]?.providerMetadata).toBeUndefined();
 
     // Encrypted data is still accumulated and available in reasoning-end
     const reasoningEnd = elements.find((el) => el.type === 'reasoning-end');
@@ -1745,19 +1693,9 @@ describe('doStream', () => {
       },
     });
 
-    // Verify reasoning-start also has providerMetadata when first delta includes it
+    // reasoning-start should NOT carry providerMetadata (fix for #413 payload bloat)
     const reasoningStart = elements.find(isReasoningStartPart);
-
-    expect(reasoningStart?.providerMetadata).toEqual({
-      openrouter: {
-        reasoning_details: [
-          {
-            type: ReasoningDetailType.Text,
-            text: 'First reasoning chunk',
-          },
-        ],
-      },
-    });
+    expect(reasoningStart?.providerMetadata).toBeUndefined();
   });
 
   it('should not emit reasoning events when only encrypted details arrive in stream', async () => {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -9,7 +9,6 @@ import type {
   LanguageModelV3StreamPart,
   LanguageModelV3Usage,
   SharedV3Headers,
-  SharedV3ProviderMetadata,
   SharedV3Warning,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
@@ -740,21 +739,16 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
 
             const delta = choice.delta;
 
-            const emitReasoningChunk = (
-              chunkText: string,
-              providerMetadata?: SharedV3ProviderMetadata,
-            ) => {
+            const emitReasoningChunk = (chunkText: string) => {
               if (!reasoningStarted) {
                 reasoningId = generateId();
                 controller.enqueue({
-                  providerMetadata,
                   type: 'reasoning-start',
                   id: reasoningId,
                 });
                 reasoningStarted = true;
               }
               controller.enqueue({
-                providerMetadata,
                 type: 'reasoning-delta',
                 delta: chunkText,
                 id: reasoningId || generateId(),
@@ -796,24 +790,13 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               // start a new reasoning block — doing so would create duplicate
               // reasoning parts in the UIMessage.
               if (!textStarted) {
-                // Emit a snapshot of accumulated reasoning_details in providerMetadata
-                // so downstream consumers always see the full reasoning history
-                // (including signatures that arrive in later deltas).
-                const reasoningMetadata: SharedV3ProviderMetadata = {
-                  openrouter: {
-                    reasoning_details: accumulatedReasoningDetails.map((d) => ({
-                      ...d,
-                    })),
-                  },
-                };
-
                 for (const detail of delta.reasoning_details) {
                   switch (detail.type) {
                     case ReasoningDetailType.Text: {
                       // Emit even when detail.text is empty/undefined — a signature-only
                       // delta (no text, just signature) must still be emitted so that
                       // the signature propagates to the reasoning part's providerMetadata.
-                      emitReasoningChunk(detail.text || '', reasoningMetadata);
+                      emitReasoningChunk(detail.text || '');
                       break;
                     }
                     case ReasoningDetailType.Encrypted: {
@@ -825,7 +808,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                     }
                     case ReasoningDetailType.Summary: {
                       if (detail.summary) {
-                        emitReasoningChunk(detail.summary, reasoningMetadata);
+                        emitReasoningChunk(detail.summary);
                       }
                       break;
                     }


### PR DESCRIPTION
## Summary

Fixes #413 — reasoning metadata O(N²) payload bloat.

### Problem

Each `reasoning-delta` SSE event carried a full snapshot of all `accumulatedReasoningDetails` in its `providerMetadata`. For N reasoning chunks, total serialized payload grew **O(N²)** instead of O(N).

For example, with 20 reasoning chunks the total payload was 10,537 bytes — well above the 6,000-byte linear threshold (300 bytes × 20 chunks).

### Fix

`reasoning-start` and `reasoning-delta` events no longer carry `providerMetadata`. The full accumulated `reasoning_details` are still available on `reasoning-end`, `tool-call`, and `finish` events (unchanged).

### Before / After

**Before:** Every `reasoning-delta` included a growing snapshot:
```
reasoning-delta { delta: "chunk 1", providerMetadata: { reasoning_details: [detail1] } }
reasoning-delta { delta: "chunk 2", providerMetadata: { reasoning_details: [detail1, detail2] } }
reasoning-delta { delta: "chunk 3", providerMetadata: { reasoning_details: [detail1, detail2, detail3] } }
// ... O(N²) total payload
```

**After:** Deltas carry only the text:
```
reasoning-delta { delta: "chunk 1" }
reasoning-delta { delta: "chunk 2" }
reasoning-delta { delta: "chunk 3" }
// reasoning_details still available on reasoning-end and finish events
```

### Changes

- `src/chat/index.ts` — Removed `providerMetadata` parameter from `emitReasoningChunk`, removed snapshot creation
- `src/chat/index.test.ts` — Updated 3 test expectations to verify `providerMetadata` is `undefined` on reasoning-delta/start events
- `e2e/issues/issue-413-reasoning-metadata-bloat.test.ts` — 7 new regression tests
- `.changeset/fix-413-reasoning-metadata-bloat.md` — Patch changeset

### Test Results

- Unit tests: 400 passed
- Regression tests (issue-413): 7/7 passed
- `pnpm stylecheck`: passed
- `pnpm typecheck`: passed

### Human Review Checklist

- [ ] Verify that consumers relying on `providerMetadata` from `reasoning-delta` events are not broken (this was undocumented behavior)
- [ ] Confirm `reasoning-end` and `finish` events still carry the full `reasoning_details`
- [ ] Check that multi-turn reasoning with tool calls still works correctly

---

*Generated by [Devin](https://app.devin.ai/sessions/479bba50be784e36a5b12c23b9c7a1b6)*