### PR TITLE
fix(chat): merge consecutive streaming reasoning.summary deltas (#519)

### DIFF
--- a/e2e/issues/issue-519-streaming-summary-merge.test.ts
+++ b/e2e/issues/issue-519-streaming-summary-merge.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression test for GitHub issue #519
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/519
+ *
+ * Issue: During streaming, consecutive `reasoning.summary` deltas were pushed
+ * to the accumulated reasoning_details as-is (one entry per delta) instead of
+ * being merged the way consecutive `reasoning.text` deltas are. Providers such
+ * as OpenAI `openai-responses-v1` stream a single logical summary as many small
+ * deltas that all carry `index: 0`, so the array fragmented into one entry per
+ * delta. Re-submitting that fragmented array on the next turn breaks multi-turn
+ * reasoning round-tripping (cf. langchain-ai/langchain#36400).
+ *
+ * Fix: consecutive `reasoning.summary` deltas are concatenated by their
+ * `summary` field, mirroring the existing `reasoning.text` merge. Encrypted
+ * details remain discrete (each is an opaque blob with its own id).
+ */
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { createOpenRouter } from '@/src';
+import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
+
+vi.mock('@/src/version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Think step by step.' }] },
+];
+
+const provider = createOpenRouter({
+  apiKey: 'test-api-key',
+  compatibility: 'strict',
+});
+
+type AccumulatedDetail = {
+  type: string;
+  summary?: string;
+  data?: string;
+  id?: string;
+  index?: number;
+};
+
+describe('Issue #519: streaming reasoning.summary deltas must be merged', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/chat/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  /**
+   * Reproduces the customer scenario: a summary streamed as N deltas (all
+   * index:0), followed by a single encrypted delta (also index:0), then text.
+   */
+  function buildSummaryThenEncryptedChunks(summaryParts: string[]): string[] {
+    const id = 'chatcmpl-519-summary';
+    const base = `"object":"chat.completion.chunk","created":1711357598,"model":"openai/gpt-5.4-nano","system_fingerprint":"fp_test"`;
+    const chunks: string[] = [];
+
+    summaryParts.forEach((part, i) => {
+      const isFirst = i === 0;
+      const rolePart = isFirst ? `"role":"assistant","content":"",` : '';
+      chunks.push(
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{${rolePart}"reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":${JSON.stringify(part)},"format":"openai-responses-v1","index":0}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+      );
+    });
+
+    // Encrypted block — different type, but also index:0 in streaming.
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Encrypted}","data":"gAAAAA...Fgw=","id":"rs_0fcb21ad7ba2c5f7","format":"openai-responses-v1","index":0}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+    );
+
+    // Text content delta
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"content":"The answer is 42."},"logprobs":null,"finish_reason":null}]}\n\n`,
+    );
+
+    // Finish + usage + DONE
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}\n\n`,
+    );
+    chunks.push(
+      `data: {"id":"${id}",${base},"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+    );
+    chunks.push('data: [DONE]\n\n');
+
+    return chunks;
+  }
+
+  function getAccumulatedDetails(
+    elements: Array<{ type: string; providerMetadata?: unknown }>,
+  ): AccumulatedDetail[] | undefined {
+    const finishEvent = elements.find((el) => el.type === 'finish');
+    return (
+      finishEvent?.providerMetadata as
+        | { openrouter?: { reasoning_details?: AccumulatedDetail[] } }
+        | undefined
+    )?.openrouter?.reasoning_details;
+  }
+
+  it('merges consecutive summary deltas into a single entry', async () => {
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: buildSummaryThenEncryptedChunks([' reading', ' it', '.']),
+    };
+
+    const model = provider.chat('openai/gpt-5.4-nano');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const details = getAccumulatedDetails(elements);
+    expect(details).toBeDefined();
+
+    const summaries = details!.filter(
+      (d) => d.type === ReasoningDetailType.Summary,
+    );
+    const encrypted = details!.filter(
+      (d) => d.type === ReasoningDetailType.Encrypted,
+    );
+
+    // Three summary deltas collapse into ONE merged summary entry...
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.summary).toBe(' reading it.');
+    // ...and the encrypted block stays a discrete entry.
+    expect(encrypted).toHaveLength(1);
+    expect(encrypted[0]?.data).toBe('gAAAAA...Fgw=');
+
+    // Total accumulated shape matches non-streaming: [summary, encrypted]
+    expect(details).toHaveLength(2);
+  });
+
+  it('keeps distinct encrypted blocks separate (no cross-type merge)', async () => {
+    const id = 'chatcmpl-519-multi';
+    const base = `"object":"chat.completion.chunk","created":1711357598,"model":"openai/gpt-5.4-nano"`;
+    const chunks: string[] = [
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":"a","format":"openai-responses-v1","index":0}]},"finish_reason":null}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":"b","format":"openai-responses-v1","index":0}]},"finish_reason":null}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Encrypted}","data":"BLOB1","id":"rs_1","index":0}]},"finish_reason":null}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":"c","format":"openai-responses-v1","index":0}]},"finish_reason":null}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"${ReasoningDetailType.Encrypted}","data":"BLOB2","id":"rs_2","index":0}]},"finish_reason":null}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n`,
+      `data: {"id":"${id}",${base},"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n`,
+      'data: [DONE]\n\n',
+    ];
+
+    server.urls['https://openrouter.ai/api/v1/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+
+    const model = provider.chat('openai/gpt-5.4-nano');
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT });
+    const elements = await convertReadableStreamToArray(stream);
+
+    const details = getAccumulatedDetails(elements);
+    expect(details).toBeDefined();
+
+    // summary(a+b) | encrypted(BLOB1) | summary(c) | encrypted(BLOB2)
+    expect(details).toHaveLength(4);
+    expect(details![0]).toMatchObject({
+      type: ReasoningDetailType.Summary,
+      summary: 'ab',
+    });
+    expect(details![1]).toMatchObject({
+      type: ReasoningDetailType.Encrypted,
+      data: 'BLOB1',
+    });
+    expect(details![2]).toMatchObject({
+      type: ReasoningDetailType.Summary,
+      summary: 'c',
+    });
+    expect(details![3]).toMatchObject({
+      type: ReasoningDetailType.Encrypted,
+      data: 'BLOB2',
+    });
+  });
+});

