### PR TITLE
fix: stop emitting duplicate tool-call events on trailing-whitespace deltas

### DIFF
--- a/.changeset/fix-streaming-merge-path-duplicate-tool-call.md
+++ b/.changeset/fix-streaming-merge-path-duplicate-tool-call.md
@@ -1,0 +1,15 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+fix: stop emitting duplicate `tool-call` events when a trailing-whitespace argument delta arrives after a complete tool call
+
+In the streaming chat handler, the merge-into-existing-tool-call path enqueues a `tool-call` stream event whenever the accumulated `function.arguments` is parsable JSON. Because `JSON.parse` accepts trailing whitespace, any subsequent argument delta for the same tool-call `index` (e.g. a stray space, newline, or closing-token chunk) leaves the arguments parsable and would re-trigger the emit, producing a second `tool-call` event with the same `toolCallId`. Downstream tool runners (e.g. Vercel AI SDK `streamText`) then execute the tool twice. Observed in production with `moonshotai/kimi-k2.6` via OpenRouter, where the user-visible effect was every outbound message being delivered twice.
+
+**`src/chat/index.ts`:**
+
+- Merge-path `tool-call` emit is now gated on `!toolCall.sent`, mirroring the new-path behavior. The `sent` flag was already being set after the first emit but was never read on this path.
+
+**`src/chat/index.test.ts`:**
+
+- Adds a regression test that streams a complete tool call followed by a trailing-whitespace-only argument delta for the same `index` and asserts exactly one `tool-call` event is emitted.

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -4667,6 +4667,73 @@ describe('includeRawChunks', () => {
     ]);
   });
 
