### PR TITLE
feat: support Vercel AI SDK v7

### DIFF
--- a/.changeset/loose-cups-film.md
+++ b/.changeset/loose-cups-film.md
@@ -1,0 +1,9 @@
+---
+"@openrouter/ai-sdk-provider": major
+---
+
+Support Vercel AI SDK v7 as a v7-only major release.
+
+This is a breaking change because the provider now peers on `ai@^7.0.0`, requires Node.js 22 or newer, and publishes ESM-only output. The provider, language, embedding, image, and video model implementations now target the `@ai-sdk/provider@4` V4 interfaces, with V4 file payloads and provider-defined tool factories.
+
+Consumers should upgrade to `ai@7`, run on Node.js 22+, and import this package from ESM. Usage accounting follows the AI SDK v7 shape: cached input tokens are exposed via `usage.inputTokenDetails.cacheReadTokens`, and reasoning tokens are exposed via `usage.outputTokenDetails.reasoningTokens`. OpenRouter-specific cost, BYOK, reasoning details, annotations, and cache-control metadata remain available under `providerMetadata.openrouter`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - uses: pnpm/action-setup@v4
       - run: pnpm install
       - run: pnpm test

--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@openrouter"
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@openrouter"
           cache: pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @openrouter/ai-sdk-provider
 
+## Unreleased
+
+### Major Changes
+
+- feat: support Vercel AI SDK v7.
+
+  This release line is v7-only: it peers on `ai@^7.0.0`, requires Node.js 22 or newer, and publishes ESM-only output. The provider now implements the `@ai-sdk/provider@4` V4 provider/model interfaces across chat, completion, embedding, image, and video models.
+
+  Usage accounting is mapped to the AI SDK v7 token detail shape: cached input tokens are available through `usage.inputTokenDetails.cacheReadTokens`, and reasoning tokens are available through `usage.outputTokenDetails.reasoningTokens`. OpenRouter-specific cost, BYOK, reasoning details, annotations, and cache-control metadata continue to be exposed through `providerMetadata.openrouter`.
+
 ## 2.9.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 The [OpenRouter](https://openrouter.ai/) provider for the [Vercel AI SDK](https://sdk.vercel.ai/docs) gives access to over 300 large language models on the OpenRouter chat and completion APIs.
 
-## Setup for AI SDK v6
+## Setup for AI SDK v7
+
+This release line supports `ai@^7.0.0`, requires Node.js 22 or newer, and is ESM-only.
 
 ```bash
 # For pnpm
@@ -13,6 +15,19 @@ npm install @openrouter/ai-sdk-provider
 
 # For yarn
 yarn add @openrouter/ai-sdk-provider
+```
+
+## (LEGACY) Setup for AI SDK v6
+
+```bash
+# For pnpm
+pnpm add @openrouter/ai-sdk-provider@2.9.1
+
+# For npm
+npm install @openrouter/ai-sdk-provider@2.9.1
+
+# For yarn
+yarn add @openrouter/ai-sdk-provider@2.9.1
 ```
 
 ## (LEGACY) Setup for AI SDK v5
@@ -383,6 +398,11 @@ const result = await generateText({
   prompt: 'Hello, how are you today?',
 });
 
+// AI SDK v7 standard usage details
+console.log('Input tokens:', result.usage.inputTokens);
+console.log('Cached input tokens:', result.usage.inputTokenDetails.cacheReadTokens);
+console.log('Reasoning tokens:', result.usage.outputTokenDetails.reasoningTokens);
+
 // Provider-specific usage details (available in providerMetadata)
 if (result.providerMetadata?.openrouter?.usage) {
   console.log('Cost:', result.providerMetadata.openrouter.usage.cost);
@@ -410,6 +430,10 @@ const result = await generateText({
   model,
   prompt: 'Hello, how are you today?',
 });
+
+console.log('Input tokens:', result.usage.inputTokens);
+console.log('Cached input tokens:', result.usage.inputTokenDetails.cacheReadTokens);
+console.log('Reasoning tokens:', result.usage.outputTokenDetails.reasoningTokens);
 
 // Provider-specific BYOK usage details (available in providerMetadata)
 if (result.providerMetadata?.openrouter?.usage) {

--- a/e2e/issues/issue-181-tool-response-image.test.ts
+++ b/e2e/issues/issue-181-tool-response-image.test.ts
@@ -31,8 +31,11 @@ describe('Issue #181: Tool response for image not working', () => {
                   text: 'Here is the screenshot:',
                 },
                 {
-                  type: 'file-data',
-                  data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                  type: 'file',
+                  data: {
+                    type: 'data',
+                    data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                  },
                   mediaType: 'image/png',
                 },
               ],
@@ -78,8 +81,12 @@ describe('Issue #181: Tool response for image not working', () => {
                   text: 'Generated image:',
                 },
                 {
-                  type: 'file-url',
-                  url: 'https://example.com/generated-image.png',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/generated-image.png'),
+                  },
+                  mediaType: 'image/png',
                 },
               ],
             },
@@ -168,9 +175,12 @@ describe('Issue #181: Tool response for image not working', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
+                  type: 'file',
                   mediaType: 'image/jpeg',
-                  data: '/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIAFgAXAMBIgACEQEDEQH/xAAcAAACAgMBAQAA',
+                  data: {
+                    type: 'data',
+                    data: '/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHBgkIBwgKCgkLDRYPDQwMDRsUFRAWIB0iIiAdHx8kKDQsJCYxJx8fLT0tMTU3Ojo6Iys/RD84QzQ5OjcBCgoKDQwNGg8PGjclHyU3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3N//AABEIAFgAXAMBIgACEQEDEQH/xAAcAAACAgMBAQAA',
+                  },
                 },
               ],
             },

