### PR TITLE
feat: support `reasoning` parameter introduced in AI SDK v7

### DIFF
--- a/.changeset/calm-seas-shave.md
+++ b/.changeset/calm-seas-shave.md
@@ -1,0 +1,5 @@
+---
+"@openrouter/ai-sdk-provider": minor
+---
+
+Support `reasoning` parameter introduced in AI SDK v7

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -6100,3 +6100,231 @@ describe('includeRawChunks', () => {
     expect(errorChunks.length).toBe(1);
   });
 });
+
+describe('reasoning settings', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  function prepareJsonResponse({ content = '' }: { content?: string } = {}) {
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'anthropic/claude-3.5-sonnet',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content,
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 4,
+          total_tokens: 34,
+          completion_tokens: 30,
+        },
+      },
+    };
+  }
+
+  describe('if reasoning settings is given', () => {
+    it('should pass reasoning settings in doGenerate', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'anthropic/claude-3.5-sonnet',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning: {
+          effort: 'medium',
+        },
+      });
+    });
+
+    it('should ignore reasoning parameter of model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.chat(
+        'anthropic/claude-3.5-sonnet',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'anthropic/claude-3.5-sonnet',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning: {
+          effort: 'medium',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning parameter is undefined', () => {
+    it('should not include reasoning parameter', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      const requestBody = await server.calls[0]!.requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning');
+    });
+
+    it('should falls back to reasoning parameter of model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.chat(
+        'anthropic/claude-3.5-sonnet',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'anthropic/claude-3.5-sonnet',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning: {
+          effort: 'high',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning parameter is provider-default', () => {
+    it('should not include reasoning parameter', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'provider-default',
+      });
+
+      const requestBody = await server.calls[0]!.requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning');
+    });
+
+    it('should falls back to reasoning parameter of model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.chat(
+        'anthropic/claude-3.5-sonnet',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'provider-default',
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'anthropic/claude-3.5-sonnet',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning: {
+          effort: 'high',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning parameter is given by providerOptions', () => {
+    it('should ignore top-level reasoning parameter and model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.chat(
+        'anthropic/claude-3.5-sonnet',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+        providerOptions: {
+          openrouter: {
+            reasoning: {
+              effort: 'low',
+            },
+          },
+        },
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'anthropic/claude-3.5-sonnet',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning: {
+          effort: 'low',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning_effort parameter is given by providerOptions', () => {
+    it('should ignore top-level reasoning parameter and model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.chat(
+        'anthropic/claude-3.5-sonnet',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+        providerOptions: {
+          openrouter: {
+            reasoning_effort: 'low',
+          },
+        },
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'anthropic/claude-3.5-sonnet',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning_effort: 'low',
+      });
+    });
+  });
+});

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -31,6 +31,7 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
+  isCustomReasoning,
   isParsableJson,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -102,6 +103,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
     topK,
     tools,
     toolChoice,
+    reasoning,
+    providerOptions,
   }: LanguageModelV4CallOptions) {
     const baseArgs = {
       // model id:
@@ -158,7 +161,13 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
 
       // OpenRouter specific settings:
       include_reasoning: this.settings.includeReasoning,
-      reasoning: this.settings.reasoning,
+      reasoning:
+        providerOptions?.openrouter?.reasoning_effort !== undefined ||
+        providerOptions?.openrouter?.reasoning !== undefined
+          ? undefined
+          : isCustomReasoning(reasoning)
+            ? { effort: reasoning }
+            : this.settings.reasoning,
       usage: this.settings.usage,
 
       // Web search settings:

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -962,3 +962,228 @@ describe('includeRawChunks', () => {
     expect(errorChunks.length).toBe(1);
   });
 });
