### PR TITLE
fix: allow opting out of response_format strict mode (#483)

### DIFF
--- a/.changeset/issue-483-structured-outputs-strict.md
+++ b/.changeset/issue-483-structured-outputs-strict.md
@@ -1,0 +1,17 @@
+---
+'@openrouter/ai-sdk-provider': minor
+---
+
+Add `structuredOutputs.strict` setting to opt out of `response_format.json_schema.strict` (issue #483).
+
+Previously the SDK hardcoded `strict: true` whenever a JSON schema response format was used, which made it impossible to route requests to providers that don't advertise support for strict json_schema. Models like `moonshotai/kimi-k2.6` (routed through Parasail/Venice/Io Net) returned HTTP 404 "No endpoints available matching your guardrail restrictions and data policy" because the strict flag eliminated every eligible endpoint.
+
+Users can now opt out per-model:
+
+```ts
+const model = openrouter.chat('moonshotai/kimi-k2.6', {
+  structuredOutputs: { strict: false },
+});
+```
+
+The default remains `strict: true` for backward compatibility.

--- a/e2e/issues/issue-483-response-format-strict-option.test.ts
+++ b/e2e/issues/issue-483-response-format-strict-option.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression test for GitHub issue #483
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/483
+ *
+ * Issue: `response_format.json_schema.strict` is hardcoded to `true` in the
+ * outbound payload, with no setting to opt out. For models whose downstream
+ * providers don't advertise support for strict mode, OpenRouter returns
+ * HTTP 404 ("No endpoints available matching your guardrail restrictions
+ * and data policy") because the strict flag eliminates every eligible
+ * endpoint.
+ *
+ * Expected behavior after fix: the SDK still defaults `strict` to `true`
+ * (backward compatible), but a new `structuredOutputs.strict` setting on
+ * `OpenRouterChatSettings` lets users override the value (in particular
+ * set it to `false`) so they can route to providers that don't implement
+ * strict json_schema.
+ */
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { JSONSchema7 } from 'json-schema';
+
+import { createTestServer } from '@ai-sdk/test-server';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+const TEST_SCHEMA: JSONSchema7 = {
+  type: 'object',
+  properties: { items: { type: 'array', items: { type: 'string' } } },
+  required: ['items'],
+  additionalProperties: false,
+};
+
+const TEST_PROMPT: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+];
+
+function prepareJsonResponse(
+  content: string,
+  server: ReturnType<typeof createTestServer>,
+) {
+  server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+    type: 'json-value',
+    body: {
+      id: 'x',
+      object: 'chat.completion',
+      created: 0,
+      model: 'moonshotai/kimi-k2.6',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  };
+}
+
+describe('Issue #483: response_format strict should be configurable', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  const provider = createOpenRouter({ apiKey: 'test-key' });
+
+  it('defaults strict to true (backward compatible)', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6');
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: { type: 'json', schema: TEST_SCHEMA, name: 'Colors' },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: { json_schema: { strict: true } },
+    });
+  });
+
+  it('allows disabling strict via structuredOutputs setting', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: { strict: false },
+    });
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: { type: 'json', schema: TEST_SCHEMA, name: 'Colors' },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: { json_schema: { strict: false } },
+    });
+  });
+
+  it('allows explicit strict=true via structuredOutputs setting', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: { strict: true },
+    });
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: { type: 'json', schema: TEST_SCHEMA, name: 'Colors' },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: { json_schema: { strict: true } },
+    });
+  });
+
+  it('treats structuredOutputs.strict=undefined as default (true)', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: { strict: undefined },
+    });
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: { type: 'json', schema: TEST_SCHEMA, name: 'Colors' },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: { json_schema: { strict: true } },
+    });
+  });
+
+  it('treats empty structuredOutputs object as default (true)', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: {},
+    });
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: { type: 'json', schema: TEST_SCHEMA, name: 'Colors' },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: { json_schema: { strict: true } },
+    });
+  });
+
+  it('preserves responseFormat.name and description alongside strict override', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: { strict: false },
+    });
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: TEST_SCHEMA,
+        name: 'PersonResponse',
+        description: 'A person object',
+      },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          schema: TEST_SCHEMA,
+          strict: false,
+          name: 'PersonResponse',
+          description: 'A person object',
+        },
+      },
+    });
+  });
+
+  it('does not emit response_format when responseFormat is omitted, regardless of structuredOutputs', async () => {
+    prepareJsonResponse('hello', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: { strict: false },
+    });
+    await model.doGenerate({ prompt: TEST_PROMPT });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).not.toHaveProperty('response_format');
+  });
+
+  it('still emits json_object (no strict) when responseFormat.type=json without schema', async () => {
+    prepareJsonResponse('{"items":[]}', server);
+    const model = provider.chat('moonshotai/kimi-k2.6', {
+      structuredOutputs: { strict: false },
+    });
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: { type: 'json' },
+    });
+    const body = await server.calls[0]!.requestBodyJson;
+    expect(body).toMatchObject({
+      response_format: { type: 'json_object' },
+    });
+    // json_object branch never carries `strict`; structuredOutputs.strict
+    // should be a no-op for it.
+    expect(body).not.toHaveProperty('response_format.json_schema');
+  });
+});

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -142,7 +142,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                 type: 'json_schema',
                 json_schema: {
                   schema: responseFormat.schema,
-                  strict: true,
+                  strict: this.settings.structuredOutputs?.strict ?? true,
                   name: responseFormat.name ?? 'response',
                   ...(responseFormat.description && {
                     description: responseFormat.description,

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -159,6 +159,26 @@ monitor and detect abuse. Learn more.
   };
 
   /**
+   * Structured-output options forwarded to OpenRouter's
+   * `response_format.json_schema` payload.
+   *
+   * Use this to opt out of strict mode for models whose providers don't
+   * advertise support for it (e.g. open-source models routed through
+   * non-OpenAI-compatible providers). When `strict` is left unset, the
+   * SDK defaults to `true` for backward compatibility.
+   *
+   * Only applies when a `responseFormat` with a `schema` is provided on
+   * the call site. Has no effect for `json_object` or text responses.
+   */
+  structuredOutputs?: {
+    /**
+     * Whether to set `response_format.json_schema.strict` on the outbound
+     * request. Defaults to `true` when omitted.
+     */
+    strict?: boolean;
+  };
+
+  /**
    * Provider routing preferences to control request routing behavior
    */
   provider?: {


### PR DESCRIPTION
## Description

Fixes [#483](https://github.com/OpenRouterTeam/ai-sdk-provider/issues/483) by adding a new `structuredOutputs.strict` setting that lets users opt out of `response_format.json_schema.strict` per chat model.

### Problem

`src/chat/index.ts` hardcoded `strict: true` whenever a JSON schema response format was used:

```ts
response_format:
  responseFormat?.type === 'json'
    ? responseFormat.schema != null
      ? {
          type: 'json_schema',
          json_schema: {
            schema: responseFormat.schema,
            strict: true, // <-- hardcoded, no override
            name: responseFormat.name ?? 'response',
            ...(responseFormat.description && { description: responseFormat.description }),
          },
        }
      : { type: 'json_object' }
    : undefined,
```

There was no provider-setting, no call-site option, and no way for a user to opt out. For models whose downstream providers don't implement strict json_schema (e.g. `moonshotai/kimi-k2.6` routed through Parasail/Venice/Io Net), OpenRouter returned HTTP 404 `"No endpoints available matching your guardrail restrictions and data policy"` because the strict flag eliminated every eligible endpoint.

### Fix

Added a new optional `structuredOutputs?: { strict?: boolean }` field to `OpenRouterChatSettings`. When present, its `strict` value is forwarded to `response_format.json_schema.strict`. When omitted, the SDK continues to default to `true` (backward compatible).

**Before**

```ts
const model = openrouter.chat('moonshotai/kimi-k2.6');
// SDK always sends strict: true → 404 if provider doesn't support it
```

**After**

```ts
// Default behavior unchanged — strict: true
const defaultModel = openrouter.chat('moonshotai/kimi-k2.6');

// Opt out for providers that don't support strict mode
const relaxed = openrouter.chat('moonshotai/kimi-k2.6', {
  structuredOutputs: { strict: false },
});

// Explicit opt-in still works
const explicit = openrouter.chat('moonshotai/kimi-k2.6', {
  structuredOutputs: { strict: true },
});
```

### Implementation notes

- `src/chat/index.ts:145` — replaced the hardcoded `strict: true` with `this.settings.structuredOutputs?.strict ?? true`.
- `src/types/openrouter-chat-settings.ts` — added the `structuredOutputs?: { strict?: boolean }` setting alongside other top-level chat settings.
- `src/completion/index.ts` — verified there is no `response_format.json_schema` branch (the legacy completion path forwards `responseFormat` directly without setting `strict`), so no mirror change was needed.
- Existing `should pass responseFormat for JSON schema structured outputs` and `should use default name when name is not provided in responseFormat` tests in `src/chat/index.test.ts` continue to assert `strict: true` and pass without modification — the default is preserved.

### Tests

Added `e2e/issues/issue-483-response-format-strict-option.test.ts` with 8 cases covering:

1. Default (no setting) → `strict: true` (backward compat)
2. `structuredOutputs: { strict: false }` → `strict: false`
3. `structuredOutputs: { strict: true }` → `strict: true`
4. `structuredOutputs: { strict: undefined }` → default `true`
5. `structuredOutputs: {}` (empty object) → default `true`
6. Strict override preserves `name` and `description`
7. No `response_format` emitted when call has no `responseFormat`, regardless of `structuredOutputs`
8. `responseFormat: { type: 'json' }` (no schema) still emits `json_object`, no `strict`, no `json_schema`

Verified the failing-on-main subset of these tests reproduce the bug before applying the fix (2/8 fail on main, all 8 pass on this branch).

## Human review checklist

Verified against the diff at HEAD:

- [x] Default behavior is preserved: `chat(model)` with no `structuredOutputs` setting still emits `strict: true` (existing tests in `src/chat/index.test.ts` are unmodified and continue to pass; default-case test in the new file confirms it explicitly).
- [x] No type assertions / `as` casts in the new test file (per repo no-casting rule).
- [x] The public type addition (`OpenRouterChatSettings.structuredOutputs`) is the right shape — option lives on the chat settings, mirrors `reasoning` / `plugins` placement, and is documented with TSDoc.
- [x] No existing test in `src/chat/index.test.ts` was modified — `git diff --merge-base origin/main -- src/chat/index.test.ts` is empty.
- [x] Changeset is `minor` (new public setting = small feature).

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass (421 passed)
- [x] I have added tests for my changes (`e2e/issues/issue-483-response-format-strict-option.test.ts`, 8 cases — all pass; the two `strict: false` cases failed on main as expected before the fix)
- [x] I have updated documentation (TSDoc on the new `structuredOutputs` setting)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file (`minor`)