### PR TITLE
test(e2e): replace retired anthropic model slugs

### DIFF
--- a/e2e/cache-control.test.ts
+++ b/e2e/cache-control.test.ts
@@ -38,7 +38,7 @@ async function callLLM() {
     apiKey: process.env.OPENROUTER_API_KEY,
     baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
   });
-  const model = openrouter('anthropic/claude-3.7-sonnet', {
+  const model = openrouter('anthropic/claude-sonnet-4', {
     usage: {
       include: true,
     },

--- a/e2e/issues/issue-196-anthropic-1h-cache-ttl.test.ts
+++ b/e2e/issues/issue-196-anthropic-1h-cache-ttl.test.ts
@@ -22,7 +22,7 @@ describe('Issue #196: Anthropic 1-hour cache TTL', () => {
     baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
   });
 
-  const model = openrouter('anthropic/claude-3.7-sonnet', {
+  const model = openrouter('anthropic/claude-sonnet-4', {
     usage: { include: true },
   });
 

--- a/e2e/issues/issue-407-token-usage-details.test.ts
+++ b/e2e/issues/issue-407-token-usage-details.test.ts
@@ -59,9 +59,9 @@ describe('Issue #407: Token usage detail fields should not be undefined', () => 
       );
     });
 
-    it('should populate reasoning tokens with anthropic/claude-3.7-sonnet:thinking', async () => {
+    it('should populate reasoning tokens with anthropic/claude-sonnet-4:thinking', async () => {
       const response = await generateText({
-        model: openrouter('anthropic/claude-3.7-sonnet:thinking'),
+        model: openrouter('anthropic/claude-sonnet-4:thinking'),
         messages: [
           {
             role: 'user',
@@ -113,9 +113,9 @@ describe('Issue #407: Token usage detail fields should not be undefined', () => 
       );
     });
 
-    it('should populate reasoning tokens with anthropic/claude-3.7-sonnet:thinking', async () => {
+    it('should populate reasoning tokens with anthropic/claude-sonnet-4:thinking', async () => {
       const response = streamText({
-        model: openrouter('anthropic/claude-3.7-sonnet:thinking'),
+        model: openrouter('anthropic/claude-sonnet-4:thinking'),
         messages: [
           {
             role: 'user',

--- a/e2e/pdf-blob/index.test.ts
+++ b/e2e/pdf-blob/index.test.ts
@@ -71,7 +71,7 @@ test('sending large pdf base64 blob with FileParserPlugin', async () => {
     baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
   });
 
-  const model = openrouter('anthropic/claude-3.5-sonnet', {
+  const model = openrouter('anthropic/claude-sonnet-4', {
     plugins: [
       {
         id: 'file-parser',

--- a/e2e/usage-accounting.test.ts
+++ b/e2e/usage-accounting.test.ts
@@ -11,7 +11,7 @@ it('receive usage accounting', async () => {
     apiKey: process.env.OPENROUTER_API_KEY,
     baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
   });
-  const model = openrouter('anthropic/claude-3.7-sonnet:thinking', {
+  const model = openrouter('anthropic/claude-sonnet-4:thinking', {
     usage: {
       include: true,
     },

--- a/e2e/web-search/index.test.ts
+++ b/e2e/web-search/index.test.ts
@@ -14,7 +14,7 @@ describe('Web Search E2E Tests', () => {
       baseUrl: `${process.env.OPENROUTER_API_BASE}/api/v1`,
     });
 
-    const model = openrouter('anthropic/claude-3.5-sonnet', {
+    const model = openrouter('anthropic/claude-sonnet-4', {
       plugins: [
         {
           id: 'web',


### PR DESCRIPTION
Closes #512

The e2e suite pins `anthropic/claude-3.5-sonnet` and `anthropic/claude-3.7-sonnet` (plus the `:thinking` variant), which have been retired and now return 404 "No endpoints found". Those tests fail before exercising any provider behavior.

This points the affected real-API tests at `anthropic/claude-sonnet-4`, which most of the suite already uses:

* `cache-control` and `issue-196`: plain `claude-sonnet-4`, it supports prompt caching and the 1h TTL
* `usage-accounting` and `issue-407`: `claude-sonnet-4:thinking`, since issue-407 asserts `reasoningTokens` is populated and needs a reasoning variant. The variant doesn't show up in `/api/v1/models` but resolves fine via the endpoints API.
* `web-search` and `pdf-blob` (large pdf case): plain `claude-sonnet-4`

Not touched: `issue-412` and `issue-413` only use the old slug as label data inside mocked SSE payloads, and it turns out `issue-484` never hits the network either (fake API key, it only checks the `supportedUrls` regexes), so the old slug is inert in all three. Same for the src unit test fixtures.

Verified the replacement slugs resolve against the live API. `pnpm test`, `pnpm typecheck` and `biome check` on the changed files all pass locally. I don't have a setup to run the full e2e suite against a live key, but #512 reports the four verified-failing tests pass with `claude-sonnet-4` and no other changes.
