### PR TITLE
fix: send null content for tool-only assistant messages

### DIFF
--- a/.changeset/tool-only-null-content.md
+++ b/.changeset/tool-only-null-content.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Send `content: null` instead of `content: ""` for assistant messages that contain only tool calls. Fixes AWS Bedrock Nova rejecting requests with "The text field in the ContentBlock object is blank."

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -2831,6 +2831,101 @@ describe('tool messages', () => {
   });
 });
 
+describe('tool-only assistant messages send null content (issue #443)', () => {
+  it('should send content: null for assistant messages with only tool calls', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            input: { location: 'San Francisco' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: expect.any(String),
+          },
+        },
+      ],
+    });
+  });
+
+  it('should send content: null for assistant messages with multiple tool calls and no text', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            input: { location: 'SF' },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'get_time',
+            input: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.content).toBeNull();
+    const msg = result[0] as { tool_calls?: unknown[] };
+    expect(msg.tool_calls).toHaveLength(2);
+  });
+
+  it('should preserve text content when assistant message has both text and tool calls', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me check the weather.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            input: { location: 'San Francisco' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.content).toBe('Let me check the weather.');
+    const msg = result[0] as { tool_calls?: unknown[] };
+    expect(msg.tool_calls).toHaveLength(1);
+  });
+
+  it('should preserve text content for text-only assistant messages', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.content).toBe('Hello!');
+  });
+});
+
 describe('deterministic tool call argument serialization', () => {
   it('should produce identical serialized arguments regardless of key insertion order', () => {
     // Simulate the same tool call arguments with different key insertion orders,
@@ -2877,7 +2972,7 @@ describe('deterministic tool call argument serialization', () => {
     expect(resultA).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call-1',

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -370,7 +370,7 @@ export function convertToOpenRouterChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           reasoning: effectiveReasoning,
           reasoning_details: finalReasoningDetails,


### PR DESCRIPTION
## Description

Fixes [SDK-443](https://linear.app/openrouter/issue/SDK-443/send-null-content-for-tool-only-assistant-messages): Assistant messages that contain only tool calls (no text parts) were sending `content: ""` (empty string), which breaks AWS Bedrock Nova with `The text field in the ContentBlock object ... is blank.`

The fix changes `content: text` to `content: text || null` in the assistant message handler of `convertToOpenRouterChatMessages`, so tool-only assistant messages emit `content: null` instead of an empty string. This matches the fix Vercel shipped for the same issue in `@ai-sdk/openai-compatible`.

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

Made with [Cursor](https://cursor.com)