--- a/e2e/issues/issue-519-streaming-summary-merge.test.ts
+++ b/e2e/issues/issue-519-streaming-summary-merge.test.ts
@@ -49,6 +49,7 @@ type AccumulatedDetail = {
   data?: string;
   id?: string;
   index?: number;
+  format?: string;
 };
 
 describe('Issue #519: streaming reasoning.summary deltas must be merged', () => {
@@ -74,8 +75,13 @@ describe('Issue #519: streaming reasoning.summary deltas must be merged', () => 
     summaryParts.forEach((part, i) => {
       const isFirst = i === 0;
       const rolePart = isFirst ? `"role":"assistant","content":"",` : '';
+      // The first summary delta intentionally omits `format`; a later delta
+      // carries it. This exercises the merge's format-preservation fallback
+      // (lastDetail.format = lastDetail.format || detail.format) so the merged
+      // entry ends up with the format even when the leading delta lacked it.
+      const formatPart = isFirst ? '' : `,"format":"openai-responses-v1"`;
       chunks.push(
-        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{${rolePart}"reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":${JSON.stringify(part)},"format":"openai-responses-v1","index":0}]},"logprobs":null,"finish_reason":null}]}\n\n`,
+        `data: {"id":"${id}",${base},"choices":[{"index":0,"delta":{${rolePart}"reasoning_details":[{"type":"${ReasoningDetailType.Summary}","summary":${JSON.stringify(part)}${formatPart},"index":0}]},"logprobs":null,"finish_reason":null}]}\n\n`,
       );
     });
 
@@ -135,6 +141,8 @@ describe('Issue #519: streaming reasoning.summary deltas must be merged', () => 
     // Three summary deltas collapse into ONE merged summary entry...
     expect(summaries).toHaveLength(1);
     expect(summaries[0]?.summary).toBe(' reading it.');
+    // ...with format preserved from the deltas on the merged entry.
+    expect(summaries[0]?.format).toBe('openai-responses-v1');
     // ...and the encrypted block stays a discrete entry.
     expect(encrypted).toHaveLength(1);
     expect(encrypted[0]?.data).toBe('gAAAAA...Fgw=');

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -772,14 +772,22 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
             };
 
             if (delta.reasoning_details && delta.reasoning_details.length > 0) {
-              // Accumulate reasoning_details to preserve for multi-turn conversations
-              // Merge consecutive reasoning.text items into a single entry
+              // Accumulate reasoning_details to preserve for multi-turn conversations.
+              // Merge consecutive same-type text/summary deltas into a single
+              // entry. Providers (e.g. OpenAI `openai-responses-v1`) stream a
+              // logical reasoning block as many small deltas that all carry the
+              // same `index` (frequently `index: 0`), so `index` cannot be used
+              // to reassemble the array — reassembly is driven by the `type`
+              // transition instead. Without merging summary deltas the array
+              // fragments into one entry per delta, which breaks multi-turn
+              // round-tripping when re-submitted (see issue #519, langchain #36400).
               for (const detail of delta.reasoning_details) {
+                const lastDetail =
+                  accumulatedReasoningDetails[
+                    accumulatedReasoningDetails.length - 1
+                  ];
+
                 if (detail.type === ReasoningDetailType.Text) {
-                  const lastDetail =
-                    accumulatedReasoningDetails[
-                      accumulatedReasoningDetails.length - 1
-                    ];
                   if (lastDetail?.type === ReasoningDetailType.Text) {
                     // Merge with the previous text detail
                     lastDetail.text =
@@ -793,8 +801,20 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
                     // Start a new text detail
                     accumulatedReasoningDetails.push({ ...detail });
                   }
+                } else if (detail.type === ReasoningDetailType.Summary) {
+                  if (lastDetail?.type === ReasoningDetailType.Summary) {
+                    // Merge consecutive summary deltas by concatenating text
+                    lastDetail.summary =
+                      (lastDetail.summary || '') + (detail.summary || '');
+
+                    lastDetail.format = lastDetail.format || detail.format;
+                  } else {
+                    // Start a new summary detail
+                    accumulatedReasoningDetails.push({ ...detail });
+                  }
                 } else {
-                  // Non-text details (encrypted, summary) are pushed as-is
+                  // Encrypted details are opaque blobs (each has its own id);
+                  // they are discrete and must be pushed as-is, never merged.
                   accumulatedReasoningDetails.push(detail);
                 }
               }


### PR DESCRIPTION
## Summary

Fixes #519.

During streaming, the provider merges consecutive `reasoning.text` deltas into a single accumulated entry, but `reasoning.summary` deltas were pushed as-is — one array entry per delta. Providers that stream a summary as many small deltas (e.g. OpenAI `openai-responses-v1`, `openai/gpt-5.4-nano`) therefore fragmented a single logical summary block into dozens of one-token entries.

When that fragmented `reasoning_details` array is re-submitted on the next turn to preserve reasoning context, it no longer matches the shape returned in non-streaming mode, which breaks multi-turn round-tripping. This is the same class of failure reported downstream in langchain-ai/langchain#36400 (`reasoning_details count: Expected 1, Actual 6` → `BadRequestResponseError` on turn 2).

## Why not merge by `index`?

Callers often expect to reassemble deltas using the `index` field, but in streaming every `reasoning_details` delta carries `index: 0` regardless of which logical block it belongs to (both summary and encrypted). In non-streaming the same response returns properly incrementing indices. Because `index` is unreliable in streaming, reassembly is driven by the `type` transition — exactly what the existing text-merge path already does. This PR gives summary deltas the same treatment.

## Changes

- `src/chat/index.ts`: consecutive `reasoning.summary` deltas are now concatenated by their `summary` field (mirroring the `reasoning.text` merge). `reasoning.encrypted` deltas remain discrete — each is an opaque blob with its own `id` and must never be merged.
- `e2e/issues/issue-519-streaming-summary-merge.test.ts`: regression test reproducing the customer scenario (N summary deltas all `index:0`, then an encrypted delta), asserting summaries collapse to one entry while encrypted stays separate, and a second case verifying no cross-type merging across interleaved summary/encrypted blocks.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:node` — 432 passed (no regressions)
- [x] `pnpm stylecheck` (biome) — clean on changed files
- [x] New regression test **fails on `main`** (summaries fragment: got 3, expected 1) and **passes with this fix**

## Before / after (accumulated `reasoning_details` for a summary streamed as `" reading"`, `" it"`, `"."` then an encrypted block)

| | Result |
|---|---|
| Before | `[summary" reading", summary" it", summary".", encrypted]` — 4 entries |
| After | `[summary" reading it.", encrypted]` — 2 entries, matches non-streaming |
