### PR TITLE
fix: forward image detail for vision inputs

### DIFF
--- a/.changeset/olive-images-wave.md
+++ b/.changeset/olive-images-wave.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Forward image part `imageDetail` provider metadata to `image_url.detail`.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,40 @@ There are 3 ways to pass extra body to OpenRouter:
    });
    ```
 
+### Passing Image Detail
+
+For vision requests, pass the OpenAI-compatible `imageDetail` option on the
+image file part. The provider forwards it as `image_url.detail`:
+
+```typescript
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { streamText } from 'ai';
+
+const openrouter = createOpenRouter({ apiKey: 'your-api-key' });
+
+await streamText({
+  model: openrouter('openai/gpt-4o-mini'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'file',
+          data: 'https://example.com/image.png',
+          mediaType: 'image/png',
+          providerOptions: {
+            openrouter: {
+              imageDetail: 'low',
+            },
+          },
+        },
+      ],
+    },
+  ],
+});
+```
+
 ## Anthropic Prompt Caching
 
 You can include Anthropic-specific options directly in your messages when using functions like `streamText`. The OpenRouter provider will automatically convert these messages to the correct format internally.

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -585,6 +585,111 @@ describe('cache control', () => {
     ]);
   });
 
+  it('should pass image detail from OpenRouter image part provider metadata', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+            providerOptions: {
+              openrouter: {
+                imageDetail: 'low',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'data:image/png;base64,AAECAw==',
+              detail: 'low',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should pass image detail from OpenAI-compatible image part provider metadata', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'https://example.com/image.png',
+            mediaType: 'image/png',
+            providerOptions: {
+              openai: {
+                imageDetail: 'high',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should use message-level image detail when the image part has no override', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'https://example.com/image.png',
+            mediaType: 'image/png',
+          },
+        ],
+        providerOptions: {
+          openrouter: {
+            imageDetail: 'auto',
+          },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'auto',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should pass cache control to file parts from user message provider metadata', () => {
     const result = convertToOpenRouterChatMessages([
       {

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -42,6 +42,21 @@ function getCacheControl(
     anthropic?.cache_control) as OpenRouterCacheControl | undefined;
 }
 
+function getImageDetail(
+  providerMetadata: SharedV3ProviderMetadata | undefined,
+): 'auto' | 'low' | 'high' | undefined {
+  const openrouterImageDetail = providerMetadata?.openrouter?.imageDetail;
+  const openaiImageDetail = providerMetadata?.openai?.imageDetail;
+  const detail =
+    openrouterImageDetail ??
+    openaiImageDetail ??
+    providerMetadata?.openrouter?.detail;
+
+  return detail === 'auto' || detail === 'low' || detail === 'high'
+    ? detail
+    : undefined;
+}
+
 export function convertToOpenRouterChatMessages(
   prompt: LanguageModelV3Prompt,
 ): OpenRouterChatCompletionsInput {
@@ -129,10 +144,14 @@ export function convertToOpenRouterChatMessages(
                     part,
                     defaultMediaType: 'image/jpeg',
                   });
+                  const detail =
+                    getImageDetail(part.providerOptions) ??
+                    getImageDetail(providerOptions);
                   return {
                     type: 'image_url' as const,
                     image_url: {
                       url,
+                      ...(detail && { detail }),
                     },
                     ...(cacheControl && { cache_control: cacheControl }),
                   };

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -44,6 +44,7 @@ export interface ChatCompletionContentPartImage {
   type: 'image_url';
   image_url: {
     url: string;
+    detail?: 'auto' | 'low' | 'high';
   };
   cache_control?: OpenRouterCacheControl;
 }


### PR DESCRIPTION
## Summary
- forward per-image `providerOptions.openrouter.imageDetail` to `image_url.detail`
- also accepts OpenAI-compatible `providerOptions.openai.imageDetail` on image file parts
- document image detail usage and add a patch changeset

Fixes #493.

## Test plan
- `git diff --check`
- `corepack pnpm exec vitest src/chat/convert-to-openrouter-chat-messages.test.ts --run` *(blocked locally: dependencies are not installed on this lightweight worktree; no dependency install was run on the 8GB laptop)*