### PR TITLE
fix: align assistant cache_control handling with user/system paths

### DIFF
--- a/.changeset/every-zoos-sip.md
+++ b/.changeset/every-zoos-sip.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": patch
+---
+
+fix: align assistant cache_control handling with user/system paths

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -793,8 +793,45 @@ describe('cache control', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: 'Assistant response',
-        cache_control: { type: 'ephemeral' },
+        content: [
+          {
+            type: 'text',
+            text: 'Assistant response',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should pass cache control from assistant text part provider metadata', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Assistant response',
+            providerOptions: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Assistant response',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
       },
     ]);
   });

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -836,6 +836,35 @@ describe('cache control', () => {
     ]);
   });
 
+  it('should only apply message-level cache control to last text part on assistant message (multiple text parts)', () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'First' },
+          { type: 'text', text: 'Second' },
+        ],
+        providerOptions: {
+          anthropic: { cacheControl: { type: 'ephemeral' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'First' },
+          {
+            type: 'text',
+            text: 'Second',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should pass cache control from tool message provider metadata', () => {
     const result = convertToOpenRouterChatMessages([
       {

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -9,6 +9,7 @@ import type {
 import type { ReasoningDetailUnion } from '../schemas/reasoning-details';
 import type {
   ChatCompletionContentPart,
+  ChatCompletionContentPartText,
   OpenRouterChatCompletionsInput,
 } from '../types/openrouter-chat-completions-input';
 
@@ -220,16 +221,35 @@ export function convertToOpenRouterChatMessages(
       case 'assistant': {
         let text = '';
         let reasoning = '';
+        const textParts: ChatCompletionContentPartText[] = [];
         const toolCalls: Array<{
           id: string;
           type: 'function';
           function: { name: string; arguments: string };
         }> = [];
+        const messageCacheControl = getCacheControl(providerOptions);
+        let lastTextPartIndex = -1;
 
-        for (const part of content) {
+        for (let index = content.length - 1; index >= 0; index--) {
+          if (content[index]?.type === 'text') {
+            lastTextPartIndex = index;
+            break;
+          }
+        }
+
+        for (const [index, part] of content.entries()) {
           switch (part.type) {
             case 'text': {
+              const cacheControl =
+                getCacheControl(part.providerOptions) ??
+                (index === lastTextPartIndex ? messageCacheControl : undefined);
+
               text += part.text;
+              textParts.push({
+                type: 'text',
+                text: part.text,
+                ...(cacheControl && { cache_control: cacheControl }),
+              });
               break;
             }
             case 'tool-call': {
@@ -367,15 +387,20 @@ export function convertToOpenRouterChatMessages(
           reasoning && finalReasoningDetails && finalReasoningDetails.length > 0
             ? reasoning
             : undefined;
+        const hasTextPartCacheControl = textParts.some(
+          (part) => part.cache_control !== undefined,
+        );
 
         messages.push({
           role: 'assistant',
-          content: text || null,
+          content: hasTextPartCacheControl ? textParts : text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           reasoning: effectiveReasoning,
           reasoning_details: finalReasoningDetails,
           annotations: messageAnnotations,
-          cache_control: getCacheControl(providerOptions),
+          cache_control: hasTextPartCacheControl
+            ? undefined
+            : messageCacheControl,
         });
 
         break;

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -90,7 +90,7 @@ export interface ChatCompletionContentPartInputAudio {
 
 export interface ChatCompletionAssistantMessageParam {
   role: 'assistant';
-  content?: string | null;
+  content?: string | null | Array<ChatCompletionContentPartText>;
   reasoning?: string | null;
   reasoning_details?: ReasoningDetailUnion[];
   annotations?: FileAnnotation[];


### PR DESCRIPTION
`providerOptions.anthropic.cacheControl` on an assistant text part stayed out of the serialized content block, so the converter did not match the user/system cache-control path. This maps assistant text-part and message-level cache control onto assistant text content blocks, while assistant turns without cache control still use the existing string/null content shape. The new converter test captures that repro: before the fix it emitted string content with no block-level `cache_control`, and after the change the assistant text block carries `cache_control`. I ran `pnpm vitest run src/chat/convert-to-openrouter-chat-messages.test.ts`, `pnpm test`, `pnpm typecheck`, `pnpm stylecheck`, and `pnpm build`. If #511 lands first this may need a rebase; fixes #498.
