### PR TITLE
fix: send `content: null` instead of `content: ""` for tool-only assistant messages

### DIFF
--- a/.changeset/fix-tool-only-content-null.md
+++ b/.changeset/fix-tool-only-content-null.md
@@ -1,0 +1,10 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+fix: send `content: null` instead of `content: ""` for tool-only assistant messages
+
+Assistant messages containing only tool calls (no text) were serialized with
+`content: ""`. Providers that strictly validate the OpenAI chat format
+(e.g. AWS Bedrock / Nova) reject blank content with a 400 error. Empty text is
+now coerced to `null`, which the spec explicitly allows for assistant messages.

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -2792,6 +2792,105 @@ describe('tool messages', () => {
   });
 });
 
+describe('assistant message content for tool-only turns', () => {
+  it('should send content as null when assistant turn has only tool calls', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            input: { location: 'San Francisco' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"location":"San Francisco"}',
+          },
+        },
+      ],
+    });
+  });
+
+  it('should preserve text content when assistant turn has both text and tool calls', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me check the weather.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            input: { location: 'SF' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: 'assistant',
+      content: 'Let me check the weather.',
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"location":"SF"}',
+          },
+        },
+      ],
+    });
+  });
+
+  it('should send content as null when assistant turn has multiple tool calls and no text', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            input: { location: 'SF' },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'get_time',
+            input: { timezone: 'PST' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        expect.objectContaining({ id: 'call-1' }),
+        expect.objectContaining({ id: 'call-2' }),
+      ],
+    });
+  });
+});
+
 describe('deterministic tool call argument serialization', () => {
   it('should produce identical serialized arguments regardless of key insertion order', () => {
     // Simulate the same tool call arguments with different key insertion orders,
@@ -2838,7 +2937,7 @@ describe('deterministic tool call argument serialization', () => {
     expect(resultA).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call-1',

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -357,7 +357,7 @@ export function convertToOpenRouterChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           reasoning: effectiveReasoning,
           reasoning_details: finalReasoningDetails,


### PR DESCRIPTION
## Description

Assistant messages containing only tool calls (no text) were serialized with `content: ""`. Providers that strictly validate the OpenAI chat format (e.g. AWS Bedrock / Nova) reject blank content with a 400 error:

> The text field in the ContentBlock object at messages.X.content.0 is blank. Add text to the text field, and try again.

**Root cause:** In `convertToOpenRouterChatMessages`, `text` is initialized as `""` and never changes when the assistant turn has only `tool-call` parts. The type already allows `string | null`.

**Fix:** `content: text` → `content: text || null` — one-line change that coerces empty string to `null`, which the OpenAI spec explicitly allows for assistant messages. Non-empty text is unaffected.

**Before:**
```ts
messages.push({
  role: 'assistant',
  content: text,           // "" for tool-only turns → Bedrock 400
  tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
});
```

**After:**
```ts
messages.push({
  role: 'assistant',
  content: text || null,   // null for tool-only turns → accepted
  tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
});
```

Same root cause Vercel fixed in `@ai-sdk/openai-compatible` ([vercel/ai#13466](https://github.com/vercel/ai/issues/13466)).

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.