### PR TITLE
fix: allow query strings and fragments in image URL regex (#484)

### DIFF
--- a/.changeset/fix-issue-484-image-url-query-params.md
+++ b/.changeset/fix-issue-484-image-url-query-params.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Fix `supportedUrls['image/*']` regex to accept image URLs with query strings or fragments (e.g. `https://cdn.example.com/photo.png?height=200`, `.../photo.webp#frag`). Previously the `$` anchor on the extension caused such URLs to be treated as unsupported, forcing the AI SDK runtime to download and base64-inline them, which bloated conversation history and inflated token usage.

--- a/e2e/issues/issue-484-image-url-query-params.test.ts
+++ b/e2e/issues/issue-484-image-url-query-params.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression test for GitHub issue #484
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/484
+ *
+ * Issue: "Zod Schema for Image URLs restricts query params"
+ *
+ * The `supportedUrls` regex for `image/*` only matches URLs that END with a
+ * known extension. Valid image URLs with query strings or fragments do NOT
+ * match, so the AI SDK's LanguageModelV3 layer treats them as unsupported
+ * and downloads + base64-encodes them.
+ */
+import { describe, expect, it } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+const provider = createOpenRouter({ apiKey: 'test-key' });
+const chatModel = provider.chat('anthropic/claude-3.5-sonnet');
+const completionModel = provider.completion('openai/gpt-3.5-turbo-instruct');
+
+const IMAGE_URLS_WITH_QUERY_PARAMS = [
+  'https://cdn.example.com/photo.png?height=200',
+  'https://cdn.example.com/photo.jpeg?w=100&h=200',
+  'https://cdn.example.com/photo.webp?v=1&t=2',
+  'https://cdn.example.com/photo.gif?cache=false',
+  'https://cdn.example.com/photo.jpg?signature=abc123',
+] as const;
+
+const IMAGE_URLS_WITH_FRAGMENTS = [
+  'https://cdn.example.com/photo.png#section',
+  'https://cdn.example.com/photo.webp#fragment',
+] as const;
+
+const IMAGE_URLS_WITH_QUERY_AND_FRAGMENT = [
+  'https://cdn.example.com/photo.png?height=200#section',
+] as const;
+
+const STILL_VALID_PLAIN_URLS = [
+  'https://cdn.example.com/photo.png',
+  'https://cdn.example.com/photo.PNG',
+  'https://cdn.example.com/photo.jpeg',
+  'https://cdn.example.com/photo.jpg',
+  'https://cdn.example.com/photo.webp',
+  'https://cdn.example.com/photo.gif',
+  'data:image/png;base64,AAECAw==',
+] as const;
+
+const STILL_INVALID_URLS = [
+  'https://example.com/not-an-image.txt',
+  'ftp://example.com/photo.png',
+  'https://example.com/document.pdf',
+] as const;
+
+/**
+ * Additional defensive edge cases for the same failure mode.
+ *
+ * These cover real-world image URL shapes commonly seen with CDNs and
+ * pre-signed object storage URLs (S3, GCS, R2, etc.). They are deliberately
+ * tightly scoped to the same `?...` / `#...` suffix relaxation — they should
+ * NOT pass under any pattern that drops the extension requirement entirely.
+ */
+const DEFENSIVE_EXTRA_VALID_URLS = [
+  // URL-encoded query value (typical for signed URLs)
+  'https://cdn.example.com/photo.png?token=abc%20def%2F123',
+  // Pre-signed S3-style URL with multiple query params
+  'https://my-bucket.s3.amazonaws.com/photo.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=900&X-Amz-Signature=deadbeef',
+  // Both query and fragment, plus uppercase extension
+  'https://cdn.example.com/photo.PNG?x=1#frag',
+  // Empty query string (still a query, just no params)
+  'https://cdn.example.com/photo.gif?',
+  // Empty fragment
+  'https://cdn.example.com/photo.webp#',
+] as const;
+
+/**
+ * Defensive cases that must REMAIN rejected after the fix.
+ *
+ * The most important one is the "extension-in-the-path" shape:
+ * `https://cdn.example.com/some.png/redirect`. Naive relaxations of the
+ * regex (e.g. dropping the `$` anchor or replacing it with `.*`) would
+ * accept this, which would regress the explicit `image/*` allowlist.
+ */
+const DEFENSIVE_EXTRA_INVALID_URLS = [
+  // Extension is in the path, not terminal — must stay rejected
+  'https://cdn.example.com/some.png/redirect',
+  // Extension followed by another path segment
+  'https://cdn.example.com/photo.jpg/thumbnail',
+  // No extension at all, just a query string
+  'https://cdn.example.com/photo?type=png',
+  // Wrong scheme with query params
+  'ftp://example.com/photo.png?x=1',
+] as const;
+
+function firstImagePattern(supportedUrls: Record<string, RegExp[]>): RegExp[] {
+  const patterns = supportedUrls['image/*'];
+  if (!patterns) {
+    throw new Error('image/* patterns missing');
+  }
+  return patterns;
+}
+
+function matchesAny(url: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(url));
+}
+
+describe('Issue #484: image URL regex must accept query strings and fragments', () => {
+  describe('chat model supportedUrls', () => {
+    const patterns = firstImagePattern(chatModel.supportedUrls);
+    it.each(IMAGE_URLS_WITH_QUERY_PARAMS)('accepts query params: %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(true);
+    });
+    it.each(IMAGE_URLS_WITH_FRAGMENTS)('accepts fragment: %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(true);
+    });
+    it.each(
+      IMAGE_URLS_WITH_QUERY_AND_FRAGMENT,
+    )('accepts query+fragment: %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(true);
+    });
+    it.each(STILL_VALID_PLAIN_URLS)('still accepts plain: %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(true);
+    });
+    it.each(STILL_INVALID_URLS)('still rejects: %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(false);
+    });
+    it.each(DEFENSIVE_EXTRA_VALID_URLS)('defensive: accepts %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(true);
+    });
+    it.each(
+      DEFENSIVE_EXTRA_INVALID_URLS,
+    )('defensive: still rejects %s', (url) => {
+      expect(matchesAny(url, patterns)).toBe(false);
+    });
+  });
+
+  describe('completion model supportedUrls', () => {
+    const patterns = firstImagePattern(completionModel.supportedUrls);
+    it('accepts image URL with query params', () => {
+      expect(
+        matchesAny('https://cdn.example.com/photo.png?height=200', patterns),
+      ).toBe(true);
+    });
+    it('accepts image URL with fragment', () => {
+      expect(matchesAny('https://cdn.example.com/photo.webp#f', patterns)).toBe(
+        true,
+      );
+    });
+    it('still rejects non-image URL', () => {
+      expect(matchesAny('https://example.com/document.pdf', patterns)).toBe(
+        false,
+      );
+    });
+    it('defensive: still rejects extension-in-path', () => {
+      expect(
+        matchesAny('https://cdn.example.com/some.png/redirect', patterns),
+      ).toBe(false);
+    });
+    it('defensive: accepts pre-signed URL with multiple query params', () => {
+      expect(
+        matchesAny(
+          'https://my-bucket.s3.amazonaws.com/photo.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=900&X-Amz-Signature=deadbeef',
+          patterns,
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -70,7 +70,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
   readonly supportedUrls: Record<string, RegExp[]> = {
     'image/*': [
       /^data:image\/[a-zA-Z]+;base64,/,
-      /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i,
+      /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)(?:[?#].*)?$/i,
     ],
     // 'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -54,7 +54,7 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
   readonly supportedUrls: Record<string, RegExp[]> = {
     'image/*': [
       /^data:image\/[a-zA-Z]+;base64,/,
-      /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i,
+      /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)(?:[?#].*)?$/i,
     ],
     'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],


### PR DESCRIPTION
## Description

Fixes [#484](https://github.com/OpenRouterTeam/ai-sdk-provider/issues/484) — the `supportedUrls['image/*']` regex anchored the extension to the end of the string with `$`, so any valid image URL with a query string or fragment (e.g. `https://cdn.example.com/photo.png?height=200`) did NOT match. When `supportedUrls` doesn't match, the AI SDK's `LanguageModelV3` layer downloads the image and inlines it as base64 into the prompt, which bloats conversation history and inflates token usage.

The fix relaxes the pattern to allow an optional `?...` and/or `#...` suffix after the extension. Strict allowlist behavior is preserved — the extension is still required and must remain terminal in the path. The same fix is applied to both `src/chat/index.ts` and `src/completion/index.ts` to keep them in sync. The `data:image/...` pattern is left unchanged.

### Before / after

```ts
// before — src/chat/index.ts:73, src/completion/index.ts:57
/^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)$/i

// after
/^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)(?:[?#].*)?$/i
```

```ts
const re = /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)(?:[?#].*)?$/i;

re.test('https://cdn.example.com/photo.png');                  // true (unchanged)
re.test('https://cdn.example.com/photo.png?height=200');       // true (was false)
re.test('https://cdn.example.com/photo.webp#frag');            // true (was false)
re.test('https://cdn.example.com/photo.PNG?x=1#frag');         // true (was false)
re.test('https://cdn.example.com/some.png/redirect');          // false (still rejected — extension not terminal)
re.test('https://example.com/document.pdf');                   // false (unchanged)
```

### Test coverage

Added `e2e/issues/issue-484-image-url-query-params.test.ts` with 32 unit-style cases (no network) covering both `chat` and `completion` `supportedUrls`:

- query strings, fragments, and combined `?...#...` suffixes
- plain URLs (no suffix) and `data:` URIs — must still match
- non-image URLs and wrong scheme — must still be rejected
- defensive: URL-encoded query values, pre-signed S3-style URLs with multiple query params, empty `?` / `#`, uppercase extension with query
- defensive: extension-in-path shapes (`.../some.png/redirect`, `.../photo.jpg/thumbnail`) — must REMAIN rejected (guards against overly-loose relaxations)

On current `main` 16 of these cases fail; with the fix all 32 pass.

### Reviewer checklist

Verified against the diff at HEAD:

- [x] Both `src/chat/index.ts:73` and `src/completion/index.ts:57` updated identically (same regex literal in both files)
- [x] `data:image/...` pattern unchanged (`/^data:image\/[a-zA-Z]+;base64,/`)
- [x] `application/*` and `text/*` patterns untouched
- [x] No `as` / type assertions introduced (only `as const` literal-narrowing in the new test, which is allowed)
- [x] Strict allowlist behavior preserved: extension is still required and must be terminal in the path (defensive cases `.../some.png/redirect` and `.../photo.jpg/thumbnail` confirmed still rejected)
- [x] Regression test fails on `main` (16/32 fail) and passes on this branch (32/32)

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable) — N/A, internal regex bug fix with no public API change

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file