### PR TITLE
Preserve reasoning_content for DeepSeek tool-call turns

### DIFF
--- a/.changeset/deepseek-reasoning-content.md
+++ b/.changeset/deepseek-reasoning-content.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+Preserve and replay `reasoning_content` for DeepSeek tool-call continuations.

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -1173,7 +1173,9 @@ describe('reasoning_details accumulation', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
+        annotations: undefined,
+        cache_control: undefined,
         tool_calls: [
           {
             id: 'call_time',

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -1146,6 +1146,51 @@ describe('reasoning_details accumulation', () => {
     ]);
   });
 
+  it('should include reasoning_content for DeepSeek tool-call turns with empty reasoning_details', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Need to call the time tool.',
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_time',
+            toolName: 'get_time',
+            input: { city: 'London' },
+          },
+        ],
+        providerOptions: {
+          openrouter: {
+            reasoning_details: [],
+          },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_time',
+            type: 'function',
+            function: {
+              name: 'get_time',
+              arguments: '{"city":"London"}',
+            },
+          },
+        ],
+        reasoning: undefined,
+        reasoning_content: 'Need to call the time tool.',
+        reasoning_details: [],
+      },
+    ]);
+  });
+
   it('should not include reasoning or reasoning_details when not present in providerOptions', () => {
     const result = convertToOpenRouterChatMessages([
       {

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -261,6 +261,9 @@ export function convertToOpenRouterChatMessages(
         const messageReasoningDetails = parsedProviderOptions.success
           ? parsedProviderOptions.data?.openrouter?.reasoning_details
           : undefined;
+        const messageReasoningContent = parsedProviderOptions.success
+          ? parsedProviderOptions.data?.openrouter?.reasoning_content
+          : undefined;
         const messageAnnotations = parsedProviderOptions.success
           ? parsedProviderOptions.data?.openrouter?.annotations
           : undefined;
@@ -367,12 +370,21 @@ export function convertToOpenRouterChatMessages(
           reasoning && finalReasoningDetails && finalReasoningDetails.length > 0
             ? reasoning
             : undefined;
+        const effectiveReasoningContent =
+          messageReasoningContent ??
+          findFirstReasoningContent(content) ??
+          (toolCalls.length > 0 &&
+          candidateReasoningDetails &&
+          candidateReasoningDetails.length === 0
+            ? reasoning || ''
+            : undefined);
 
         messages.push({
           role: 'assistant',
           content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           reasoning: effectiveReasoning,
+          reasoning_content: effectiveReasoningContent,
           reasoning_details: finalReasoningDetails,
           annotations: messageAnnotations,
           cache_control: getCacheControl(providerOptions),
@@ -537,6 +549,34 @@ function findFirstReasoningDetails(
         parsed.data.openrouter.reasoning_details.length > 0
       ) {
         return parsed.data.openrouter.reasoning_details;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function findFirstReasoningContent(
+  content: Array<{
+    type: string;
+    providerOptions?: Record<string, unknown>;
+  }>,
+): string | undefined {
+  for (const partType of ['tool-call', 'reasoning']) {
+    for (const part of content) {
+      if (part.type !== partType) {
+        continue;
+      }
+
+      const parsed = OpenRouterProviderOptionsSchema.safeParse(
+        part.providerOptions,
+      );
+      const reasoningContent = parsed.success
+        ? parsed.data?.openrouter?.reasoning_content
+        : undefined;
+
+      if (reasoningContent != null) {
+        return reasoningContent;
       }
     }
   }

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -300,6 +300,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
       : emptyUsage();
 
     const reasoningDetails = choice.message.reasoning_details ?? [];
+    const reasoningContent = choice.message.reasoning_content ?? undefined;
+    const reasoningText = choice.message.reasoning ?? reasoningContent;
 
     const reasoning: Array<LanguageModelV4Content> =
       reasoningDetails.length > 0
@@ -348,11 +350,21 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
               return null;
             })
             .filter((p) => p !== null) as Array<LanguageModelV4Content>)
-        : choice.message.reasoning
+        : reasoningText
           ? [
               {
                 type: 'reasoning' as const,
-                text: choice.message.reasoning,
+                text: reasoningText,
+                ...(reasoningContent != null
+                  ? {
+                      providerMetadata: {
+                        openrouter: {
+                          reasoning_content: reasoningContent,
+                          reasoning_details: reasoningDetails,
+                        },
+                      },
+                    }
+                  : {}),
               },
             ]
           : [];
@@ -395,6 +407,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
           providerMetadata: !reasoningDetailsAttachedToToolCall
             ? {
                 openrouter: {
+                  ...(reasoningContent != null
+                    ? { reasoning_content: reasoningContent }
+                    : {}),
                   reasoning_details: reasoningDetails,
                 },
               }
@@ -482,6 +497,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
       providerMetadata: {
         openrouter: OpenRouterProviderMetadataSchema.parse({
           provider: response.provider ?? '',
+          reasoning_content: reasoningContent,
           reasoning_details: choice.message.reasoning_details ?? [],
           annotations:
             fileAnnotations && fileAnnotations.length > 0

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -51,6 +51,7 @@ export const OpenRouterNonStreamChatCompletionResponseSchema = z.union([
               role: z.literal('assistant'),
               content: z.string().nullable().optional(),
               reasoning: z.string().nullable().optional(),
+              reasoning_content: z.string().nullable().optional(),
               reasoning_details: ReasoningDetailArraySchema.nullish(),
               images: ImageResponseArraySchema.nullish(),
 
@@ -176,6 +177,7 @@ export const OpenRouterStreamChatCompletionChunkSchema = z.union([
               role: z.enum(['assistant']).optional(),
               content: z.string().nullish(),
               reasoning: z.string().nullish().optional(),
+              reasoning_content: z.string().nullish().optional(),
               reasoning_details: ReasoningDetailArraySchema.nullish(),
               images: ImageResponseArraySchema.nullish(),
               tool_calls: z

--- a/src/schemas/provider-metadata.ts
+++ b/src/schemas/provider-metadata.ts
@@ -37,6 +37,7 @@ export type FileAnnotation = z.infer<typeof FileAnnotationSchema>;
 export const OpenRouterProviderMetadataSchema = z
   .object({
     provider: z.string(),
+    reasoning_content: z.string().optional(),
     reasoning_details: z.array(ReasoningDetailUnionSchema).optional(),
     annotations: z.array(FileAnnotationSchema).optional(),
     usage: z
@@ -83,6 +84,7 @@ export const OpenRouterProviderOptionsSchema = z
         // z.array(ReasoningDetailUnionSchema) so that a single malformed entry
         // (e.g., a future format not yet in the enum) is individually dropped
         // rather than causing the entire array to fail parsing.
+        reasoning_content: z.string().optional(),
         reasoning_details: ReasoningDetailArraySchema.optional(),
         annotations: z.array(FileAnnotationSchema).optional(),
       })

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -92,6 +92,7 @@ export interface ChatCompletionAssistantMessageParam {
   role: 'assistant';
   content?: string | null;
   reasoning?: string | null;
+  reasoning_content?: string | null;
   reasoning_details?: ReasoningDetailUnion[];
   annotations?: FileAnnotation[];
   tool_calls?: Array<ChatCompletionMessageToolCall>;


### PR DESCRIPTION
## Description

Fixes #501.

DeepSeek-style OpenAI-compatible responses can use `reasoning_content` instead of OpenRouter's normalized `reasoning` field. This preserves that field through response parsing/provider metadata and replays it when converting assistant tool-call history back into OpenRouter chat messages.

The request conversion also handles the existing DeepSeek empty `reasoning_details: []` signal by sending `reasoning_content` for assistant tool-call turns, while keeping the existing `reasoning` guard for signed `reasoning_details`.

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have added a changeset file

## Validation

- `corepack pnpm run stylecheck`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