--- a/e2e/issues/issue-196-anthropic-1h-cache-ttl.test.ts
+++ b/e2e/issues/issue-196-anthropic-1h-cache-ttl.test.ts
@@ -29,6 +29,7 @@ describe('Issue #196: Anthropic 1-hour cache TTL', () => {
   async function callWithIssue196Structure() {
     const response = await streamText({
       model,
+      allowSystemInMessages: true,
       messages: [
         {
           role: 'system',

--- a/e2e/issues/issue-234-prompt-caching.test.ts
+++ b/e2e/issues/issue-234-prompt-caching.test.ts
@@ -68,6 +68,7 @@ Remember to be helpful and concise in your responses.`;
       for (let i = 0; i < 3; i++) {
         const response = await generateText({
           model,
+          allowSystemInMessages: true,
           messages: [
             { role: 'system', content: longSystemPrompt },
             {
@@ -138,6 +139,7 @@ Remember to be helpful and concise in your responses.`;
       for (let i = 0; i < 3; i++) {
         const response = await generateText({
           model,
+          allowSystemInMessages: true,
           messages: [
             { role: 'system', content: longSystemPrompt },
             {

--- a/e2e/issues/issue-341-cache-control-last-text-part.test.ts
+++ b/e2e/issues/issue-341-cache-control-last-text-part.test.ts
@@ -48,6 +48,7 @@ Remember to be helpful and concise in your responses.`;
     // The fix ensures only the last text part gets cache_control
     const response = await generateText({
       model,
+      allowSystemInMessages: true,
       messages: [
         {
           role: 'system',
@@ -78,6 +79,7 @@ Remember to be helpful and concise in your responses.`;
     // Test cache control on system message
     const response = await generateText({
       model,
+      allowSystemInMessages: true,
       messages: [
         {
           role: 'system',
@@ -107,6 +109,7 @@ Remember to be helpful and concise in your responses.`;
     for (let i = 0; i < 2; i++) {
       const response = await generateText({
         model,
+        allowSystemInMessages: true,
         messages: [
           {
             role: 'system',

--- a/e2e/issues/issue-389-system-cache-control.test.ts
+++ b/e2e/issues/issue-389-system-cache-control.test.ts
@@ -45,6 +45,7 @@ Remember to be helpful and concise in your responses.`;
   it('should trigger cache write on first request with system message cache control', async () => {
     const response = await generateText({
       model,
+      allowSystemInMessages: true,
       messages: [
         {
           role: 'system',
@@ -71,6 +72,7 @@ Remember to be helpful and concise in your responses.`;
     const makeRequest = () =>
       generateText({
         model,
+        allowSystemInMessages: true,
         messages: [
           {
             role: 'system',

--- a/e2e/issues/issue-411-output-object-tools-conflict.test.ts
+++ b/e2e/issues/issue-411-output-object-tools-conflict.test.ts
@@ -48,7 +48,7 @@ describe('Issue #411: generateText with Output.object() + tools should return st
             'Look up the email for john@example.com and return the result.',
         },
       ],
-      experimental_output: Output.object({
+      output: Output.object({
         schema: z.object({
           name: z.string(),
           email: z.string(),

--- a/e2e/issues/issue-412-mid-stream-termination.test.ts
+++ b/e2e/issues/issue-412-mid-stream-termination.test.ts
@@ -16,8 +16,8 @@
  * already streamed before the connection drop.
  */
 import type {
-  LanguageModelV3Prompt,
-  LanguageModelV3StreamPart,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -37,7 +37,7 @@ vi.mock('@/src/version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
@@ -86,13 +86,13 @@ describe('Issue #412: Mid-stream socket termination should emit error and finish
     const elements = await convertReadableStreamToArray(stream);
 
     const hasTextDelta = elements.some(
-      (e: LanguageModelV3StreamPart) => e.type === 'text-delta',
+      (e: LanguageModelV4StreamPart) => e.type === 'text-delta',
     );
     const errorEvent = elements.find(
-      (e: LanguageModelV3StreamPart) => e.type === 'error',
+      (e: LanguageModelV4StreamPart) => e.type === 'error',
     );
     const finishEvent = elements.find(
-      (e: LanguageModelV3StreamPart) => e.type === 'finish',
+      (e: LanguageModelV4StreamPart) => e.type === 'finish',
     );
 
     expect(hasTextDelta).toBe(true);
@@ -129,13 +129,13 @@ describe('Issue #412: Mid-stream socket termination should emit error and finish
     const elements = await convertReadableStreamToArray(stream);
 
     const textDeltas = elements.filter(
-      (e: LanguageModelV3StreamPart) => e.type === 'text-delta',
+      (e: LanguageModelV4StreamPart) => e.type === 'text-delta',
     );
 
     expect(textDeltas.length).toBeGreaterThan(0);
     expect(
       textDeltas.some(
-        (e: LanguageModelV3StreamPart) =>
+        (e: LanguageModelV4StreamPart) =>
           e.type === 'text-delta' && e.delta === 'Partial',
       ),
     ).toBe(true);
@@ -160,10 +160,10 @@ describe('Issue #412: Mid-stream socket termination should emit error and finish
     const elements = await convertReadableStreamToArray(stream);
 
     const errorEvent = elements.find(
-      (e: LanguageModelV3StreamPart) => e.type === 'error',
+      (e: LanguageModelV4StreamPart) => e.type === 'error',
     );
     const finishEvent = elements.find(
-      (e: LanguageModelV3StreamPart) => e.type === 'finish',
+      (e: LanguageModelV4StreamPart) => e.type === 'finish',
     );
 
     expect(errorEvent).toBeDefined();
@@ -202,7 +202,7 @@ describe('Issue #412: Mid-stream socket termination should emit error and finish
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (e: LanguageModelV3StreamPart) => e.type === 'finish',
+      (e: LanguageModelV4StreamPart) => e.type === 'finish',
     );
 
     expect(finishEvent).toBeDefined();

--- a/e2e/issues/issue-413-reasoning-metadata-bloat.test.ts
+++ b/e2e/issues/issue-413-reasoning-metadata-bloat.test.ts
@@ -11,8 +11,8 @@
  * available on reasoning-end, tool-call, and finish events.
  */
 import type {
-  LanguageModelV3Prompt,
-  LanguageModelV3StreamPart,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -33,7 +33,7 @@ vi.mock('@/src/version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Think step by step.' }] },
 ];
 
@@ -99,7 +99,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const reasoningDeltas = elements.filter(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-delta',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-delta',
     );
 
     expect(reasoningDeltas).toHaveLength(N);
@@ -121,7 +121,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const reasoningStart = elements.find(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-start',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-start',
     );
 
     expect(reasoningStart).toBeDefined();
@@ -140,7 +140,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const reasoningEnd = elements.find(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-end',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-end',
     );
 
     expect(reasoningEnd).toBeDefined();
@@ -171,7 +171,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el: LanguageModelV3StreamPart) => el.type === 'finish',
+      (el: LanguageModelV4StreamPart) => el.type === 'finish',
     );
 
     expect(finishEvent).toBeDefined();
@@ -202,7 +202,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
 
     // Serialize all stream parts to measure total payload size
     const totalBytes = elements.reduce(
-      (sum: number, el: LanguageModelV3StreamPart) =>
+      (sum: number, el: LanguageModelV4StreamPart) =>
         sum + JSON.stringify(el).length,
       0,
     );
@@ -227,7 +227,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const reasoningDeltas = elements.filter(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-delta',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-delta',
     );
 
     expect(reasoningDeltas).toHaveLength(1);
@@ -235,7 +235,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
 
     // reasoning-end should still have metadata
     const reasoningEnd = elements.find(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-end',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-end',
     );
     expect(reasoningEnd?.providerMetadata).toBeDefined();
   });
@@ -268,7 +268,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
 
     // Text + Summary produce deltas; Encrypted does not
     const reasoningDeltas = elements.filter(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-delta',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-delta',
     );
     expect(reasoningDeltas).toHaveLength(2);
 
@@ -279,7 +279,7 @@ describe('Issue #413: reasoning metadata bloat in streaming', () => {
 
     // reasoning-end should have all 3 types accumulated
     const reasoningEnd = elements.find(
-      (el: LanguageModelV3StreamPart) => el.type === 'reasoning-end',
+      (el: LanguageModelV4StreamPart) => el.type === 'reasoning-end',
     );
     const details = (
       reasoningEnd?.providerMetadata?.openrouter as {

--- a/e2e/issues/issue-413-tool-input-end-streaming.test.ts
+++ b/e2e/issues/issue-413-tool-input-end-streaming.test.ts
@@ -18,8 +18,8 @@
  * full tool-input-start -> tool-input-delta -> tool-input-end -> tool-call sequence.
  */
 import type {
-  LanguageModelV3Prompt,
-  LanguageModelV3StreamPart,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -39,7 +39,7 @@ vi.mock('@/src/version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'What is the weather?' }] },
 ];
 
@@ -76,7 +76,7 @@ describe('Issue #413: tool-input-end missing in streaming tool calls', () => {
     const { stream } = await model.doStream({ prompt: TEST_PROMPT });
     const elements = await convertReadableStreamToArray(stream);
 
-    const toolEvents = elements.filter((el: LanguageModelV3StreamPart) =>
+    const toolEvents = elements.filter((el: LanguageModelV4StreamPart) =>
       [
         'tool-input-start',
         'tool-input-delta',
@@ -85,7 +85,7 @@ describe('Issue #413: tool-input-end missing in streaming tool calls', () => {
       ].includes(el.type),
     );
 
-    expect(toolEvents.map((e: LanguageModelV3StreamPart) => e.type)).toEqual([
+    expect(toolEvents.map((e: LanguageModelV4StreamPart) => e.type)).toEqual([
       'tool-input-start',
       'tool-input-delta',
       'tool-input-delta',
@@ -109,7 +109,7 @@ describe('Issue #413: tool-input-end missing in streaming tool calls', () => {
     const { stream } = await model.doStream({ prompt: TEST_PROMPT });
     const elements = await convertReadableStreamToArray(stream);
 
-    const toolEvents = elements.filter((el: LanguageModelV3StreamPart) =>
+    const toolEvents = elements.filter((el: LanguageModelV4StreamPart) =>
       [
         'tool-input-start',
         'tool-input-delta',
@@ -120,7 +120,7 @@ describe('Issue #413: tool-input-end missing in streaming tool calls', () => {
 
     // Single-chunk tool call: complete in first chunk, so full lifecycle is
     // emitted immediately (start -> delta -> end -> call)
-    expect(toolEvents.map((e: LanguageModelV3StreamPart) => e.type)).toEqual([
+    expect(toolEvents.map((e: LanguageModelV4StreamPart) => e.type)).toEqual([
       'tool-input-start',
       'tool-input-delta',
       'tool-input-end',
@@ -147,7 +147,7 @@ describe('Issue #413: tool-input-end missing in streaming tool calls', () => {
     const { stream } = await model.doStream({ prompt: TEST_PROMPT });
     const elements = await convertReadableStreamToArray(stream);
 
-    const toolEvents = elements.filter((el: LanguageModelV3StreamPart) =>
+    const toolEvents = elements.filter((el: LanguageModelV4StreamPart) =>
       [
         'tool-input-start',
         'tool-input-delta',
@@ -157,7 +157,7 @@ describe('Issue #413: tool-input-end missing in streaming tool calls', () => {
     );
 
     // Partially streamed (inputStarted=true): flush should only add end + call
-    expect(toolEvents.map((e: LanguageModelV3StreamPart) => e.type)).toEqual([
+    expect(toolEvents.map((e: LanguageModelV4StreamPart) => e.type)).toEqual([
       'tool-input-start',
       'tool-input-delta',
       'tool-input-end',

--- a/e2e/issues/issue-432-raw-response-body.test.ts
+++ b/e2e/issues/issue-432-raw-response-body.test.ts
@@ -28,6 +28,7 @@ describe('Issue #432: raw response body in doGenerate', () => {
   it('should include raw response body with OpenRouter-specific fields', async () => {
     const result = await generateText({
       model: openrouter('openai/gpt-4.1-nano'),
+      include: { responseBody: true },
       prompt: 'Say hello in one word.',
     });
 
@@ -42,6 +43,7 @@ describe('Issue #432: raw response body in doGenerate', () => {
   it('should expose provider field in raw response body', async () => {
     const result = await generateText({
       model: openrouter('openai/gpt-4.1-nano'),
+      include: { responseBody: true },
       prompt: 'Say hi.',
     });
 

--- a/e2e/issues/issue-443-eager-input-streaming.test.ts
+++ b/e2e/issues/issue-443-eager-input-streaming.test.ts
@@ -11,7 +11,7 @@
  * This test verifies that eager_input_streaming from tool.providerOptions.openrouter
  * is correctly included in the request body sent to the OpenRouter API.
  */
-import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 
 import { createTestServer } from '@ai-sdk/test-server';
 import {
@@ -29,7 +29,7 @@ vi.mock('@/src/version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   {
     role: 'user',
     content: [{ type: 'text', text: 'What is the weather in Tokyo?' }],

--- a/e2e/issues/issue-474-web-search-server-tool.test.ts
+++ b/e2e/issues/issue-474-web-search-server-tool.test.ts
@@ -7,7 +7,7 @@
  * The OpenRouter provider did not export provider-defined tools, unlike
  * @ai-sdk/openai, @ai-sdk/google, and @ai-sdk/anthropic. The getArgs()
  * method filtered tools to only function tools, discarding any
- * LanguageModelV3ProviderTool.
+ * LanguageModelV4ProviderTool.
  *
  * This test verifies that openrouter.tools.webSearch() works end-to-end
  * with both generateText and streamText, producing text with URL citations

--- a/e2e/issues/issue-483-response-format-strict-option.test.ts
+++ b/e2e/issues/issue-483-response-format-strict-option.test.ts
@@ -15,7 +15,7 @@
  * set it to `false`) so they can route to providers that don't implement
  * strict json_schema.
  */
-import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 import type { JSONSchema7 } from 'json-schema';
 
 import { createTestServer } from '@ai-sdk/test-server';
@@ -29,7 +29,7 @@ const TEST_SCHEMA: JSONSchema7 = {
   additionalProperties: false,
 };
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'hi' }] },
 ];
 

--- a/e2e/issues/issue-484-image-url-query-params.test.ts
+++ b/e2e/issues/issue-484-image-url-query-params.test.ts
@@ -6,7 +6,7 @@
  *
  * The `supportedUrls` regex for `image/*` only matches URLs that END with a
  * known extension. Valid image URLs with query strings or fragments do NOT
- * match, so the AI SDK's LanguageModelV3 layer treats them as unsupported
+ * match, so the AI SDK's LanguageModelV4 layer treats them as unsupported
  * and downloads + base64-encodes them.
  */
 import { describe, expect, it } from 'vitest';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openrouter/ai-sdk-provider",
   "version": "2.9.1",
+  "type": "module",
   "license": "Apache-2.0",
   "pnpm": {
     "overrides": {
@@ -10,13 +11,12 @@
   },
   "sideEffects": false,
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "pnpm clean && tsup",
     "clean": "rm -rf dist && rm -rf internal/dist",
     "dev": "tsup --watch",
     "stylecheck": "biome check",
@@ -36,19 +36,18 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./internal": {
       "types": "./dist/internal/index.d.ts",
-      "import": "./dist/internal/index.mjs",
-      "module": "./dist/internal/index.mjs",
-      "require": "./dist/internal/index.js"
+      "import": "./dist/internal/index.js",
+      "default": "./dist/internal/index.js"
     }
   },
   "devDependencies": {
-    "@ai-sdk/provider": "3.0.8",
-    "@ai-sdk/provider-utils": "4.0.23",
+    "@ai-sdk/provider": "4.0.0",
+    "@ai-sdk/provider-utils": "5.0.0",
     "@ai-sdk/test-server": "1.0.3",
     "@biomejs/biome": "2.3.7",
     "@changesets/changelog-github": "0.5.1",
@@ -56,7 +55,7 @@
     "@edge-runtime/vm": "5.0.0",
     "@types/json-schema": "7.0.15",
     "@types/node": "24.2.0",
-    "ai": "6.0.162",
+    "ai": "7.0.2",
     "dotenv": "17.2.1",
     "msw": "2.12.4",
     "tsup": "8.5.0",
@@ -65,11 +64,11 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "ai": "^6.0.0",
-    "zod": "^3.25.0 || ^4.0.0"
+    "ai": "^7.0.0",
+    "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "pnpm clean && tsup",
-    "clean": "rm -rf dist && rm -rf internal/dist",
+    "clean": "node -e \"const fs=require('node:fs'); for (const path of ['dist','internal/dist']) fs.rmSync(path,{recursive:true,force:true});\"",
     "dev": "tsup --watch",
     "stylecheck": "biome check",
     "typecheck": "tsc --noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
   .:
     dependencies:
       zod:
-        specifier: ^3.25.0 || ^4.0.0
+        specifier: ^3.25.76 || ^4.1.8
         version: 4.3.5
     devDependencies:
       '@ai-sdk/provider':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,11 +17,11 @@ importers:
         version: 4.3.5
     devDependencies:
       '@ai-sdk/provider':
-        specifier: 3.0.8
-        version: 3.0.8
+        specifier: 4.0.0
+        version: 4.0.0
       '@ai-sdk/provider-utils':
-        specifier: 4.0.23
-        version: 4.0.23(zod@4.3.5)
+        specifier: 5.0.0
+        version: 5.0.0(zod@4.3.5)
       '@ai-sdk/test-server':
         specifier: 1.0.3
         version: 1.0.3(@types/node@24.2.0)(typescript@5.9.2)
@@ -44,8 +44,8 @@ importers:
         specifier: 24.2.0
         version: 24.2.0
       ai:
-        specifier: 6.0.162
-        version: 6.0.162(zod@4.3.5)
+        specifier: 7.0.2
+        version: 7.0.2(zod@4.3.5)
       dotenv:
         specifier: 17.2.1
         version: 17.2.1
@@ -67,21 +67,21 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.99':
-    resolution: {integrity: sha512-8/UuzFY8p+T8j4XP/9m841pUb5bhnFt8cecSnJpd2zhBttNZ6GbfjZTmsqnvM/RwJOvzIsdFULZrU+E9QFREsQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.2':
+    resolution: {integrity: sha512-Jz1BiiTSvhDsCBJrkFRSqLHDRMVjFtYk9GdbSi3UOqY+/epza+oIESMDzfN4m+YHT/1IYmNEmxaMfjXOvxKDjQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.23':
-    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.0':
+    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/test-server@1.0.3':
     resolution: {integrity: sha512-Qw/phEW2IBKzfHIVdySuYijoqAvVJKuwupCrDbl1ofPJ4jsaH/+f+6EysRwui8LNlo/tbFgH0P39gvRFLKHleQ==}
@@ -613,10 +613,6 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
-
   '@rollup/rollup-android-arm-eabi@4.55.2':
     resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
     cpu: [arm]
@@ -766,8 +762,8 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vitest/expect@3.2.4':
@@ -799,14 +795,17 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.162:
-    resolution: {integrity: sha512-1PSvNEK1PEbpUXahnFrcey6l7DJXMVWmg0ibQ8h8oMSe9V1Vx5d+R3xNu0hzBtwqfxYj21ddZo+EUYVs6GOEyA==}
-    engines: {node: '>=18'}
+  ai@7.0.2:
+    resolution: {integrity: sha512-VMU08jHIDJnnKDrbC9AFa5ZsPpOTfAPRLvTRHtJk4FGAoeldmJROMxvZ2ak5lCjEJ2GP2OLPQbMRyEK8w0+S4A==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -971,8 +970,8 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
@@ -1650,21 +1649,22 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.99(zod@4.3.5)':
+  '@ai-sdk/gateway@4.0.2(zod@4.3.5)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.5)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.3.5)
+      '@vercel/oidc': 3.2.0
       zod: 4.3.5
 
-  '@ai-sdk/provider-utils@4.0.23(zod@4.3.5)':
+  '@ai-sdk/provider-utils@5.0.0(zod@4.3.5)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
       zod: 4.3.5
 
-  '@ai-sdk/provider@3.0.8':
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -2128,8 +2128,6 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opentelemetry/api@1.9.0': {}
-
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true
 
@@ -2226,7 +2224,7 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -2271,14 +2269,15 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@workflow/serde@4.1.0': {}
+
   acorn@8.15.0: {}
 
-  ai@6.0.162(zod@4.3.5):
+  ai@7.0.2(zod@4.3.5):
     dependencies:
-      '@ai-sdk/gateway': 3.0.99(zod@4.3.5)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.5)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 4.0.2(zod@4.3.5)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.3.5)
       zod: 4.3.5
 
   ansi-colors@4.1.3: {}
@@ -2453,7 +2452,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.1.0: {}
 
   expect-type@1.3.0: {}
 

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -65,6 +65,29 @@ describe('user messages', () => {
     ]);
   });
 
+  it.each([
+    'file:///tmp/image.png',
+    'blob:https://example.com/image-id',
+  ])('should reject unsupported file URL protocol %s', (url) => {
+    expect(() =>
+      convertToOpenRouterChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL(url),
+              },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ]),
+    ).toThrow('Only http(s) and data: file URLs are supported by OpenRouter');
+  });
+
   it('should convert messages with image base64', async () => {
     const result = convertToOpenRouterChatMessages([
       {

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -12,7 +12,7 @@ describe('user messages', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'image/png',
           },
         ],
@@ -41,7 +41,10 @@ describe('user messages', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: 'https://example.com/image.png',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
             mediaType: 'image/png',
           },
         ],
@@ -70,7 +73,7 @@ describe('user messages', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: 'data:image/png;base64,AAECAw==',
+            data: { type: 'data', data: 'data:image/png;base64,AAECAw==' },
             mediaType: 'image/png',
           },
         ],
@@ -114,7 +117,7 @@ describe('user messages', () => {
         content: [
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType,
           },
         ],
@@ -144,7 +147,7 @@ describe('user messages', () => {
         content: [
           {
             type: 'file',
-            data: 'data:audio/mpeg;base64,AAECAw==',
+            data: { type: 'data', data: 'data:audio/mpeg;base64,AAECAw==' },
             mediaType: 'audio/mpeg',
           },
         ],
@@ -174,7 +177,7 @@ describe('user messages', () => {
         content: [
           {
             type: 'file',
-            data: 'AAECAw==',
+            data: { type: 'data', data: 'AAECAw==' },
             mediaType: 'audio/mpeg',
           },
         ],
@@ -205,7 +208,10 @@ describe('user messages', () => {
           content: [
             {
               type: 'file',
-              data: 'https://example.com/audio.mp3',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/audio.mp3'),
+              },
               mediaType: 'audio/mpeg',
             },
           ],
@@ -222,7 +228,10 @@ describe('user messages', () => {
           { type: 'text', text: 'Describe this video' },
           {
             type: 'file',
-            data: 'https://example.com/video.mp4',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/video.mp4'),
+            },
             mediaType: 'video/mp4',
           },
         ],
@@ -251,7 +260,7 @@ describe('user messages', () => {
           { type: 'text', text: 'What is in this video?' },
           {
             type: 'file',
-            data: 'data:video/mp4;base64,AAECAw==',
+            data: { type: 'data', data: 'data:video/mp4;base64,AAECAw==' },
             mediaType: 'video/mp4',
           },
         ],
@@ -279,7 +288,7 @@ describe('user messages', () => {
         content: [
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'video/webm',
           },
         ],
@@ -311,7 +320,7 @@ describe('user messages', () => {
         content: [
           {
             type: 'file',
-            data: 'https://example.com/sample',
+            data: { type: 'url', url: new URL('https://example.com/sample') },
             mediaType,
           },
         ],
@@ -339,7 +348,7 @@ describe('user messages', () => {
           content: [
             {
               type: 'file',
-              data: new Uint8Array([0, 1, 2, 3]),
+              data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
               mediaType: 'audio/webm',
             },
           ],
@@ -492,7 +501,7 @@ describe('cache control', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'image/png',
           },
         ],
@@ -546,12 +555,12 @@ describe('cache control', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'image/png',
           },
           {
             type: 'file',
-            data: new Uint8Array([4, 5, 6, 7]),
+            data: { type: 'data', data: new Uint8Array([4, 5, 6, 7]) },
             mediaType: 'image/jpeg',
           },
         ],
@@ -593,7 +602,7 @@ describe('cache control', () => {
           { type: 'text', text: 'Hello' },
           {
             type: 'file',
-            data: 'ZmlsZSBjb250ZW50',
+            data: { type: 'data', data: 'ZmlsZSBjb250ZW50' },
             mediaType: 'text/plain',
             providerOptions: {
               openrouter: {
@@ -643,7 +652,7 @@ describe('cache control', () => {
           },
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'image/png',
             providerOptions: {
               anthropic: {
@@ -653,7 +662,7 @@ describe('cache control', () => {
           },
           {
             type: 'file',
-            data: 'ZmlsZSBjb250ZW50',
+            data: { type: 'data', data: 'ZmlsZSBjb250ZW50' },
             mediaType: 'text/plain',
             providerOptions: {
               openrouter: {
@@ -752,7 +761,7 @@ describe('cache control', () => {
           },
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'image/png',
           },
         ],
@@ -913,7 +922,7 @@ describe('cache control', () => {
           { type: 'text', text: 'Listen to this' },
           {
             type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: 'data', data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: 'audio/mpeg',
           },
         ],
@@ -2225,8 +2234,11 @@ describe('multimodal tool result content (issue #181)', () => {
                   text: 'Here is the screenshot:',
                 },
                 {
-                  type: 'image-data',
-                  data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                  type: 'file',
+                  data: {
+                    type: 'data',
+                    data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                  },
                   mediaType: 'image/png',
                 },
               ],
@@ -2272,8 +2284,12 @@ describe('multimodal tool result content (issue #181)', () => {
                   text: 'Generated image:',
                 },
                 {
-                  type: 'image-url',
-                  url: 'https://example.com/generated-image.png',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/generated-image.png'),
+                  },
+                  mediaType: 'image/png',
                 },
               ],
             },
@@ -2307,8 +2323,8 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
-                  data: 'AAECAw==',
+                  type: 'file',
+                  data: { type: 'data', data: 'AAECAw==' },
                   mediaType: 'image/jpeg',
                 },
               ],
@@ -2346,8 +2362,8 @@ describe('multimodal tool result content (issue #181)', () => {
                   text: 'Document contents:',
                 },
                 {
-                  type: 'file-data',
-                  data: 'ZmlsZSBjb250ZW50',
+                  type: 'file',
+                  data: { type: 'data', data: 'ZmlsZSBjb250ZW50' },
                   mediaType: 'application/pdf',
                   filename: 'report.pdf',
                 },
@@ -2386,8 +2402,12 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-url',
-                  url: 'https://example.com/photo.jpg',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/photo.jpg'),
+                  },
+                  mediaType: 'image/jpeg',
                 },
               ],
             },
@@ -2420,8 +2440,13 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-url',
-                  url: 'https://example.com/report.pdf',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/report.pdf'),
+                  },
+                  mediaType: 'application/pdf',
+                  filename: 'report.pdf',
                 },
               ],
             },
@@ -2457,8 +2482,12 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-url',
-                  url: 'https://api.example.com/files/123',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://api.example.com/files/123'),
+                  },
+                  mediaType: 'application/octet-stream',
                 },
               ],
             },
@@ -2498,8 +2527,12 @@ describe('multimodal tool result content (issue #181)', () => {
                   text: 'Here is the file:',
                 },
                 {
-                  type: 'file-id',
-                  fileId: 'file-abc-123',
+                  type: 'custom',
+                  providerOptions: {
+                    openrouter: {
+                      fileId: 'file-abc-123',
+                    },
+                  },
                 },
               ],
             },
@@ -2513,10 +2546,13 @@ describe('multimodal tool result content (issue #181)', () => {
 
     expect(result[0]?.content).toEqual([
       { type: 'text', text: 'Here is the file:' },
-      // Unknown type falls back to stringified text
+      // Custom content falls back to stringified text
       {
         type: 'text',
-        text: JSON.stringify({ type: 'file-id', fileId: 'file-abc-123' }),
+        text: JSON.stringify({
+          type: 'custom',
+          providerOptions: { openrouter: { fileId: 'file-abc-123' } },
+        }),
       },
     ]);
   });
@@ -2611,8 +2647,8 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
-                  data: 'ZmlsZSBjb250ZW50',
+                  type: 'file',
+                  data: { type: 'data', data: 'ZmlsZSBjb250ZW50' },
                   mediaType: 'application/pdf',
                 },
               ],
@@ -2649,8 +2685,8 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
-                  data: 'YXVkaW9fZGF0YQ==',
+                  type: 'file',
+                  data: { type: 'data', data: 'YXVkaW9fZGF0YQ==' },
                   mediaType: 'audio/mpeg',
                 },
               ],
@@ -2687,8 +2723,8 @@ describe('multimodal tool result content (issue #181)', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
-                  data: 'dmlkZW9fZGF0YQ==',
+                  type: 'file',
+                  data: { type: 'data', data: 'dmlkZW9fZGF0YQ==' },
                   mediaType: 'video/mp4',
                 },
               ],
@@ -2726,13 +2762,17 @@ describe('multimodal tool result content (issue #181)', () => {
                   text: 'Screenshots captured:',
                 },
                 {
-                  type: 'image-data',
-                  data: 'AAECAw==',
+                  type: 'file',
+                  data: { type: 'data', data: 'AAECAw==' },
                   mediaType: 'image/png',
                 },
                 {
-                  type: 'image-url',
-                  url: 'https://example.com/screenshot2.png',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/screenshot2.png'),
+                  },
+                  mediaType: 'image/png',
                 },
               ],
             },

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -1,10 +1,10 @@
 import type {
-  LanguageModelV3FilePart,
-  LanguageModelV3Prompt,
-  LanguageModelV3TextPart,
-  LanguageModelV3ToolResultOutput,
-  LanguageModelV3ToolResultPart,
-  SharedV3ProviderMetadata,
+  LanguageModelV4FilePart,
+  LanguageModelV4Prompt,
+  LanguageModelV4TextPart,
+  LanguageModelV4ToolResultOutput,
+  LanguageModelV4ToolResultPart,
+  SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import type { ReasoningDetailUnion } from '../schemas/reasoning-details';
 import type {
@@ -18,8 +18,8 @@ import { ReasoningDetailType } from '../schemas/reasoning-details';
 import { deterministicStringify } from '../utils/deterministic-stringify';
 import { ReasoningDetailsDuplicateTracker } from '../utils/reasoning-details-duplicate-tracker';
 import {
-  buildFileDataUrl,
   getBase64FromDataUrl,
+  getFileDataUrl,
   getFileUrl,
   getInputAudioData,
   MIME_TO_FORMAT,
@@ -30,7 +30,7 @@ import { isUrl } from './is-url';
 export type OpenRouterCacheControl = { type: 'ephemeral' };
 
 function getCacheControl(
-  providerMetadata: SharedV3ProviderMetadata | undefined,
+  providerMetadata: SharedV4ProviderMetadata | undefined,
 ): OpenRouterCacheControl | undefined {
   const anthropic = providerMetadata?.anthropic;
   const openrouter = providerMetadata?.openrouter;
@@ -43,7 +43,7 @@ function getCacheControl(
 }
 
 export function convertToOpenRouterChatMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): OpenRouterChatCompletionsInput {
   const messages: OpenRouterChatCompletionsInput = [];
 
@@ -105,7 +105,7 @@ export function convertToOpenRouterChatMessages(
         }
 
         const contentParts: ChatCompletionContentPart[] = content.map(
-          (part: LanguageModelV3TextPart | LanguageModelV3FilePart, index) => {
+          (part: LanguageModelV4TextPart | LanguageModelV4FilePart, index) => {
             const isLastTextPart =
               part.type === 'text' && index === lastTextPartIndex;
             const partCacheControl = getCacheControl(part.providerOptions);
@@ -412,7 +412,7 @@ export function convertToOpenRouterChatMessages(
 }
 
 function getToolResultContent(
-  input: LanguageModelV3ToolResultPart,
+  input: LanguageModelV4ToolResultPart,
 ): string | ChatCompletionContentPart[] {
   switch (input.output.type) {
     case 'text':
@@ -429,7 +429,7 @@ function getToolResultContent(
 }
 
 type ToolResultContentPart = Extract<
-  LanguageModelV3ToolResultOutput,
+  LanguageModelV4ToolResultOutput,
   { type: 'content' }
 >['value'][number];
 
@@ -441,26 +441,8 @@ function mapToolResultContentParts(
       case 'text':
         return { type: 'text', text: part.text };
 
-      case 'image-data':
-        return {
-          type: 'image_url',
-          image_url: {
-            url: buildFileDataUrl({
-              data: part.data,
-              mediaType: part.mediaType,
-              defaultMediaType: 'image/jpeg',
-            }),
-          },
-        };
-
-      case 'image-url':
-        return {
-          type: 'image_url',
-          image_url: { url: part.url },
-        };
-
-      case 'file-data': {
-        const dataUrl = buildFileDataUrl({
+      case 'file': {
+        const dataUrl = getFileDataUrl({
           data: part.data,
           mediaType: part.mediaType,
           defaultMediaType: 'application/octet-stream',
@@ -503,27 +485,6 @@ function mapToolResultContentParts(
         };
       }
 
-      case 'file-url': {
-        // file-url parts don't carry a mediaType field in the SDK,
-        // so we infer from the URL path extension to route correctly.
-        if (looksLikeImageUrl(part.url)) {
-          return {
-            type: 'image_url',
-            image_url: { url: part.url },
-          };
-        }
-
-        return {
-          type: 'file',
-          file: {
-            filename: filenameFromUrl(part.url),
-            file_data: part.url,
-          },
-        };
-      }
-
-      case 'file-id':
-      case 'image-file-id':
       case 'custom':
         return { type: 'text', text: JSON.stringify(part) };
 
@@ -533,40 +494,6 @@ function mapToolResultContentParts(
       }
     }
   });
-}
-
-const IMAGE_EXTENSIONS = new Set([
-  'jpg',
-  'jpeg',
-  'png',
-  'gif',
-  'webp',
-  'svg',
-  'bmp',
-  'ico',
-  'tif',
-  'tiff',
-  'avif',
-]);
-
-function looksLikeImageUrl(url: string): boolean {
-  try {
-    const pathname = new URL(url).pathname;
-    const ext = pathname.split('.').pop()?.toLowerCase();
-    return ext !== undefined && IMAGE_EXTENSIONS.has(ext);
-  } catch {
-    return false;
-  }
-}
-
-function filenameFromUrl(url: string): string {
-  try {
-    const pathname = new URL(url).pathname;
-    const last = pathname.split('/').pop();
-    return last?.includes('.') ? last : '';
-  } catch {
-    return '';
-  }
 }
 
 /**

--- a/src/chat/errors.test.ts
+++ b/src/chat/errors.test.ts
@@ -1,10 +1,10 @@
-import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 
 import { createTestServer } from '@ai-sdk/test-server';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createOpenRouter } from '../provider';
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 

--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -1,4 +1,7 @@
-import type { LanguageModelV3FilePart } from '@ai-sdk/provider';
+import type {
+  LanguageModelV4FilePart,
+  SharedV4FileData,
+} from '@ai-sdk/provider';
 import type { OpenRouterAudioFormat } from '../types/openrouter-chat-completions-input';
 
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
@@ -39,13 +42,52 @@ export function getFileUrl({
   part,
   defaultMediaType,
 }: {
-  part: LanguageModelV3FilePart;
+  part: LanguageModelV4FilePart;
   defaultMediaType: string;
 }) {
-  const data = part.data instanceof URL ? part.data.toString() : part.data;
-  return buildFileDataUrl({
-    data,
+  return getFileDataUrl({
+    data: part.data,
     mediaType: part.mediaType,
+    defaultMediaType,
+  });
+}
+
+export function getFileDataUrl({
+  data,
+  mediaType,
+  defaultMediaType,
+}: {
+  data: SharedV4FileData;
+  mediaType?: string;
+  defaultMediaType: string;
+}): string {
+  switch (data.type) {
+    case 'data':
+      return buildFileDataUrl({
+        data: data.data,
+        mediaType,
+        defaultMediaType,
+      });
+    case 'url':
+      return data.url.toString();
+    case 'text': {
+      const encoded = new TextEncoder().encode(data.text);
+      return buildFileDataUrl({
+        data: encoded,
+        mediaType: mediaType ?? 'text/plain',
+        defaultMediaType,
+      });
+    }
+    case 'reference':
+      throw new Error(
+        'Provider file references are not supported by OpenRouter',
+      );
+  }
+
+  const _exhaustiveCheck: never = data;
+  return buildFileDataUrl({
+    data: _exhaustiveCheck,
+    mediaType,
     defaultMediaType,
   });
 }
@@ -117,7 +159,7 @@ export const MIME_TO_FORMAT: Record<string, OpenRouterAudioFormat> = {
  * // Returns: { data: "base64string...", format: "mp3" }
  * ```
  */
-export function getInputAudioData(part: LanguageModelV3FilePart): {
+export function getInputAudioData(part: LanguageModelV4FilePart): {
   data: string;
   format: OpenRouterAudioFormat;
 } {

--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -68,8 +68,21 @@ export function getFileDataUrl({
         mediaType,
         defaultMediaType,
       });
-    case 'url':
-      return data.url.toString();
+    case 'url': {
+      const url = data.url.toString();
+      if (
+        url.startsWith('data:') ||
+        isUrl({
+          url,
+          protocols: new Set(['http:', 'https:'] as const),
+        })
+      ) {
+        return url;
+      }
+      throw new Error(
+        'Only http(s) and data: file URLs are supported by OpenRouter',
+      );
+    }
     case 'text': {
       const encoded = new TextEncoder().encode(data.text);
       return buildFileDataUrl({

--- a/src/chat/get-tool-choice.ts
+++ b/src/chat/get-tool-choice.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3ToolChoice } from '@ai-sdk/provider';
+import type { LanguageModelV4ToolChoice } from '@ai-sdk/provider';
 
 import { InvalidArgumentError } from '@ai-sdk/provider';
 import { z } from 'zod/v4';
@@ -18,7 +18,7 @@ const ChatCompletionToolChoiceSchema = z.union([
 type ChatCompletionToolChoice = z.infer<typeof ChatCompletionToolChoiceSchema>;
 
 export function getChatCompletionToolChoice(
-  toolChoice: LanguageModelV3ToolChoice,
+  toolChoice: LanguageModelV4ToolChoice,
 ): ChatCompletionToolChoice {
   switch (toolChoice.type) {
     case 'auto':

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1,7 +1,7 @@
 import type {
-  LanguageModelV3Content,
-  LanguageModelV3Prompt,
-  LanguageModelV3StreamPart,
+  LanguageModelV4Content,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 import type { JSONSchema7 } from 'json-schema';
 import type { ImageResponse } from '../schemas/image';
@@ -17,7 +17,7 @@ vi.mock('@/src/version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
@@ -127,8 +127,8 @@ const provider = createOpenRouter({
 
 const model = provider.chat('anthropic/claude-3.5-sonnet');
 
-function isReasoningDeltaPart(part: LanguageModelV3StreamPart): part is Extract<
-  LanguageModelV3StreamPart,
+function isReasoningDeltaPart(part: LanguageModelV4StreamPart): part is Extract<
+  LanguageModelV4StreamPart,
   {
     type: 'reasoning-delta';
   }
@@ -136,8 +136,8 @@ function isReasoningDeltaPart(part: LanguageModelV3StreamPart): part is Extract<
   return part.type === 'reasoning-delta';
 }
 
-function isReasoningStartPart(part: LanguageModelV3StreamPart): part is Extract<
-  LanguageModelV3StreamPart,
+function isReasoningStartPart(part: LanguageModelV4StreamPart): part is Extract<
+  LanguageModelV4StreamPart,
   {
     type: 'reasoning-start';
   }
@@ -145,8 +145,8 @@ function isReasoningStartPart(part: LanguageModelV3StreamPart): part is Extract<
   return part.type === 'reasoning-start';
 }
 
-function isTextDeltaPart(part: LanguageModelV3StreamPart): part is Extract<
-  LanguageModelV3StreamPart,
+function isTextDeltaPart(part: LanguageModelV4StreamPart): part is Extract<
+  LanguageModelV4StreamPart,
   {
     type: 'text-delta';
   }
@@ -1292,7 +1292,7 @@ describe('doGenerate', () => {
       {
         type: 'file',
         mediaType: 'image/png',
-        data: TEST_IMAGE_BASE64,
+        data: { type: 'data', data: TEST_IMAGE_BASE64 },
       },
     ]);
   });
@@ -1326,7 +1326,7 @@ describe('doGenerate', () => {
     });
 
     const toolCalls = result.content.filter(
-      (c): c is Extract<LanguageModelV3Content, { type: 'tool-call' }> =>
+      (c): c is Extract<LanguageModelV4Content, { type: 'tool-call' }> =>
         c.type === 'tool-call',
     );
 
@@ -1365,7 +1365,7 @@ describe('doGenerate', () => {
     });
 
     const toolCalls = result.content.filter(
-      (c): c is Extract<LanguageModelV3Content, { type: 'tool-call' }> =>
+      (c): c is Extract<LanguageModelV4Content, { type: 'tool-call' }> =>
         c.type === 'tool-call',
     );
 
@@ -1399,7 +1399,7 @@ describe('doGenerate', () => {
     });
 
     const toolCalls = result.content.filter(
-      (c): c is Extract<LanguageModelV3Content, { type: 'tool-call' }> =>
+      (c): c is Extract<LanguageModelV4Content, { type: 'tool-call' }> =>
         c.type === 'tool-call',
     );
 
@@ -1605,11 +1605,11 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
     const finishChunk = elements.find(
       (
         chunk,
-      ): chunk is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): chunk is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         chunk.type === 'finish',
     );
     const openrouterUsage = (
@@ -1645,11 +1645,11 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
     const finishChunk = elements.find(
       (
         chunk,
-      ): chunk is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): chunk is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         chunk.type === 'finish',
     );
     const openrouterUsage = (
@@ -2408,7 +2408,7 @@ describe('doStream', () => {
 
     // Find the finish event
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2420,7 +2420,7 @@ describe('doStream', () => {
 
     // Should have the tool call
     const toolCallEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-call' } =>
         el.type === 'tool-call',
     );
     expect(toolCallEvent?.toolName).toBe('get_weather');
@@ -2465,7 +2465,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2476,7 +2476,7 @@ describe('doStream', () => {
     });
 
     const toolCallEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-call' } =>
         el.type === 'tool-call',
     );
     expect(toolCallEvent?.toolName).toBe('get_weather');
@@ -2504,7 +2504,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2553,7 +2553,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2587,7 +2587,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2625,7 +2625,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2670,7 +2670,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2700,7 +2700,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2742,7 +2742,7 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const finishEvent = elements.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'finish' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'finish' } =>
         el.type === 'finish',
     );
 
@@ -2781,7 +2781,7 @@ describe('doStream', () => {
       {
         type: 'file',
         mediaType: 'image/png',
-        data: TEST_IMAGE_BASE64,
+        data: { type: 'data', data: TEST_IMAGE_BASE64 },
       },
       {
         type: 'response-metadata',
@@ -3171,13 +3171,13 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
 
     // Find the finish chunk
     const finishChunk = elements.find(
       (
         chunk,
-      ): chunk is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): chunk is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         chunk.type === 'finish',
     );
 
@@ -3245,12 +3245,12 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
 
     const finishChunk = elements.find(
       (
         chunk,
-      ): chunk is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): chunk is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         chunk.type === 'finish',
     );
 
@@ -3322,7 +3322,7 @@ describe('doStream', () => {
     const reasoningEnd = elements.find(
       (
         el,
-      ): el is Extract<LanguageModelV3StreamPart, { type: 'reasoning-end' }> =>
+      ): el is Extract<LanguageModelV4StreamPart, { type: 'reasoning-end' }> =>
         el.type === 'reasoning-end',
     );
 
@@ -3351,7 +3351,7 @@ describe('doStream', () => {
 
     // Also verify that the finish event has the same accumulated data
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
 
@@ -3632,7 +3632,7 @@ describe('doStream', () => {
     // The late signature MUST still be accumulated in accumulatedReasoningDetails
     // and appear in the finish event's providerMetadata for multi-turn roundtrip
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
 
@@ -3655,7 +3655,7 @@ describe('doStream', () => {
     const reasoningEnd = elements.find(
       (
         el,
-      ): el is Extract<LanguageModelV3StreamPart, { type: 'reasoning-end' }> =>
+      ): el is Extract<LanguageModelV4StreamPart, { type: 'reasoning-end' }> =>
         el.type === 'reasoning-end',
     );
 
@@ -3721,7 +3721,7 @@ describe('doStream', () => {
 
     // ALL late details must be accumulated in finish metadata
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
     const finishDetails = (
@@ -3812,7 +3812,7 @@ describe('doStream', () => {
 
     // Signature should be in finish metadata
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
     const finishDetails = (
@@ -3868,7 +3868,7 @@ describe('doStream', () => {
 
     // But reasoning data IS in finish metadata for multi-turn
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
     const finishDetails = (
@@ -3974,7 +3974,7 @@ describe('doStream', () => {
 
     // Tool call should have reasoning_details with signature
     const toolCallEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'tool-call' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'tool-call' }> =>
         el.type === 'tool-call',
     );
     expect(toolCallEvent).toBeDefined();
@@ -4045,7 +4045,7 @@ describe('doStream', () => {
 
     // Signature in finish metadata
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
     const finishDetails = (
@@ -4098,7 +4098,7 @@ describe('doStream', () => {
     const reasoningEnd = elements.find(
       (
         el,
-      ): el is Extract<LanguageModelV3StreamPart, { type: 'reasoning-end' }> =>
+      ): el is Extract<LanguageModelV4StreamPart, { type: 'reasoning-end' }> =>
         el.type === 'reasoning-end',
     );
     const reasoningEndDetails = (
@@ -4123,7 +4123,7 @@ describe('doStream', () => {
 
     // finish event metadata: has BOTH text AND signature (accumulated after text)
     const finishEvent = elements.find(
-      (el): el is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      (el): el is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         el.type === 'finish',
     );
     const finishDetails = (
@@ -4361,7 +4361,7 @@ describe('web search citations', () => {
 
     // Find the source event
     const sourceEvent = elements.find(
-      (e): e is Extract<LanguageModelV3StreamPart, { type: 'source' }> =>
+      (e): e is Extract<LanguageModelV4StreamPart, { type: 'source' }> =>
         e.type === 'source',
     );
 
@@ -4540,7 +4540,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -4559,7 +4559,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -4575,7 +4575,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -4592,7 +4592,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -4718,7 +4718,7 @@ describe('includeRawChunks', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const toolCallEvents = elements.filter(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-call' } =>
         el.type === 'tool-call',
     );
 
@@ -4904,7 +4904,7 @@ describe('includeRawChunks', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const toolInputDeltas = elements.filter(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-input-delta' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-input-delta' } =>
         el.type === 'tool-input-delta',
     );
 
@@ -5209,7 +5209,7 @@ describe('includeRawChunks', () => {
     // Concatenated deltas should equal the tool-call input
     const deltas = toolEvents
       .filter(
-        (e): e is LanguageModelV3StreamPart & { type: 'tool-input-delta' } =>
+        (e): e is LanguageModelV4StreamPart & { type: 'tool-input-delta' } =>
           e.type === 'tool-input-delta',
       )
       .map((e) => e.delta)
@@ -5549,11 +5549,11 @@ describe('includeRawChunks', () => {
 
     // For every tool-input-end, there must be a preceding tool-input-start with the same id
     const ends = elements.filter(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-input-end' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-input-end' } =>
         el.type === 'tool-input-end',
     );
     const starts = elements.filter(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-input-start' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-input-start' } =>
         el.type === 'tool-input-start',
     );
 
@@ -5991,7 +5991,7 @@ describe('includeRawChunks', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const toolCallEvents = elements.filter(
-      (el: LanguageModelV3StreamPart) => el.type === 'tool-call',
+      (el: LanguageModelV4StreamPart) => el.type === 'tool-call',
     );
 
     expect(toolCallEvents).toHaveLength(2);
@@ -6022,7 +6022,7 @@ describe('includeRawChunks', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const toolCallEvents = elements.filter(
-      (el: LanguageModelV3StreamPart) => el.type === 'tool-call',
+      (el: LanguageModelV4StreamPart) => el.type === 'tool-call',
     );
 
     expect(toolCallEvents).toHaveLength(2);
@@ -6054,12 +6054,12 @@ describe('includeRawChunks', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     const toolCallEvents = elements.filter(
-      (el: LanguageModelV3StreamPart) => el.type === 'tool-call',
+      (el: LanguageModelV4StreamPart) => el.type === 'tool-call',
     );
 
     expect(toolCallEvents).toHaveLength(1);
     const toolCallEvent = toolCallEvents.find(
-      (el): el is LanguageModelV3StreamPart & { type: 'tool-call' } =>
+      (el): el is LanguageModelV4StreamPart & { type: 'tool-call' } =>
         el.type === 'tool-call',
     );
     expect(toolCallEvent?.toolCallId).toBe('call_unique_abc');
@@ -6078,11 +6078,11 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
     const errorChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'error' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'error' }> =>
         chunk.type === 'error',
     );
 

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1494,6 +1494,7 @@ describe('doStream', () => {
     // note: space moved to last chunk bc of trimming
     const elements = await convertReadableStreamToArray(stream);
     expect(elements).toStrictEqual([
+      { type: 'stream-start', warnings: [] },
       {
         type: 'response-metadata',
         id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
@@ -2075,6 +2076,7 @@ describe('doStream', () => {
     });
 
     expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+      { type: 'stream-start', warnings: [] },
       {
         type: 'response-metadata',
         id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
@@ -2280,6 +2282,7 @@ describe('doStream', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     expect(elements).toStrictEqual([
+      { type: 'stream-start', warnings: [] },
       {
         type: 'response-metadata',
         id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
@@ -2770,6 +2773,7 @@ describe('doStream', () => {
     });
 
     expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+      { type: 'stream-start', warnings: [] },
       {
         type: 'response-metadata',
         id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
@@ -2842,6 +2846,10 @@ describe('doStream', () => {
 
     expect(await convertReadableStreamToArray(stream)).toStrictEqual([
       {
+        type: 'stream-start',
+        warnings: [],
+      },
+      {
         type: 'error',
         error: {
           message:
@@ -2892,9 +2900,10 @@ describe('doStream', () => {
 
     const elements = await convertReadableStreamToArray(stream);
 
-    expect(elements.length).toBe(2);
-    expect(elements[0]?.type).toBe('error');
-    expect(elements[1]).toStrictEqual({
+    expect(elements.length).toBe(3);
+    expect(elements[0]).toStrictEqual({ type: 'stream-start', warnings: [] });
+    expect(elements[1]?.type).toBe('error');
+    expect(elements[2]).toStrictEqual({
       finishReason: { unified: 'error', raw: undefined },
 
       type: 'finish',

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -649,6 +649,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
     let reasoningId: string | undefined;
     let openrouterResponseId: string | undefined;
     let provider: string | undefined;
+    const warnings: Array<SharedV4Warning> = [];
 
     return {
       stream: safeResponse.pipeThrough(
@@ -658,6 +659,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
           >,
           LanguageModelV4StreamPart
         >({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
           transform(chunk, controller) {
             // Emit raw chunk if requested (before anything else)
             if (options.includeRawChunks) {
@@ -1263,7 +1268,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
           },
         }),
       ),
-      warnings: [],
+      warnings,
       request: { body: args },
       response: { headers: responseHeaders },
     };

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1,15 +1,15 @@
 import type {
   JSONObject,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3ProviderTool,
-  LanguageModelV3ResponseMetadata,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-  SharedV3Headers,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4ProviderTool,
+  LanguageModelV4ResponseMetadata,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+  SharedV4Headers,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
 import type { z } from 'zod/v4';
@@ -60,8 +60,8 @@ type OpenRouterChatConfig = {
   extraBody?: Record<string, unknown>;
 };
 
-export class OpenRouterChatLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OpenRouterChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider = 'openrouter';
   readonly defaultObjectGenerationMode = 'tool' as const;
 
@@ -102,7 +102,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
     topK,
     tools,
     toolChoice,
-  }: LanguageModelV3CallOptions) {
+  }: LanguageModelV4CallOptions) {
     const baseArgs = {
       // model id:
       model: this.modelId,
@@ -215,11 +215,11 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
     return baseArgs;
   }
 
-  async doGenerate(options: LanguageModelV3CallOptions): Promise<{
-    content: Array<LanguageModelV3Content>;
-    finishReason: LanguageModelV3FinishReason;
-    usage: LanguageModelV3Usage;
-    warnings: Array<SharedV3Warning>;
+  async doGenerate(options: LanguageModelV4CallOptions): Promise<{
+    content: Array<LanguageModelV4Content>;
+    finishReason: LanguageModelV4FinishReason;
+    usage: LanguageModelV4Usage;
+    warnings: Array<SharedV4Warning>;
     providerMetadata?: {
       openrouter: {
         provider: string;
@@ -228,8 +228,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
       };
     };
     request?: { body?: unknown };
-    response?: LanguageModelV3ResponseMetadata & {
-      headers?: SharedV3Headers;
+    response?: LanguageModelV4ResponseMetadata & {
+      headers?: SharedV4Headers;
       body?: unknown;
     };
   }> {
@@ -295,13 +295,13 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
       });
     }
 
-    const usageInfo: LanguageModelV3Usage = response.usage
+    const usageInfo: LanguageModelV4Usage = response.usage
       ? computeTokenUsage(response.usage)
       : emptyUsage();
 
     const reasoningDetails = choice.message.reasoning_details ?? [];
 
-    const reasoning: Array<LanguageModelV3Content> =
+    const reasoning: Array<LanguageModelV4Content> =
       reasoningDetails.length > 0
         ? (reasoningDetails
             .map((detail) => {
@@ -347,7 +347,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
               }
               return null;
             })
-            .filter((p) => p !== null) as Array<LanguageModelV3Content>)
+            .filter((p) => p !== null) as Array<LanguageModelV4Content>)
         : choice.message.reasoning
           ? [
               {
@@ -357,7 +357,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
             ]
           : [];
 
-    const content: Array<LanguageModelV3Content> = [];
+    const content: Array<LanguageModelV4Content> = [];
 
     // Add reasoning content first
     content.push(...reasoning);
@@ -409,7 +409,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
         content.push({
           type: 'file' as const,
           mediaType: getMediaType(image.image_url.url, 'image/jpeg'),
-          data: getBase64FromDataUrl(image.image_url.url),
+          data: {
+            type: 'data' as const,
+            data: getBase64FromDataUrl(image.image_url.url),
+          },
         });
       }
     }
@@ -531,12 +534,12 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
     };
   }
 
-  async doStream(options: LanguageModelV3CallOptions): Promise<{
-    stream: ReadableStream<LanguageModelV3StreamPart>;
-    warnings: Array<SharedV3Warning>;
+  async doStream(options: LanguageModelV4CallOptions): Promise<{
+    stream: ReadableStream<LanguageModelV4StreamPart>;
+    warnings: Array<SharedV4Warning>;
     request?: { body?: unknown };
-    response?: LanguageModelV3ResponseMetadata & {
-      headers?: SharedV3Headers;
+    response?: LanguageModelV4ResponseMetadata & {
+      headers?: SharedV4Headers;
       body?: unknown;
     };
   }> {
@@ -607,8 +610,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
     // return empty, null, or duplicate IDs for parallel tool calls.
     const seenToolCallIds = new Set<string>();
 
-    let finishReason: LanguageModelV3FinishReason = createFinishReason('other');
-    const usage: LanguageModelV3Usage = {
+    let finishReason: LanguageModelV4FinishReason = createFinishReason('other');
+    const usage: LanguageModelV4Usage = {
       inputTokens: {
         total: undefined,
         noCache: undefined,
@@ -653,7 +656,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
           ParseResult<
             z.infer<typeof OpenRouterStreamChatCompletionChunkSchema>
           >,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           transform(chunk, controller) {
             // Emit raw chunk if requested (before anything else)
@@ -1093,7 +1096,10 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
                 controller.enqueue({
                   type: 'file',
                   mediaType: getMediaType(image.image_url.url, 'image/jpeg'),
-                  data: getBase64FromDataUrl(image.image_url.url),
+                  data: {
+                    type: 'data',
+                    data: getBase64FromDataUrl(image.image_url.url),
+                  },
                 });
               }
             }
@@ -1271,7 +1277,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV3 {
  * to `openrouter:<tool_name>` in the API request tools array.
  */
 function mapProviderTool(
-  tool: LanguageModelV3ProviderTool,
+  tool: LanguageModelV4ProviderTool,
 ): Record<string, unknown> {
   // Convert provider tool ID format (openrouter.web_search)
   // to OpenRouter API format (openrouter:web_search)

--- a/src/chat/large-pdf-response.test.ts
+++ b/src/chat/large-pdf-response.test.ts
@@ -1,10 +1,10 @@
-import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 
 import { createTestServer } from '@ai-sdk/test-server';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createOpenRouter } from '../provider';
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 

--- a/src/chat/payload-comparison.test.ts
+++ b/src/chat/payload-comparison.test.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 import type { OpenRouterChatCompletionsInput } from '../types/openrouter-chat-completions-input';
 import type { OpenRouterChatSettings } from '../types/openrouter-chat-settings';
 
@@ -61,7 +61,7 @@ describe('Payload Comparison - Large PDF', () => {
     const smallPdfBase64 = 'JVBERi0xLjQKJeLjz9MKM...(truncated)';
     const dataUrl = `data:application/pdf;base64,${smallPdfBase64}`;
 
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       {
         role: 'user',
         content: [
@@ -71,7 +71,7 @@ describe('Payload Comparison - Large PDF', () => {
           },
           {
             type: 'file',
-            data: dataUrl,
+            data: { type: 'data', data: dataUrl },
             mediaType: 'application/pdf',
           },
         ],

--- a/src/completion/convert-to-openrouter-completion-prompt.ts
+++ b/src/completion/convert-to-openrouter-completion-prompt.ts
@@ -1,11 +1,4 @@
-import type {
-  LanguageModelV3FilePart,
-  LanguageModelV3Prompt,
-  LanguageModelV3ReasoningPart,
-  LanguageModelV3TextPart,
-  LanguageModelV3ToolCallPart,
-  LanguageModelV3ToolResultPart,
-} from '@ai-sdk/provider';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 
 import {
   InvalidPromptError,
@@ -18,7 +11,7 @@ export function convertToOpenRouterCompletionPrompt({
   user = 'user',
   assistant = 'assistant',
 }: {
-  prompt: LanguageModelV3Prompt;
+  prompt: LanguageModelV4Prompt;
   inputFormat: 'prompt' | 'messages';
   user?: string;
   assistant?: string;
@@ -58,7 +51,7 @@ export function convertToOpenRouterCompletionPrompt({
 
       case 'user': {
         const userMessage = content
-          .map((part: LanguageModelV3TextPart | LanguageModelV3FilePart) => {
+          .map((part) => {
             switch (part.type) {
               case 'text': {
                 return part.text;
@@ -82,47 +75,38 @@ export function convertToOpenRouterCompletionPrompt({
 
       case 'assistant': {
         const assistantMessage = content
-          .map(
-            (
-              part:
-                | LanguageModelV3TextPart
-                | LanguageModelV3FilePart
-                | LanguageModelV3ReasoningPart
-                | LanguageModelV3ToolCallPart
-                | LanguageModelV3ToolResultPart,
-            ) => {
-              switch (part.type) {
-                case 'text': {
-                  return part.text;
-                }
-                case 'tool-call': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'tool-call messages',
-                  });
-                }
-                case 'tool-result': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'tool-result messages',
-                  });
-                }
-                case 'reasoning': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'reasoning messages',
-                  });
-                }
-
-                case 'file': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'file attachments',
-                  });
-                }
-
-                default: {
-                  return '';
-                }
+          .map((part) => {
+            switch (part.type) {
+              case 'text': {
+                return part.text;
               }
-            },
-          )
+              case 'tool-call': {
+                throw new UnsupportedFunctionalityError({
+                  functionality: 'tool-call messages',
+                });
+              }
+              case 'tool-result': {
+                throw new UnsupportedFunctionalityError({
+                  functionality: 'tool-result messages',
+                });
+              }
+              case 'reasoning': {
+                throw new UnsupportedFunctionalityError({
+                  functionality: 'reasoning messages',
+                });
+              }
+
+              case 'file': {
+                throw new UnsupportedFunctionalityError({
+                  functionality: 'file attachments',
+                });
+              }
+
+              default: {
+                return '';
+              }
+            }
+          })
           .join('');
 
         text += `${assistant}:\n${assistantMessage}\n\n`;

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -513,6 +513,7 @@ describe('doStream', () => {
     // note: space moved to last chunk bc of trimming
     const elements = await convertReadableStreamToArray(stream);
     expect(elements).toStrictEqual([
+      { type: 'stream-start', warnings: [] },
       { type: 'text-delta', delta: 'Hello', id: expect.any(String) },
       { type: 'text-delta', delta: ', ', id: expect.any(String) },
       { type: 'text-delta', delta: 'World!', id: expect.any(String) },
@@ -686,6 +687,10 @@ describe('doStream', () => {
 
     expect(await convertReadableStreamToArray(stream)).toStrictEqual([
       {
+        type: 'stream-start',
+        warnings: [],
+      },
+      {
         type: 'error',
         error: {
           message:
@@ -735,9 +740,10 @@ describe('doStream', () => {
 
     const elements = await convertReadableStreamToArray(stream);
 
-    expect(elements.length).toBe(2);
-    expect(elements[0]?.type).toBe('error');
-    expect(elements[1]).toStrictEqual({
+    expect(elements.length).toBe(3);
+    expect(elements[0]).toStrictEqual({ type: 'stream-start', warnings: [] });
+    expect(elements[1]?.type).toBe('error');
+    expect(elements[2]).toStrictEqual({
       finishReason: { unified: 'error', raw: undefined },
       providerMetadata: {
         openrouter: {

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -1,6 +1,6 @@
 import type {
-  LanguageModelV3Prompt,
-  LanguageModelV3StreamPart,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -12,7 +12,7 @@ vi.mock('@/src/version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
@@ -569,11 +569,11 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
     const finishChunk = elements.find(
       (
         element,
-      ): element is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): element is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         element.type === 'finish',
     );
 
@@ -609,11 +609,11 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
     const finishChunk = elements.find(
       (
         element,
-      ): element is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): element is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         element.type === 'finish',
     );
     const openrouterUsage = (
@@ -649,11 +649,11 @@ describe('doStream', () => {
 
     const elements = (await convertReadableStreamToArray(
       stream,
-    )) as LanguageModelV3StreamPart[];
+    )) as LanguageModelV4StreamPart[];
     const finishChunk = elements.find(
       (
         element,
-      ): element is Extract<LanguageModelV3StreamPart, { type: 'finish' }> =>
+      ): element is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
         element.type === 'finish',
     );
     const openrouterUsage = (
@@ -870,7 +870,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -889,7 +889,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -905,7 +905,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -922,7 +922,7 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
 
@@ -943,11 +943,11 @@ describe('includeRawChunks', () => {
 
     const elements = await convertReadableStreamToArray(stream);
     const rawChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'raw' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'raw' }> =>
         chunk.type === 'raw',
     );
     const errorChunks = elements.filter(
-      (chunk): chunk is Extract<LanguageModelV3StreamPart, { type: 'error' }> =>
+      (chunk): chunk is Extract<LanguageModelV4StreamPart, { type: 'error' }> =>
         chunk.type === 'error',
     );
 

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -1,10 +1,10 @@
 import type {
   JSONObject,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3FinishReason,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4FinishReason,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
 import type { z } from 'zod/v4';
@@ -46,8 +46,8 @@ type OpenRouterCompletionConfig = {
   extraBody?: Record<string, unknown>;
 };
 
-export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider = 'openrouter';
   readonly modelId: OpenRouterCompletionModelId;
   readonly supportsImageUrls = true;
@@ -87,7 +87,7 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
     stopSequences,
     tools,
     toolChoice,
-  }: LanguageModelV3CallOptions) {
+  }: LanguageModelV4CallOptions) {
     const { prompt: completionPrompt } = convertToOpenRouterCompletionPrompt({
       prompt,
       inputFormat: 'prompt',
@@ -149,8 +149,8 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<Awaited<ReturnType<LanguageModelV3['doGenerate']>>> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<Awaited<ReturnType<LanguageModelV4['doGenerate']>>> {
     const providerOptions = options.providerOptions || {};
     const openrouterOptions = providerOptions.openrouter || {};
 
@@ -254,8 +254,8 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<Awaited<ReturnType<LanguageModelV3['doStream']>>> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<Awaited<ReturnType<LanguageModelV4['doStream']>>> {
     const providerOptions = options.providerOptions || {};
     const openrouterOptions = providerOptions.openrouter || {};
 
@@ -293,8 +293,8 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
       streamError = err;
     });
 
-    let finishReason: LanguageModelV3FinishReason = createFinishReason('other');
-    const usage: LanguageModelV3Usage = {
+    let finishReason: LanguageModelV4FinishReason = createFinishReason('other');
+    const usage: LanguageModelV4Usage = {
       inputTokens: {
         total: undefined,
         noCache: undefined,
@@ -319,7 +319,7 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV3 {
       stream: safeResponse.pipeThrough(
         new TransformStream<
           ParseResult<z.infer<typeof OpenRouterCompletionChunkSchema>>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           transform(chunk, controller) {
             // Emit raw chunk if requested (before anything else)

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV4FinishReason,
   LanguageModelV4StreamPart,
   LanguageModelV4Usage,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
 import type { z } from 'zod/v4';
@@ -314,6 +315,7 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
 
     // Track raw usage from the API response for usage.raw
     let rawUsage: JSONObject | undefined;
+    const warnings: Array<SharedV4Warning> = [];
 
     return {
       stream: safeResponse.pipeThrough(
@@ -321,6 +323,10 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
           ParseResult<z.infer<typeof OpenRouterCompletionChunkSchema>>,
           LanguageModelV4StreamPart
         >({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
           transform(chunk, controller) {
             // Emit raw chunk if requested (before anything else)
             if (options.includeRawChunks) {

--- a/src/embedding/index.test.ts
+++ b/src/embedding/index.test.ts
@@ -55,7 +55,7 @@ describe('OpenRouterEmbeddingModel', () => {
       expect(model).toBeInstanceOf(OpenRouterEmbeddingModel);
       expect(model.modelId).toBe('openai/text-embedding-3-small');
       expect(model.provider).toBe('openrouter');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
     });
   });
 

--- a/src/embedding/index.ts
+++ b/src/embedding/index.ts
@@ -1,7 +1,7 @@
 import type {
-  EmbeddingModelV3,
-  SharedV3Headers,
-  SharedV3ProviderMetadata,
+  EmbeddingModelV4,
+  SharedV4Headers,
+  SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import type {
   OpenRouterEmbeddingModelId,
@@ -25,8 +25,8 @@ type OpenRouterEmbeddingConfig = {
   extraBody?: Record<string, unknown>;
 };
 
-export class OpenRouterEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OpenRouterEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider = 'openrouter';
   readonly modelId: OpenRouterEmbeddingModelId;
   readonly settings: OpenRouterEmbeddingSettings;
@@ -52,12 +52,12 @@ export class OpenRouterEmbeddingModel implements EmbeddingModelV3 {
   }): Promise<{
     embeddings: Array<Array<number>>;
     usage?: { tokens: number };
-    providerMetadata?: SharedV3ProviderMetadata;
+    providerMetadata?: SharedV4ProviderMetadata;
     response?: {
-      headers?: SharedV3Headers;
+      headers?: SharedV4Headers;
       body?: unknown;
     };
-    warnings: Array<import('@ai-sdk/provider').SharedV3Warning>;
+    warnings: Array<import('@ai-sdk/provider').SharedV4Warning>;
   }> {
     const { values, abortSignal, headers } = options;
 

--- a/src/image/index.test.ts
+++ b/src/image/index.test.ts
@@ -125,7 +125,7 @@ describe('OpenRouterImageModel', () => {
       expect(model).toBeInstanceOf(OpenRouterImageModel);
       expect(model.modelId).toBe('google/gemini-2.5-flash-image');
       expect(model.provider).toBe('openrouter');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
     });
 
     it('should have maxImagesPerCall set to 1', () => {

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -1,10 +1,10 @@
 import type {
-  ImageModelV3,
-  ImageModelV3CallOptions,
-  ImageModelV3File,
-  ImageModelV3ProviderMetadata,
-  ImageModelV3Usage,
-  SharedV3Warning,
+  ImageModelV4,
+  ImageModelV4CallOptions,
+  ImageModelV4File,
+  ImageModelV4ProviderMetadata,
+  ImageModelV4Usage,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import type {
   OpenRouterImageModelId,
@@ -32,8 +32,8 @@ type OpenRouterImageConfig = {
   extraBody?: Record<string, unknown>;
 };
 
-export class OpenRouterImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OpenRouterImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider = 'openrouter';
   readonly modelId: OpenRouterImageModelId;
   readonly settings: OpenRouterImageSettings;
@@ -51,16 +51,16 @@ export class OpenRouterImageModel implements ImageModelV3 {
     this.config = config;
   }
 
-  async doGenerate(options: ImageModelV3CallOptions): Promise<{
+  async doGenerate(options: ImageModelV4CallOptions): Promise<{
     images: Array<string>;
-    warnings: Array<SharedV3Warning>;
-    providerMetadata?: ImageModelV3ProviderMetadata;
+    warnings: Array<SharedV4Warning>;
+    providerMetadata?: ImageModelV4ProviderMetadata;
     response: {
       timestamp: Date;
       modelId: string;
       headers: Record<string, string> | undefined;
     };
-    usage?: ImageModelV3Usage;
+    usage?: ImageModelV4Usage;
   }> {
     const {
       prompt,
@@ -78,7 +78,7 @@ export class OpenRouterImageModel implements ImageModelV3 {
     const openrouterOptions =
       (providerOptions?.openrouter as Record<string, unknown>) || {};
 
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     if (mask !== undefined) {
       throw new UnsupportedFunctionalityError({
@@ -110,7 +110,7 @@ export class OpenRouterImageModel implements ImageModelV3 {
 
     const userContent: string | Array<Record<string, unknown>> = hasFiles
       ? [
-          ...files.map((file: ImageModelV3File) =>
+          ...files.map((file: ImageModelV4File) =>
             convertImageFileToContentPart(file),
           ),
           { type: 'text', text: prompt ?? '' },
@@ -169,7 +169,7 @@ export class OpenRouterImageModel implements ImageModelV3 {
       }
     }
 
-    const usage: ImageModelV3Usage | undefined = responseValue.usage
+    const usage: ImageModelV4Usage | undefined = responseValue.usage
       ? {
           inputTokens: responseValue.usage.prompt_tokens,
           outputTokens: responseValue.usage.completion_tokens,
@@ -193,7 +193,7 @@ export class OpenRouterImageModel implements ImageModelV3 {
 const DEFAULT_IMAGE_MEDIA_TYPE = 'image/png';
 
 function convertImageFileToContentPart(
-  file: ImageModelV3File,
+  file: ImageModelV4File,
 ): Record<string, unknown> {
   if (file.type === 'url') {
     return {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,5 +1,5 @@
-import type { ProviderV3 } from '@ai-sdk/provider';
-import type { ProviderToolFactory } from '@ai-sdk/provider-utils';
+import type { ProviderV4 } from '@ai-sdk/provider';
+import type { ProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
 import type { Engine } from './types/openrouter-api-types';
 import type {
   OpenRouterChatModelId,
@@ -47,7 +47,7 @@ type WebSearchToolArgs = {
 
 export type { OpenRouterChatSettings, OpenRouterCompletionSettings };
 
-export interface OpenRouterProvider extends ProviderV3 {
+export interface OpenRouterProvider extends ProviderV4 {
   (
     modelId: OpenRouterChatModelId,
     settings?: OpenRouterCompletionSettings,
@@ -124,7 +124,7 @@ Creates an OpenRouter video model for video generation.
      *
      * @see https://openrouter.ai/docs/guides/features/server-tools/web-search
      */
-    webSearch: ProviderToolFactory<unknown, WebSearchToolArgs>;
+    webSearch: ProviderDefinedToolFactory<unknown, WebSearchToolArgs>;
   };
 }
 

--- a/src/tool/web-search.ts
+++ b/src/tool/web-search.ts
@@ -1,6 +1,6 @@
 import type { Engine } from '../types/openrouter-api-types';
 
-import { createProviderToolFactory } from '@ai-sdk/provider-utils';
+import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 /**
@@ -43,7 +43,7 @@ type WebSearchArgs = {
  * });
  * ```
  */
-export const webSearch = createProviderToolFactory<
+export const webSearch = createProviderDefinedToolFactory<
   WebSearchInput,
   WebSearchArgs
 >({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
-import type { LanguageModelV3, LanguageModelV3Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV4, LanguageModelV4Prompt } from '@ai-sdk/provider';
 
-export type { LanguageModelV3, LanguageModelV3Prompt };
+export type { LanguageModelV4, LanguageModelV4Prompt };
 
 export * from './openrouter-embedding-settings';
 export * from './openrouter-image-settings';

--- a/src/utils/compute-token-usage.ts
+++ b/src/utils/compute-token-usage.ts
@@ -1,4 +1,4 @@
-import type { JSONObject, LanguageModelV3Usage } from '@ai-sdk/provider';
+import type { JSONObject, LanguageModelV4Usage } from '@ai-sdk/provider';
 
 interface UsageData {
   prompt_tokens?: number | null;
@@ -12,7 +12,7 @@ interface UsageData {
   } | null;
 }
 
-export function computeTokenUsage(usage: UsageData): LanguageModelV3Usage {
+export function computeTokenUsage(usage: UsageData): LanguageModelV4Usage {
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
   const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
@@ -37,7 +37,7 @@ export function computeTokenUsage(usage: UsageData): LanguageModelV3Usage {
   };
 }
 
-export function emptyUsage(): LanguageModelV3Usage {
+export function emptyUsage(): LanguageModelV4Usage {
   return {
     inputTokens: {
       total: 0,

--- a/src/utils/map-finish-reason.ts
+++ b/src/utils/map-finish-reason.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import type { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 type UnifiedFinishReason =
   | 'stop'
@@ -28,7 +28,7 @@ function mapToUnified(
 
 export function mapOpenRouterFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV3FinishReason {
+): LanguageModelV4FinishReason {
   return {
     unified: mapToUnified(finishReason),
     raw: finishReason ?? undefined,
@@ -38,6 +38,6 @@ export function mapOpenRouterFinishReason(
 export function createFinishReason(
   unified: UnifiedFinishReason,
   raw?: string,
-): LanguageModelV3FinishReason {
+): LanguageModelV4FinishReason {
   return { unified, raw };
 }

--- a/src/video/index.test.ts
+++ b/src/video/index.test.ts
@@ -85,7 +85,7 @@ describe('OpenRouterVideoModel', () => {
       expect(model).toBeInstanceOf(OpenRouterVideoModel);
       expect(model.modelId).toBe('google/veo-3.1');
       expect(model.provider).toBe('openrouter');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
     });
 
     it('should have maxVideosPerCall set to 1', () => {
@@ -124,6 +124,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -163,6 +164,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: 42,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -202,6 +204,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -234,6 +237,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {
           openrouter: {
             provider: {
@@ -285,6 +289,7 @@ describe('OpenRouterVideoModel', () => {
           type: 'url',
           url: 'https://example.com/first-frame.png',
         },
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -322,6 +327,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -358,6 +364,7 @@ describe('OpenRouterVideoModel', () => {
           fps: undefined,
           seed: undefined,
           image: undefined,
+          generateAudio: undefined,
           providerOptions: {},
         }),
       ).rejects.toThrow('Content policy violation');
@@ -398,6 +405,7 @@ describe('OpenRouterVideoModel', () => {
           fps: undefined,
           seed: undefined,
           image: undefined,
+          generateAudio: undefined,
           providerOptions: {},
         }),
       ).rejects.toThrow(/timed out/);
@@ -428,6 +436,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -463,6 +472,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 
@@ -496,6 +506,7 @@ describe('OpenRouterVideoModel', () => {
         fps: undefined,
         seed: undefined,
         image: undefined,
+        generateAudio: undefined,
         providerOptions: {},
       });
 

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -1,10 +1,10 @@
 import type {
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
-  Experimental_VideoModelV3 as VideoModelV3,
-  Experimental_VideoModelV3CallOptions as VideoModelV3CallOptions,
-  Experimental_VideoModelV3File as VideoModelV3File,
-  Experimental_VideoModelV3VideoData as VideoModelV3VideoData,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
+  Experimental_VideoModelV4 as VideoModelV4,
+  Experimental_VideoModelV4CallOptions as VideoModelV4CallOptions,
+  Experimental_VideoModelV4File as VideoModelV4File,
+  Experimental_VideoModelV4VideoData as VideoModelV4VideoData,
 } from '@ai-sdk/provider';
 import type {
   OpenRouterVideoModelId,
@@ -37,8 +37,8 @@ type OpenRouterVideoConfig = {
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_MAX_POLL_TIME_MS = 600_000;
 
-export class OpenRouterVideoModel implements VideoModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenRouterVideoModel implements VideoModelV4 {
+  readonly specificationVersion = 'v4';
   readonly provider = 'openrouter';
   readonly modelId: OpenRouterVideoModelId;
   readonly settings: OpenRouterVideoSettings;
@@ -56,10 +56,10 @@ export class OpenRouterVideoModel implements VideoModelV3 {
     this.config = config;
   }
 
-  async doGenerate(options: VideoModelV3CallOptions): Promise<{
-    videos: Array<VideoModelV3VideoData>;
-    warnings: Array<SharedV3Warning>;
-    providerMetadata?: SharedV3ProviderMetadata;
+  async doGenerate(options: VideoModelV4CallOptions): Promise<{
+    videos: Array<VideoModelV4VideoData>;
+    warnings: Array<SharedV4Warning>;
+    providerMetadata?: SharedV4ProviderMetadata;
     response: {
       timestamp: Date;
       modelId: string;
@@ -79,7 +79,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       providerOptions,
     } = options;
 
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     if (n > 1) {
       warnings.push({
@@ -137,7 +137,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       maxPollTimeMs,
     });
 
-    const videos: VideoModelV3VideoData[] = [];
+    const videos: VideoModelV4VideoData[] = [];
 
     if (pollResult.unsigned_urls) {
       for (const url of pollResult.unsigned_urls) {
@@ -149,7 +149,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       }
     }
 
-    const providerMetadata: SharedV3ProviderMetadata = {
+    const providerMetadata: SharedV4ProviderMetadata = {
       openrouter: {
         generationId: pollResult.generation_id ?? null,
         cost: pollResult.usage?.cost ?? null,
@@ -251,7 +251,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
 }
 
 function convertImageToFrameImage(
-  file: VideoModelV3File,
+  file: VideoModelV4File,
 ): Record<string, unknown> {
   if (file.type === 'url') {
     return {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,7 @@ const package_ = JSON.parse(
 export default defineConfig([
   {
     entry: ['src/index.ts'],
-    format: ['cjs', 'esm'],
+    format: ['esm'],
     dts: true,
     sourcemap: true,
     define: {
@@ -18,7 +18,7 @@ export default defineConfig([
   {
     entry: ['src/internal/index.ts'],
     outDir: 'dist/internal',
-    format: ['cjs', 'esm'],
+    format: ['esm'],
     dts: true,
     sourcemap: true,
     define: {


### PR DESCRIPTION
Fixes #510.

## Design choice

Chose (A) v7-only. AI SDK v7 is Node >=22 and ESM-only, and first-party v7-line providers such as `@ai-sdk/openai@4` target `@ai-sdk/provider@4` V4 interfaces. Keeping v6 support would require compatibility branching around provider/model specs, file payloads, tool factories, packaging, and usage shapes, so this is a major release.

## Summary

- Bumps `ai` to `^7`, `@ai-sdk/provider` to `^4`, and `@ai-sdk/provider-utils` to `^5`; peers on `ai@^7.0.0`.
- Migrates chat and completion language models to `LanguageModelV4`, including V4 content/file payloads, provider tools, reasoning, structured outputs, cache-control passthrough, tool calls, and stream lifecycle events.
- Migrates embedding, image, and video models to the V4 spec. Video tests now pass the required `generateAudio` call option.
- Updates OpenRouter web search to `createProviderDefinedToolFactory` / `ProviderDefinedToolFactory`.
- Publishes ESM-only output with `type: module`, Node >=22, and no CommonJS export branch.
- Preserves OpenRouter usage accounting, reasoning details, cache control/cached-token handling, tool calling, structured outputs, BYOK cost metadata, and provider options.

## Usage/token remapping

Provider usage now follows the V4 internal shape: `inputTokens.cacheRead/cacheWrite/noCache` and `outputTokens.reasoning/text`. In AI SDK v7 public results, cached input tokens are read from `usage.inputTokenDetails.cacheReadTokens` and reasoning tokens from `usage.outputTokenDetails.reasoningTokens`; OpenRouter-specific usage details remain under `providerMetadata.openrouter.usage`.

## Local checks

Baseline on upstream `main` before migration:

```text
pnpm typecheck && pnpm build && pnpm test
Test Files 21 passed (21)
Tests 427 passed (427)
```

Final checks on this branch:

```text
pnpm stylecheck
Checked 133 files in 140ms. No fixes applied.

pnpm typecheck
tsc --noEmit

pnpm build
ESM dist/index.js     179.58 KB
ESM dist/internal/index.js     170.70 KB
DTS dist/index.d.ts 31.30 KB
DTS dist/internal/index.d.ts 25.47 KB

pnpm test:node
Test Files 21 passed (21)
Tests 427 passed (427)

pnpm test:edge
Test Files 21 passed (21)
Tests 427 passed (427)
```

`pnpm test:e2e` and `pnpm test:issues` were not run because they hit the real OpenRouter API and require `OPENROUTER_API_KEY`.

## Release notes

- Added a major changeset.
- Updated README and CHANGELOG for AI SDK v7, Node 22, ESM-only packaging, and v7 usage token details.