+
+describe('reasoning settings', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  function prepareJsonResponse({ content = '' }: { content?: string } = {}) {
+    server.urls['https://openrouter.ai/api/v1/completions']!.response = {
+      type: 'json-value',
+      body: {
+        id: 'cmpl-test',
+        object: 'text_completion',
+        created: 1711363706,
+        model: 'openai/gpt-3.5-turbo-instruct',
+        choices: [
+          {
+            index: 0,
+            text: content,
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 4,
+          total_tokens: 34,
+          completion_tokens: 30,
+        },
+      },
+    };
+  }
+
+  describe('if reasoning settings is given', () => {
+    it('should pass reasoning settings in doGenerate', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'openai/gpt-3.5-turbo-instruct',
+        prompt: 'Hello',
+        reasoning: {
+          effort: 'medium',
+        },
+      });
+    });
+
+    it('should ignore reasoning parameter of model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.completion(
+        'openai/gpt-3.5-turbo-instruct',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'openai/gpt-3.5-turbo-instruct',
+        prompt: 'Hello',
+        reasoning: {
+          effort: 'medium',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning parameter is undefined', () => {
+    it('should not include reasoning parameter', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      const requestBody = await server.calls[0]!.requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning');
+    });
+
+    it('should falls back to reasoning parameter of model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.completion(
+        'openai/gpt-3.5-turbo-instruct',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'openai/gpt-3.5-turbo-instruct',
+        prompt: 'Hello',
+        reasoning: {
+          effort: 'high',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning parameter is provider-default', () => {
+    it('should not include reasoning parameter', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'provider-default',
+      });
+
+      const requestBody = await server.calls[0]!.requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning');
+    });
+
+    it('should falls back to reasoning parameter of model settings', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.completion(
+        'openai/gpt-3.5-turbo-instruct',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'provider-default',
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'openai/gpt-3.5-turbo-instruct',
+        prompt: 'Hello',
+        reasoning: {
+          effort: 'high',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning parameter is given by providerOptions', () => {
+    it('should ignore top-level reasoning parameter and model setting', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.completion(
+        'openai/gpt-3.5-turbo-instruct',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+        providerOptions: {
+          openrouter: {
+            reasoning: {
+              effort: 'low',
+            },
+          },
+        },
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'openai/gpt-3.5-turbo-instruct',
+        prompt: 'Hello',
+        reasoning: {
+          effort: 'low',
+        },
+      });
+    });
+  });
+
+  describe('if reasoning_effort parameter is given by providerOptions', () => {
+    it('should ignore top-level reasoning parameter and model setting', async () => {
+      prepareJsonResponse({ content: 'Hello!' });
+
+      const modelWithReasoningSetting = provider.completion(
+        'openai/gpt-3.5-turbo-instruct',
+        {
+          reasoning: {
+            effort: 'high',
+          },
+        },
+      );
+
+      await modelWithReasoningSetting.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'medium',
+        providerOptions: {
+          openrouter: {
+            reasoning_effort: 'low',
+          },
+        },
+      });
+
+      expect(await server.calls[0]!.requestBodyJson).toStrictEqual({
+        model: 'openai/gpt-3.5-turbo-instruct',
+        prompt: 'Hello',
+        reasoning_effort: 'low',
+      });
+    });
+  });
+});

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -25,6 +25,7 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
+  isCustomReasoning,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import { openrouterFailedResponseHandler } from '../schemas/error-response';
@@ -88,6 +89,8 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
     stopSequences,
     tools,
     toolChoice,
+    reasoning,
+    providerOptions,
   }: LanguageModelV4CallOptions) {
     const { prompt: completionPrompt } = convertToOpenRouterCompletionPrompt({
       prompt,
@@ -141,7 +144,13 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
 
       // OpenRouter specific settings:
       include_reasoning: this.settings.includeReasoning,
-      reasoning: this.settings.reasoning,
+      reasoning:
+        providerOptions?.openrouter?.reasoning_effort !== undefined ||
+        providerOptions?.openrouter?.reasoning !== undefined
+          ? undefined
+          : isCustomReasoning(reasoning)
+            ? { effort: reasoning }
+            : this.settings.reasoning,
 
       // extra body:
       ...this.config.extraBody,


### PR DESCRIPTION
## Description

AI SDK v7 introduces the `reasoning` parameter to `generateText`/`streamText`:

https://ai-sdk.dev/docs/ai-sdk-core/reasoning
https://ai-sdk.dev/docs/ai-sdk-core/settings#reasoning
https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#reasoning
https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text#reasoning

It has lower precedence than `providerOptions`. See the official providers.

Note that OpenRouter accepts `reasoning_effort` and `reasoning.effort`, and we cannot use both simultaneously if they differ. So we ignore the top-level `reasoning` parameter if `providerOptions` has `reasoning_effort` or `reasoning`.

https://openrouter.ai/docs/api/api-reference/chat/create-a-chat-completion#body-reasoning

## Checklist

- [X] I have run `pnpm stylecheck` and `pnpm typecheck`
- [X] I have run `pnpm test` and all tests pass
- [X] I have added tests for my changes (if applicable)
- [X] I have updated documentation (if applicable)
         No changes are required.

`pnpm test:e2e` fails because the tests use old endpoints. They are not related to the changes I made. I didn't run `pnpm test:issues`.

### Changeset

- [X] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.