+  it('should emit only one tool-call when a trailing whitespace delta arrives after a complete tool call', async () => {
+    // Reproduces a duplicate-emission bug where the streaming merge path
+    // re-emits `tool-call` for any subsequent argument delta whose
+    // concatenation is still parsable JSON. JSON.parse accepts trailing
+    // whitespace, so a stray space/newline chunk after a complete tool call
+    // would otherwise produce a second `tool-call` event with the same
+    // toolCallId. Observed in production with moonshotai/kimi-k2.6.
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First chunk: complete tool call with parsable JSON arguments.
+        `data: {"id":"chatcmpl-dup","object":"chat.completion.chunk","created":1711357598,"model":"moonshotai/kimi-k2.6",` +
+          `"system_fingerprint":"fp_dup","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"functions.send:0","type":"function","function":{"name":"send","arguments":"{\\"hello\\":\\"world\\"}"}}]},` +
+          `"logprobs":null,"finish_reason":null}]}\n\n`,
+        // Second chunk: trailing whitespace delta for the same tool call
+        // index. The accumulated arguments remain parsable JSON, but the
+        // tool call has already been emitted and must NOT be re-emitted.
+        `data: {"id":"chatcmpl-dup","object":"chat.completion.chunk","created":1711357598,"model":"moonshotai/kimi-k2.6",` +
+          `"system_fingerprint":"fp_dup","choices":[{"index":0,"delta":{` +
+          `"tool_calls":[{"index":0,"function":{"arguments":" "}}]},` +
+          `"logprobs":null,"finish_reason":null}]}\n\n`,
+        // Finish.
+        `data: {"id":"chatcmpl-dup","object":"chat.completion.chunk","created":1711357598,"model":"moonshotai/kimi-k2.6",` +
+          `"system_fingerprint":"fp_dup","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}\n\n`,
+        `data: {"id":"chatcmpl-dup","object":"chat.completion.chunk","created":1711357598,"model":"moonshotai/kimi-k2.6",` +
+          `"system_fingerprint":"fp_dup","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'send',
+          inputSchema: {
+            type: 'object',
+            properties: { hello: { type: 'string' } },
+            required: ['hello'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const elements = await convertReadableStreamToArray(stream);
+
+    const toolCallEvents = elements.filter(
+      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+        el.type === 'tool-call',
+    );
+
+    // Exactly one `tool-call` event must be emitted, even though the
+    // accumulated arguments are still parsable JSON after the trailing
+    // whitespace delta.
+    expect(toolCallEvents).toHaveLength(1);
+    expect(toolCallEvents[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'functions.send:0',
+      toolName: 'send',
+      input: '{"hello":"world"}',
+    });
+  });
+
   it('should emit tool-input-start, tool-input-delta, and tool-input-end in flush path for unsent tool calls', async () => {
     server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
       type: 'stream-chunks',

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1047,8 +1047,14 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                   delta: toolCallDelta.function.arguments ?? '',
                 });
 
-                // check if tool call is complete
+                // check if tool call is complete. Skip if already sent so
+                // that trailing-whitespace or other no-op deltas after a
+                // complete tool call don't trigger a duplicate `tool-call`
+                // event with the same toolCallId. JSON.parse accepts trailing
+                // whitespace, so `'{...}'` and `'{...} '` are both parsable
+                // and the merge path would otherwise re-emit on each chunk.
                 if (
+                  !toolCall.sent &&
                   toolCall.function?.name != null &&
                   toolCall.function?.arguments != null &&
                   isParsableJson(toolCall.function.arguments)


### PR DESCRIPTION
## Summary

The streaming chat handler merge-into-existing-tool-call path emits a `tool-call` stream event whenever the accumulated `function.arguments` is parsable JSON. Because `JSON.parse` accepts trailing whitespace, **any** subsequent argument delta for the same tool-call `index` — a stray space, newline, or closing-token chunk — leaves the arguments parsable and re-triggers the emit. The result is a second `tool-call` event with the **same `toolCallId`** as the first.

Downstream tool runners (e.g. Vercel AI SDK `streamText`) treat the two events as two independent tool calls and execute the tool twice.

## Where I observed this

Production traffic using `moonshotai/kimi-k2.6` via OpenRouter from a Vercel AI SDK `streamText` agent loop. The user-visible effect was every outbound message being delivered twice, every shell command running twice, etc. Once the model saw the duplicate in history it would attempt to apologize via the same tool, and that apology was duplicated too — producing a self-reinforcing loop the model could not escape because the duplication was happening downstream of its own output.

The braintrust trace fingerprint:

| Tool call (same id) | input |
|---|---|
| `functions.bash:15` | `' {"command": "cat MEMORY.md \| head -30"}'` |
| `functions.bash:15` | `' {"command": "cat MEMORY.md \| head -30"} '` ← **trailing space** |

| | |
|---|---|
| `functions.send:1` | `' {"actions":[…"apologies — duplicated the send there. fixed."}]}'` |
| `functions.send:1` | `' {"actions":[…"apologies — duplicated the send there. fixed."}]} '` ← **trailing space** |

Every duplicate pair we saw differed only by trailing whitespace, which is exactly the signature of merge-path re-emission.

## Root cause

In `src/chat/index.ts`, the streaming chunk handler has two code paths for tool-call deltas:

1. **New-path** (`toolCalls[index] == null`) — creates the slot, dedupes the id via `seenToolCallIds`, emits `tool-call` if the arguments are already complete, sets `toolCall.sent = true`.
2. **Merge-path** (existing slot) — concatenates the incoming `arguments` and emits `tool-call` if the result is parsable JSON.

The merge-path **never reads `toolCall.sent`**. It only sets it after emitting. So once the new-path has emitted a complete tool call and set `sent = true`, any subsequent argument delta for the same `index` whose appended result is still parsable JSON (which trailing whitespace trivially is) re-emits the tool call.

The existing `seenToolCallIds` dedup at lines 930-933 doesn't help here because (a) it lives in the new-path, and (b) the duplicate emit reuses the same `toolCallId` deliberately — it is the same logical tool call.

## Fix

Gate the merge-path `tool-call` emit on `!toolCall.sent`, mirroring the new-path behavior. The flag was already being set; this just teaches the merge-path to read it.

```ts
if (
  !toolCall.sent &&
  toolCall.function?.name != null &&
  toolCall.function?.arguments != null &&
  isParsableJson(toolCall.function.arguments)
) {
  // ...emit tool-input-end + tool-call...
  toolCall.sent = true;
}
```

## Test plan

- [x] Added regression test in `src/chat/index.test.ts` under `describe('includeRawChunks')` that streams a complete tool call followed by a trailing-whitespace-only argument delta for the same `index`, and asserts exactly **one** `tool-call` event is emitted.
- [x] Confirmed the new test **fails on `main`** (1 tool-call event expected, 2 received).
- [x] Confirmed the new test **passes with the fix**.
- [x] Full `pnpm test:node` suite passes (423/423, including the existing parallel/multi-chunk tool-call tests).
- [x] `pnpm typecheck` clean.
- [x] `pnpm stylecheck` (biome) clean.
- [x] Added a `patch` changeset.

## Suggested review order

1. `src/chat/index.ts` — one-line guard added (plus a comment explaining the trailing-whitespace gotcha).
2. `src/chat/index.test.ts` — regression test demonstrating the bug.
3. `.changeset/fix-streaming-merge-path-duplicate-tool-call.md`.

## Notes

- This shouldn't affect any provider that flushes tool-call args in a single chunk or whose final arg-fragment is the closing brace (so parsability becomes true exactly once on the final delta). It will silence a class of duplicate emits for providers that emit a trailing-whitespace or trailing-token chunk after a complete tool call — which appears to include current Moonshot/Kimi routing on OpenRouter.
- I did not file an issue first; happy to do so if preferred. The trace evidence is included in this PR description for visibility.