### PR TITLE
feat: add video generation support (VideoModelV3)

### DIFF
--- a/.changeset/video-generation-support.md
+++ b/.changeset/video-generation-support.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': minor
+---
+
+Add video generation support via `provider.videoModel()` implementing the `Experimental_VideoModelV3` interface. Supports text-to-video and image-to-video generation with configurable aspect ratio, resolution, duration, seed, audio generation, and provider options passthrough.

--- a/e2e/video-generation.test.ts
+++ b/e2e/video-generation.test.ts
@@ -1,0 +1,43 @@
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+vi.setConfig({
+  testTimeout: 300_000,
+});
+
+describe('video generation', () => {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+  });
+
+  // Video content URLs require auth, so we provide a custom download function
+  async function download({ url }: { url: URL }) {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+      },
+    });
+    return {
+      data: new Uint8Array(await response.arrayBuffer()),
+      mediaType: response.headers.get('content-type') ?? undefined,
+    };
+  }
+
+  it('should generate a video from a text prompt', async () => {
+    const result = await generateVideo({
+      model: openrouter.videoModel('google/veo-3.1', {
+        pollIntervalMs: 5000,
+      }),
+      prompt: 'A slow pan across a calm mountain lake at sunrise',
+      aspectRatio: '16:9',
+      duration: 4,
+      download,
+    });
+
+    expect(result.videos.length).toBeGreaterThanOrEqual(1);
+    expect(result.video.uint8Array.byteLength).toBeGreaterThan(0);
+    expect(result.video.mediaType).toBe('video/mp4');
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/provider": "3.0.0",
+    "@ai-sdk/provider": "3.0.8",
     "@ai-sdk/provider-utils": "4.0.1",
     "@ai-sdk/test-server": "1.0.3",
     "@biomejs/biome": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "3.0.8",
-    "@ai-sdk/provider-utils": "4.0.1",
+    "@ai-sdk/provider-utils": "4.0.23",
     "@ai-sdk/test-server": "1.0.3",
     "@biomejs/biome": "2.3.7",
     "@changesets/changelog-github": "0.5.1",
@@ -56,7 +56,7 @@
     "@edge-runtime/vm": "5.0.0",
     "@types/json-schema": "7.0.15",
     "@types/node": "24.2.0",
-    "ai": "6.0.3",
+    "ai": "6.0.162",
     "dotenv": "17.2.1",
     "msw": "2.12.4",
     "tsup": "8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: 3.0.8
         version: 3.0.8
       '@ai-sdk/provider-utils':
-        specifier: 4.0.1
-        version: 4.0.1(zod@4.3.5)
+        specifier: 4.0.23
+        version: 4.0.23(zod@4.3.5)
       '@ai-sdk/test-server':
         specifier: 1.0.3
         version: 1.0.3(@types/node@24.2.0)(typescript@5.9.2)
@@ -44,8 +44,8 @@ importers:
         specifier: 24.2.0
         version: 24.2.0
       ai:
-        specifier: 6.0.3
-        version: 6.0.3(zod@4.3.5)
+        specifier: 6.0.162
+        version: 6.0.162(zod@4.3.5)
       dotenv:
         specifier: 17.2.1
         version: 17.2.1
@@ -67,21 +67,17 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.2':
-    resolution: {integrity: sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw==}
+  '@ai-sdk/gateway@3.0.99':
+    resolution: {integrity: sha512-8/UuzFY8p+T8j4XP/9m841pUb5bhnFt8cecSnJpd2zhBttNZ6GbfjZTmsqnvM/RwJOvzIsdFULZrU+E9QFREsQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.1':
-    resolution: {integrity: sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ==}
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@3.0.0':
-    resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
-    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -770,8 +766,8 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
-  '@vercel/oidc@3.0.5':
-    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vitest/expect@3.2.4':
@@ -808,8 +804,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.3:
-    resolution: {integrity: sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==}
+  ai@6.0.162:
+    resolution: {integrity: sha512-1PSvNEK1PEbpUXahnFrcey6l7DJXMVWmg0ibQ8h8oMSe9V1Vx5d+R3xNu0hzBtwqfxYj21ddZo+EUYVs6GOEyA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1654,23 +1650,19 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.2(zod@4.3.5)':
+  '@ai-sdk/gateway@3.0.99(zod@4.3.5)':
     dependencies:
-      '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.1(zod@4.3.5)
-      '@vercel/oidc': 3.0.5
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.5)
+      '@vercel/oidc': 3.1.0
       zod: 4.3.5
 
-  '@ai-sdk/provider-utils@4.0.1(zod@4.3.5)':
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.5)':
     dependencies:
-      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.5
-
-  '@ai-sdk/provider@3.0.0':
-    dependencies:
-      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -2234,7 +2226,7 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
-  '@vercel/oidc@3.0.5': {}
+  '@vercel/oidc@3.1.0': {}
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -2281,11 +2273,11 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@6.0.3(zod@4.3.5):
+  ai@6.0.162(zod@4.3.5):
     dependencies:
-      '@ai-sdk/gateway': 3.0.2(zod@4.3.5)
-      '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.1(zod@4.3.5)
+      '@ai-sdk/gateway': 3.0.99(zod@4.3.5)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.5)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         version: 4.3.5
     devDependencies:
       '@ai-sdk/provider':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 3.0.8
+        version: 3.0.8
       '@ai-sdk/provider-utils':
         specifier: 4.0.1
         version: 4.0.1(zod@4.3.5)
@@ -81,6 +81,10 @@ packages:
 
   '@ai-sdk/provider@3.0.0':
     resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/test-server@1.0.3':
@@ -1665,6 +1669,10 @@ snapshots:
       zod: 4.3.5
 
   '@ai-sdk/provider@3.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -6,3 +6,5 @@ export * from '../types';
 export * from '../types/openrouter-chat-settings';
 export * from '../types/openrouter-completion-settings';
 export * from '../types/openrouter-image-settings';
+export * from '../types/openrouter-video-settings';
+export * from '../video';

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,6 +17,10 @@ import type {
   OpenRouterImageModelId,
   OpenRouterImageSettings,
 } from './types/openrouter-image-settings';
+import type {
+  OpenRouterVideoModelId,
+  OpenRouterVideoSettings,
+} from './types/openrouter-video-settings';
 
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils';
 import { OpenRouterChatLanguageModel } from './chat';
@@ -26,6 +30,7 @@ import { OpenRouterImageModel } from './image';
 import { webSearch } from './tool/web-search';
 import { withUserAgentSuffix } from './utils/with-user-agent-suffix';
 import { VERSION } from './version';
+import { OpenRouterVideoModel } from './video';
 
 /**
  * Configuration args for the web search provider tool.
@@ -101,6 +106,14 @@ Creates an OpenRouter image model for image generation.
     modelId: OpenRouterImageModelId,
     settings?: OpenRouterImageSettings,
   ): OpenRouterImageModel;
+
+  /**
+Creates an OpenRouter video model for video generation.
+   */
+  videoModel(
+    modelId: OpenRouterVideoModelId,
+    settings?: OpenRouterVideoSettings,
+  ): OpenRouterVideoModel;
 
   /**
    * Provider-defined tools for OpenRouter server tools.
@@ -255,6 +268,18 @@ export function createOpenRouter(
       extraBody: options.extraBody,
     });
 
+  const createVideoModel = (
+    modelId: OpenRouterVideoModelId,
+    settings: OpenRouterVideoSettings = {},
+  ) =>
+    new OpenRouterVideoModel(modelId, settings, {
+      provider: 'openrouter.video',
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+      extraBody: options.extraBody,
+    });
+
   const createLanguageModel = (
     modelId: OpenRouterChatModelId | OpenRouterCompletionModelId,
     settings?: OpenRouterChatSettings | OpenRouterCompletionSettings,
@@ -286,6 +311,7 @@ export function createOpenRouter(
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.embedding = createEmbeddingModel; // deprecated alias for v4 compatibility
   provider.imageModel = createImageModel;
+  provider.videoModel = createVideoModel;
   provider.tools = {
     webSearch: webSearch,
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export type { LanguageModelV3, LanguageModelV3Prompt };
 
 export * from './openrouter-embedding-settings';
 export * from './openrouter-image-settings';
+export * from './openrouter-video-settings';
 
 export type OpenRouterProviderOptions = {
   models?: string[];

--- a/src/types/openrouter-video-settings.ts
+++ b/src/types/openrouter-video-settings.ts
@@ -1,0 +1,27 @@
+// https://openrouter.ai/api/v1/models
+export type OpenRouterVideoModelId = string;
+
+export type OpenRouterVideoSettings = {
+  /**
+   * Whether to generate audio alongside the video.
+   * Defaults to the endpoint's generate_audio capability flag, false if not set.
+   */
+  generateAudio?: boolean;
+
+  /**
+   * Polling interval in milliseconds when waiting for video generation to complete.
+   * @default 2000
+   */
+  pollIntervalMs?: number;
+
+  /**
+   * Maximum time in milliseconds to wait for video generation to complete.
+   * @default 600000 (10 minutes)
+   */
+  maxPollTimeMs?: number;
+
+  /**
+   * Additional body parameters to send with the video generation request.
+   */
+  extraBody?: Record<string, unknown>;
+};

--- a/src/types/openrouter-video-settings.ts
+++ b/src/types/openrouter-video-settings.ts
@@ -1,4 +1,3 @@
-// https://openrouter.ai/api/v1/models
 export type OpenRouterVideoModelId = string;
 
 export type OpenRouterVideoSettings = {

--- a/src/video/index.test.ts
+++ b/src/video/index.test.ts
@@ -33,10 +33,7 @@ function createPollResponse(
 
 function createMockFetchSequence(responses: Array<Record<string, unknown>>) {
   let callIndex = 0;
-  return async (
-    _url: URL | RequestInfo,
-    _init?: RequestInit,
-  ): Promise<Response> => {
+  return async (): Promise<Response> => {
     const response = responses[callIndex]!;
     callIndex++;
     return new Response(JSON.stringify(response), {
@@ -72,19 +69,13 @@ function createCapturingMockFetch(responses: Array<Record<string, unknown>>) {
     });
   };
 
-  return {
-    fetch,
-    get capturedRequests() {
-      return capturedRequests;
-    },
-  };
+  return { fetch, capturedRequests };
 }
 
 describe('OpenRouterVideoModel', () => {
   describe('provider methods', () => {
     it('should expose videoModel method', () => {
       const provider = createOpenRouter({ apiKey: 'test-key' });
-      expect(provider.videoModel).toBeDefined();
       expect(typeof provider.videoModel).toBe('function');
     });
 
@@ -376,10 +367,7 @@ describe('OpenRouterVideoModel', () => {
       const jobId = 'job-test-timeout';
 
       let callCount = 0;
-      const fetchThatNeverCompletes = async (
-        _url: URL | RequestInfo,
-        _init?: RequestInit,
-      ): Promise<Response> => {
+      const fetchThatNeverCompletes = async (): Promise<Response> => {
         callCount++;
         const response =
           callCount === 1
@@ -448,48 +436,6 @@ describe('OpenRouterVideoModel', () => {
           generationId: 'gen-test-123',
           cost: 1.25,
         },
-      });
-    });
-
-    it('should apply runtime providerOptions.openrouter to request', async () => {
-      const jobId = 'job-test-options';
-      const mock = createCapturingMockFetch([
-        createSubmitResponse(jobId),
-        createPollResponse(jobId, 'completed', {
-          unsigned_urls: ['https://example.com/video.mp4'],
-        }),
-      ]);
-
-      const provider = createOpenRouter({
-        apiKey: 'test-key',
-        fetch: mock.fetch,
-      });
-      const model = provider.videoModel('google/veo-3.1', {
-        pollIntervalMs: 10,
-      });
-
-      await model.doGenerate({
-        prompt: 'A cat',
-        n: 1,
-        aspectRatio: undefined,
-        resolution: undefined,
-        duration: undefined,
-        fps: undefined,
-        seed: undefined,
-        image: undefined,
-        providerOptions: {
-          openrouter: {
-            custom_field: 'test_value',
-            provider: {
-              order: ['google'],
-            },
-          },
-        },
-      });
-
-      expect(mock.capturedRequests[0]!.body?.custom_field).toBe('test_value');
-      expect(mock.capturedRequests[0]!.body?.provider).toEqual({
-        order: ['google'],
       });
     });
 

--- a/src/video/index.test.ts
+++ b/src/video/index.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it } from 'vitest';
+import { createOpenRouter } from '../provider';
+import { OpenRouterVideoModel } from './index';
+
+function createSubmitResponse(jobId: string) {
+  return {
+    id: jobId,
+    generation_id: 'gen-test-123',
+    polling_url: `/api/v1/videos/${jobId}`,
+    status: 'pending',
+  };
+}
+
+function createPollResponse(
+  jobId: string,
+  status: string,
+  options?: {
+    unsigned_urls?: string[];
+    error?: string;
+    usage?: { cost?: number; is_byok?: boolean };
+  },
+) {
+  return {
+    id: jobId,
+    generation_id: 'gen-test-123',
+    polling_url: `/api/v1/videos/${jobId}`,
+    status,
+    ...(options?.unsigned_urls && { unsigned_urls: options.unsigned_urls }),
+    ...(options?.error && { error: options.error }),
+    ...(options?.usage && { usage: options.usage }),
+  };
+}
+
+function createMockFetchSequence(responses: Array<Record<string, unknown>>) {
+  let callIndex = 0;
+  return async (
+    _url: URL | RequestInfo,
+    _init?: RequestInit,
+  ): Promise<Response> => {
+    const response = responses[callIndex]!;
+    callIndex++;
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+}
+
+function createCapturingMockFetch(responses: Array<Record<string, unknown>>) {
+  let callIndex = 0;
+  const capturedRequests: Array<{
+    url: string;
+    method: string;
+    body: Record<string, unknown> | undefined;
+  }> = [];
+
+  const fetch = async (
+    url: URL | RequestInfo,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const bodyText = init?.body as string | undefined;
+    capturedRequests.push({
+      url: url.toString(),
+      method: init?.method ?? 'POST',
+      body: bodyText ? JSON.parse(bodyText) : undefined,
+    });
+    const response = responses[callIndex]!;
+    callIndex++;
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  return {
+    fetch,
+    get capturedRequests() {
+      return capturedRequests;
+    },
+  };
+}
+
+describe('OpenRouterVideoModel', () => {
+  describe('provider methods', () => {
+    it('should expose videoModel method', () => {
+      const provider = createOpenRouter({ apiKey: 'test-key' });
+      expect(provider.videoModel).toBeDefined();
+      expect(typeof provider.videoModel).toBe('function');
+    });
+
+    it('should create a video model instance', () => {
+      const provider = createOpenRouter({ apiKey: 'test-key' });
+      const model = provider.videoModel('google/veo-3.1');
+      expect(model).toBeInstanceOf(OpenRouterVideoModel);
+      expect(model.modelId).toBe('google/veo-3.1');
+      expect(model.provider).toBe('openrouter');
+      expect(model.specificationVersion).toBe('v3');
+    });
+
+    it('should have maxVideosPerCall set to 1', () => {
+      const provider = createOpenRouter({ apiKey: 'test-key' });
+      const model = provider.videoModel('google/veo-3.1');
+      expect(model.maxVideosPerCall).toBe(1);
+    });
+  });
+
+  describe('doGenerate', () => {
+    it('should submit and poll until complete, returning video URLs', async () => {
+      const jobId = 'job-test-123';
+      const videoUrl = 'https://storage.example.com/video.mp4';
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: createMockFetchSequence([
+          createSubmitResponse(jobId),
+          createPollResponse(jobId, 'pending'),
+          createPollResponse(jobId, 'completed', {
+            unsigned_urls: [videoUrl],
+            usage: { cost: 0.5 },
+          }),
+        ]),
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      const result = await model.doGenerate({
+        prompt: 'A cat playing piano',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0]).toEqual({
+        type: 'url',
+        url: videoUrl,
+        mediaType: 'video/mp4',
+      });
+      expect(result.warnings).toEqual([]);
+      expect(result.response.modelId).toBe('google/veo-3.1');
+    });
+
+    it('should pass prompt, aspect_ratio, duration, and seed in the request body', async () => {
+      const jobId = 'job-test-456';
+      const mock = createCapturingMockFetch([
+        createSubmitResponse(jobId),
+        createPollResponse(jobId, 'completed', {
+          unsigned_urls: ['https://example.com/video.mp4'],
+        }),
+      ]);
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      await model.doGenerate({
+        prompt: 'Mountain landscape at sunset',
+        n: 1,
+        aspectRatio: '16:9',
+        resolution: '1280x720',
+        duration: 8,
+        fps: undefined,
+        seed: 42,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      const submitRequest = mock.capturedRequests[0]!;
+      expect(submitRequest.body?.model).toBe('google/veo-3.1');
+      expect(submitRequest.body?.prompt).toBe('Mountain landscape at sunset');
+      expect(submitRequest.body?.aspect_ratio).toBe('16:9');
+      expect(submitRequest.body?.size).toBe('1280x720');
+      expect(submitRequest.body?.duration).toBe(8);
+      expect(submitRequest.body?.seed).toBe(42);
+    });
+
+    it('should pass generate_audio from settings', async () => {
+      const jobId = 'job-test-audio';
+      const mock = createCapturingMockFetch([
+        createSubmitResponse(jobId),
+        createPollResponse(jobId, 'completed', {
+          unsigned_urls: ['https://example.com/video.mp4'],
+        }),
+      ]);
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        generateAudio: true,
+        pollIntervalMs: 10,
+      });
+
+      await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      expect(mock.capturedRequests[0]!.body?.generate_audio).toBe(true);
+    });
+
+    it('should pass provider options via providerOptions.openrouter', async () => {
+      const jobId = 'job-test-routing';
+      const mock = createCapturingMockFetch([
+        createSubmitResponse(jobId),
+        createPollResponse(jobId, 'completed', {
+          unsigned_urls: ['https://example.com/video.mp4'],
+        }),
+      ]);
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {
+          openrouter: {
+            provider: {
+              options: {
+                'google-vertex': {
+                  output_config: { effort: 'low' },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(mock.capturedRequests[0]!.body?.provider).toEqual({
+        options: {
+          'google-vertex': {
+            output_config: { effort: 'low' },
+          },
+        },
+      });
+    });
+
+    it('should convert image input to frame_images', async () => {
+      const jobId = 'job-test-image';
+      const mock = createCapturingMockFetch([
+        createSubmitResponse(jobId),
+        createPollResponse(jobId, 'completed', {
+          unsigned_urls: ['https://example.com/video.mp4'],
+        }),
+      ]);
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      await model.doGenerate({
+        prompt: 'Animate this image',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: {
+          type: 'url',
+          url: 'https://example.com/first-frame.png',
+        },
+        providerOptions: {},
+      });
+
+      const body = mock.capturedRequests[0]!.body;
+      expect(body?.frame_images).toEqual([
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/first-frame.png' },
+          frame_type: 'first_frame',
+        },
+      ]);
+    });
+
+    it('should return warning when n > 1', async () => {
+      const jobId = 'job-test-n';
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: createMockFetchSequence([
+          createSubmitResponse(jobId),
+          createPollResponse(jobId, 'completed', {
+            unsigned_urls: ['https://example.com/video.mp4'],
+          }),
+        ]),
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      const result = await model.doGenerate({
+        prompt: 'A cat',
+        n: 3,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'n > 1',
+        details:
+          'OpenRouter video generation returns 1 video per call. Requested 3 videos.',
+      });
+    });
+
+    it('should throw when video generation fails', async () => {
+      const jobId = 'job-test-fail';
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: createMockFetchSequence([
+          createSubmitResponse(jobId),
+          createPollResponse(jobId, 'failed', {
+            error: 'Content policy violation',
+          }),
+        ]),
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      await expect(
+        model.doGenerate({
+          prompt: 'Something',
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          image: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow('Content policy violation');
+    });
+
+    it('should throw on timeout', async () => {
+      const jobId = 'job-test-timeout';
+
+      let callCount = 0;
+      const fetchThatNeverCompletes = async (
+        _url: URL | RequestInfo,
+        _init?: RequestInit,
+      ): Promise<Response> => {
+        callCount++;
+        const response =
+          callCount === 1
+            ? createSubmitResponse(jobId)
+            : createPollResponse(jobId, 'pending');
+        return new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      };
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: fetchThatNeverCompletes,
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+        maxPollTimeMs: 50,
+      });
+
+      await expect(
+        model.doGenerate({
+          prompt: 'A cat',
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          image: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow(/timed out/);
+    });
+
+    it('should include provider metadata with generation_id and cost', async () => {
+      const jobId = 'job-test-metadata';
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: createMockFetchSequence([
+          createSubmitResponse(jobId),
+          createPollResponse(jobId, 'completed', {
+            unsigned_urls: ['https://example.com/video.mp4'],
+            usage: { cost: 1.25 },
+          }),
+        ]),
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      const result = await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata).toEqual({
+        openrouter: {
+          generationId: 'gen-test-123',
+          cost: 1.25,
+        },
+      });
+    });
+
+    it('should apply runtime providerOptions.openrouter to request', async () => {
+      const jobId = 'job-test-options';
+      const mock = createCapturingMockFetch([
+        createSubmitResponse(jobId),
+        createPollResponse(jobId, 'completed', {
+          unsigned_urls: ['https://example.com/video.mp4'],
+        }),
+      ]);
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {
+          openrouter: {
+            custom_field: 'test_value',
+            provider: {
+              order: ['google'],
+            },
+          },
+        },
+      });
+
+      expect(mock.capturedRequests[0]!.body?.custom_field).toBe('test_value');
+      expect(mock.capturedRequests[0]!.body?.provider).toEqual({
+        order: ['google'],
+      });
+    });
+
+    it('should handle response with empty unsigned_urls', async () => {
+      const jobId = 'job-test-empty';
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: createMockFetchSequence([
+          createSubmitResponse(jobId),
+          createPollResponse(jobId, 'completed', {
+            unsigned_urls: [],
+          }),
+        ]),
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      const result = await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.videos).toEqual([]);
+    });
+
+    it('should handle multiple video URLs', async () => {
+      const jobId = 'job-test-multi';
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: createMockFetchSequence([
+          createSubmitResponse(jobId),
+          createPollResponse(jobId, 'completed', {
+            unsigned_urls: [
+              'https://example.com/video1.mp4',
+              'https://example.com/video2.mp4',
+            ],
+          }),
+        ]),
+      });
+      const model = provider.videoModel('google/veo-3.1', {
+        pollIntervalMs: 10,
+      });
+
+      const result = await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        image: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.videos).toHaveLength(2);
+      expect(result.videos[0]).toEqual({
+        type: 'url',
+        url: 'https://example.com/video1.mp4',
+        mediaType: 'video/mp4',
+      });
+      expect(result.videos[1]).toEqual({
+        type: 'url',
+        url: 'https://example.com/video2.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+  });
+});

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -1,0 +1,284 @@
+import type {
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+  Experimental_VideoModelV3 as VideoModelV3,
+  Experimental_VideoModelV3CallOptions as VideoModelV3CallOptions,
+  Experimental_VideoModelV3File as VideoModelV3File,
+  Experimental_VideoModelV3VideoData as VideoModelV3VideoData,
+} from '@ai-sdk/provider';
+import type {
+  OpenRouterVideoModelId,
+  OpenRouterVideoSettings,
+} from '../types/openrouter-video-settings';
+
+import { APICallError } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  getFromApi,
+  postJsonToApi,
+} from '@ai-sdk/provider-utils';
+import { openrouterFailedResponseHandler } from '../schemas/error-response';
+import {
+  VideoGenerationPollResponseSchema,
+  VideoGenerationSubmitResponseSchema,
+} from './schemas';
+
+type OpenRouterVideoConfig = {
+  provider: string;
+  headers: () => Record<string, string | undefined>;
+  url: (options: { modelId: string; path: string }) => string;
+  fetch?: typeof fetch;
+  extraBody?: Record<string, unknown>;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_MAX_POLL_TIME_MS = 600_000;
+
+export class OpenRouterVideoModel implements VideoModelV3 {
+  readonly specificationVersion = 'v3' as const;
+  readonly provider = 'openrouter';
+  readonly modelId: OpenRouterVideoModelId;
+  readonly settings: OpenRouterVideoSettings;
+  readonly maxVideosPerCall = 1;
+
+  private readonly config: OpenRouterVideoConfig;
+
+  constructor(
+    modelId: OpenRouterVideoModelId,
+    settings: OpenRouterVideoSettings,
+    config: OpenRouterVideoConfig,
+  ) {
+    this.modelId = modelId;
+    this.settings = settings;
+    this.config = config;
+  }
+
+  async doGenerate(options: VideoModelV3CallOptions): Promise<{
+    videos: Array<VideoModelV3VideoData>;
+    warnings: Array<SharedV3Warning>;
+    providerMetadata?: SharedV3ProviderMetadata;
+    response: {
+      timestamp: Date;
+      modelId: string;
+      headers: Record<string, string> | undefined;
+    };
+  }> {
+    const {
+      prompt,
+      n,
+      aspectRatio,
+      resolution,
+      duration,
+      seed,
+      image,
+      abortSignal,
+      headers,
+      providerOptions,
+    } = options;
+
+    const openrouterOptions =
+      (providerOptions?.openrouter as Record<string, unknown>) || {};
+
+    const warnings: SharedV3Warning[] = [];
+
+    if (n > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'n > 1',
+        details: `OpenRouter video generation returns 1 video per call. Requested ${n} videos.`,
+      });
+    }
+
+    const body: Record<string, unknown> = {
+      model: this.modelId,
+      prompt: prompt ?? '',
+      ...(aspectRatio !== undefined && { aspect_ratio: aspectRatio }),
+      ...(resolution !== undefined && { size: resolution }),
+      ...(duration !== undefined && { duration }),
+      ...(seed !== undefined && { seed }),
+      ...(this.settings.generateAudio !== undefined && {
+        generate_audio: this.settings.generateAudio,
+      }),
+      ...(image !== undefined && {
+        frame_images: [convertImageToFrameImage(image)],
+      }),
+      ...this.config.extraBody,
+      ...this.settings.extraBody,
+      ...openrouterOptions,
+    };
+
+    const mergedHeaders = combineHeaders(this.config.headers(), headers);
+
+    const { value: submitResponse, responseHeaders } = await postJsonToApi({
+      url: this.config.url({
+        path: '/videos',
+        modelId: this.modelId,
+      }),
+      headers: mergedHeaders,
+      body,
+      failedResponseHandler: openrouterFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        VideoGenerationSubmitResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const pollIntervalMs =
+      this.settings.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const maxPollTimeMs =
+      this.settings.maxPollTimeMs ?? DEFAULT_MAX_POLL_TIME_MS;
+
+    const pollResult = await this.pollUntilComplete({
+      jobId: submitResponse.id,
+      headers: mergedHeaders,
+      abortSignal,
+      pollIntervalMs,
+      maxPollTimeMs,
+    });
+
+    const videos: VideoModelV3VideoData[] = [];
+
+    if (pollResult.unsigned_urls) {
+      for (const url of pollResult.unsigned_urls) {
+        videos.push({
+          type: 'url',
+          url,
+          mediaType: 'video/mp4',
+        });
+      }
+    }
+
+    const providerMetadata: SharedV3ProviderMetadata = {
+      openrouter: {
+        generationId: pollResult.generation_id ?? null,
+        cost: pollResult.usage?.cost ?? null,
+      },
+    };
+
+    return {
+      videos,
+      warnings,
+      providerMetadata,
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: responseHeaders as Record<string, string> | undefined,
+      },
+    };
+  }
+
+  private async pollUntilComplete({
+    jobId,
+    headers,
+    abortSignal,
+    pollIntervalMs,
+    maxPollTimeMs,
+  }: {
+    jobId: string;
+    headers: Record<string, string | undefined>;
+    abortSignal?: AbortSignal;
+    pollIntervalMs: number;
+    maxPollTimeMs: number;
+  }): Promise<{
+    generation_id?: string;
+    unsigned_urls?: string[];
+    usage?: { cost?: number; is_byok?: boolean };
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < maxPollTimeMs) {
+      abortSignal?.throwIfAborted();
+
+      await delay(pollIntervalMs);
+
+      abortSignal?.throwIfAborted();
+
+      const { value: pollResponse } = await getFromApi({
+        url: this.config.url({
+          path: `/videos/${jobId}`,
+          modelId: this.modelId,
+        }),
+        headers,
+        failedResponseHandler: openrouterFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(
+          VideoGenerationPollResponseSchema,
+        ),
+        abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      if (pollResponse.status === 'completed') {
+        return {
+          generation_id: pollResponse.generation_id,
+          unsigned_urls: pollResponse.unsigned_urls,
+          usage: pollResponse.usage,
+        };
+      }
+
+      if (pollResponse.status === 'failed' || pollResponse.status === 'dead' || pollResponse.status === 'cancelled' || pollResponse.status === 'expired') {
+        throw new APICallError({
+          message:
+            pollResponse.error ??
+            `Video generation failed with status: ${pollResponse.status}`,
+          url: this.config.url({
+            path: `/videos/${jobId}`,
+            modelId: this.modelId,
+          }),
+          requestBodyValues: {},
+          statusCode: 500,
+          isRetryable: false,
+        });
+      }
+    }
+
+    throw new APICallError({
+      message: `Video generation timed out after ${maxPollTimeMs}ms`,
+      url: this.config.url({
+        path: `/videos/${jobId}`,
+        modelId: this.modelId,
+      }),
+      requestBodyValues: {},
+      statusCode: 408,
+      isRetryable: true,
+    });
+  }
+}
+
+function convertImageToFrameImage(
+  file: VideoModelV3File,
+): Record<string, unknown> {
+  if (file.type === 'url') {
+    return {
+      type: 'image_url',
+      image_url: { url: file.url },
+      frame_type: 'first_frame',
+    };
+  }
+
+  const data =
+    file.data instanceof Uint8Array ? uint8ArrayToBase64(file.data) : file.data;
+
+  const mediaType = file.mediaType ?? 'image/png';
+  const isDataUrl = typeof data === 'string' && data.startsWith('data:');
+  const url = isDataUrl ? data : `data:${mediaType};base64,${data}`;
+
+  return {
+    type: 'image_url',
+    image_url: { url },
+    frame_type: 'first_frame',
+  };
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -15,9 +15,11 @@ import { APICallError } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonResponseHandler,
+  delay,
   getFromApi,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
+import { buildFileDataUrl } from '../chat/file-url-utils';
 import { openrouterFailedResponseHandler } from '../schemas/error-response';
 import {
   VideoGenerationPollResponseSchema,
@@ -36,7 +38,7 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_MAX_POLL_TIME_MS = 600_000;
 
 export class OpenRouterVideoModel implements VideoModelV3 {
-  readonly specificationVersion = 'v3' as const;
+  readonly specificationVersion = 'v3';
   readonly provider = 'openrouter';
   readonly modelId: OpenRouterVideoModelId;
   readonly settings: OpenRouterVideoSettings;
@@ -164,7 +166,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       response: {
         timestamp: new Date(),
         modelId: this.modelId,
-        headers: responseHeaders as Record<string, string> | undefined,
+        headers: responseHeaders,
       },
     };
   }
@@ -262,28 +264,15 @@ function convertImageToFrameImage(
     };
   }
 
-  const data =
-    file.data instanceof Uint8Array ? uint8ArrayToBase64(file.data) : file.data;
-
-  const mediaType = file.mediaType ?? 'image/png';
-  const isDataUrl = typeof data === 'string' && data.startsWith('data:');
-  const url = isDataUrl ? data : `data:${mediaType};base64,${data}`;
+  const url = buildFileDataUrl({
+    data: file.data,
+    mediaType: file.mediaType,
+    defaultMediaType: 'image/png',
+  });
 
   return {
     type: 'image_url',
     image_url: { url },
     frame_type: 'first_frame',
   };
-}
-
-function uint8ArrayToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]!);
-  }
-  return btoa(binary);
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -79,9 +79,6 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       providerOptions,
     } = options;
 
-    const openrouterOptions =
-      (providerOptions?.openrouter as Record<string, unknown>) || {};
-
     const warnings: SharedV3Warning[] = [];
 
     if (n > 1) {
@@ -107,7 +104,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       }),
       ...this.config.extraBody,
       ...this.settings.extraBody,
-      ...openrouterOptions,
+      ...providerOptions.openrouter,
     };
 
     const mergedHeaders = combineHeaders(this.config.headers(), headers);

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -217,7 +217,12 @@ export class OpenRouterVideoModel implements VideoModelV3 {
         };
       }
 
-      if (pollResponse.status === 'failed' || pollResponse.status === 'dead' || pollResponse.status === 'cancelled' || pollResponse.status === 'expired') {
+      if (
+        pollResponse.status === 'failed' ||
+        pollResponse.status === 'dead' ||
+        pollResponse.status === 'cancelled' ||
+        pollResponse.status === 'expired'
+      ) {
         throw new APICallError({
           message:
             pollResponse.error ??

--- a/src/video/schemas.ts
+++ b/src/video/schemas.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod/v4';
+
+export const VideoGenerationSubmitResponseSchema = z
+  .object({
+    id: z.string(),
+    generation_id: z.string().optional(),
+    polling_url: z.string(),
+    status: z.string(),
+  })
+  .passthrough();
+
+export type VideoGenerationSubmitResponse = z.infer<
+  typeof VideoGenerationSubmitResponseSchema
+>;
+
+export const VideoGenerationPollResponseSchema = z
+  .object({
+    id: z.string(),
+    generation_id: z.string().optional(),
+    polling_url: z.string(),
+    status: z.string(),
+    unsigned_urls: z.array(z.string()).optional(),
+    usage: z
+      .object({
+        cost: z.number().optional(),
+        is_byok: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    error: z.string().optional(),
+  })
+  .passthrough();
+
+export type VideoGenerationPollResponse = z.infer<
+  typeof VideoGenerationPollResponseSchema
+>;


### PR DESCRIPTION
## Description

Add video generation support to the OpenRouter AI SDK provider via a new `provider.videoModel()` method implementing the `Experimental_VideoModelV3` interface.

**What's included:**
- `OpenRouterVideoModel` class with async submit → poll → return URLs flow against `/api/v1/videos`
- Support for prompt, aspect_ratio, resolution, duration, seed, and image-to-video (frame_images)
- `generate_audio`, `extraBody`, and `providerOptions` passthrough
- Correct poll status handling: `'completed'` (not `'complete'`), plus `'cancelled'` and `'expired'` as terminal failure states
- Provider-specific options passed via `providerOptions.openrouter` at call time (not via settings-level provider routing)
- Zod schemas for submit/poll response validation
- Wired into `OpenRouterProvider` as `.videoModel()`
- Exported from both main and `/internal` entry points
- 15 unit tests covering happy path, polling, errors, timeouts, and edge cases

**Dependency bumps:**
- `@ai-sdk/provider` 3.0.0 → 3.0.8 (for `Experimental_VideoModelV3` types)
- `@ai-sdk/provider-utils` 4.0.1 → 4.0.23 (aligned with provider 3.0.8)
- `ai` 6.0.3 → 6.0.162 (aligned with provider 3.0.8)

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file