### PR TITLE
fix: implement workflow serde hooks for durable execution (#525)

### DIFF
--- a/.changeset/workflow-serialization-hooks.md
+++ b/.changeset/workflow-serialization-hooks.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Implement `WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE` hooks on the chat and completion language models so model instances can be used with `@ai-sdk/workflow` durable execution. Mirrors the first-party AI SDK providers and fixes the `WorkflowRuntimeError: Failed to serialize step arguments` thrown when a model is passed as a durable step argument (#525).

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -33,6 +33,9 @@ import {
   generateId,
   isParsableJson,
   postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
 } from '@ai-sdk/provider-utils';
 import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 import { openrouterFailedResponseHandler } from '../schemas/error-response';
@@ -78,6 +81,34 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
   readonly settings: OpenRouterChatSettings;
 
   private readonly config: OpenRouterChatConfig;
+
+  /**
+   * Serializes the model for `@ai-sdk/workflow` durable step boundaries.
+   *
+   * `serializeModelOptions` resolves the `headers` closure and strips the
+   * remaining non-JSON `config` values (`url`, `fetch`); `settings` is
+   * captured alongside so the constructor can faithfully round-trip.
+   */
+  static [WORKFLOW_SERIALIZE](model: OpenRouterChatLanguageModel) {
+    const { modelId, config } = serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+
+    return { modelId, config, settings: model.settings };
+  }
+
+  static [WORKFLOW_DESERIALIZE](data: {
+    modelId: OpenRouterChatModelId;
+    settings: OpenRouterChatSettings;
+    config: OpenRouterChatConfig;
+  }) {
+    return new OpenRouterChatLanguageModel(
+      data.modelId,
+      data.settings,
+      data.config,
+    );
+  }
 
   constructor(
     modelId: OpenRouterChatModelId,

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -26,6 +26,9 @@ import {
   createJsonResponseHandler,
   generateId,
   postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
 } from '@ai-sdk/provider-utils';
 import { openrouterFailedResponseHandler } from '../schemas/error-response';
 import { OpenRouterProviderMetadataSchema } from '../schemas/provider-metadata';
@@ -64,6 +67,34 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
   readonly settings: OpenRouterCompletionSettings;
 
   private readonly config: OpenRouterCompletionConfig;
+
+  /**
+   * Serializes the model for `@ai-sdk/workflow` durable step boundaries.
+   *
+   * `serializeModelOptions` resolves the `headers` closure and strips the
+   * remaining non-JSON `config` values (`url`, `fetch`); `settings` is
+   * captured alongside so the constructor can faithfully round-trip.
+   */
+  static [WORKFLOW_SERIALIZE](model: OpenRouterCompletionLanguageModel) {
+    const { modelId, config } = serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+
+    return { modelId, config, settings: model.settings };
+  }
+
+  static [WORKFLOW_DESERIALIZE](data: {
+    modelId: OpenRouterCompletionModelId;
+    settings: OpenRouterCompletionSettings;
+    config: OpenRouterCompletionConfig;
+  }) {
+    return new OpenRouterCompletionLanguageModel(
+      data.modelId,
+      data.settings,
+      data.config,
+    );
+  }
 
   constructor(
     modelId: OpenRouterCompletionModelId,

--- a/src/workflow-serialization.test.ts
+++ b/src/workflow-serialization.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression test for GitHub issue #525
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/525
+ *
+ * Reported error: WorkflowRuntimeError: Failed to serialize step arguments at
+ * path ".args[1]".
+ *
+ * `@ai-sdk/workflow`'s `WorkflowAgent` runs each model call as a durable step
+ * and serializes the model as a step argument. First-party providers implement
+ * the `WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE` hooks so their models
+ * round-trip across the durable (e.g. world-postgres) boundary. This test
+ * verifies the OpenRouter model classes implement the same contract: the
+ * serialized payload is structured-clone-safe (no closures), and the model
+ * reconstructs with its `modelId`, `settings`, and resolved config intact.
+ */
+import {
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import { OpenRouterChatLanguageModel } from './chat';
+import { OpenRouterCompletionLanguageModel } from './completion';
+import { createOpenRouter } from './provider';
+
+const provider = createOpenRouter({ apiKey: 'test-api-key' });
+
+// The workflow runtime hands the deserialize hook the persisted payload,
+// whose `config` has been reduced to a plain JSON object. Chaining the two
+// hooks directly in a test therefore needs a cast to model that boundary.
+type ChatDeserializeInput = Parameters<
+  (typeof OpenRouterChatLanguageModel)[typeof WORKFLOW_DESERIALIZE]
+>[0];
+type CompletionDeserializeInput = Parameters<
+  (typeof OpenRouterCompletionLanguageModel)[typeof WORKFLOW_DESERIALIZE]
+>[0];
+
+describe('Issue #525: durable-execution model serialization', () => {
+  describe('OpenRouterChatLanguageModel', () => {
+    it('exposes the workflow serde hooks as static methods', () => {
+      expect(typeof OpenRouterChatLanguageModel[WORKFLOW_SERIALIZE]).toBe(
+        'function',
+      );
+      expect(typeof OpenRouterChatLanguageModel[WORKFLOW_DESERIALIZE]).toBe(
+        'function',
+      );
+    });
+
+    it('serializes to a structured-clone-safe payload', () => {
+      const model = provider.chat('anthropic/claude-3.5-sonnet', {
+        temperature: 0.7,
+        provider: { order: ['anthropic'] },
+        extraBody: { transforms: ['middle-out'] },
+      });
+
+      const serialized = OpenRouterChatLanguageModel[WORKFLOW_SERIALIZE](model);
+
+      // Closures must be stripped; a resolved headers object is kept.
+      expect(serialized.config.url).toBeUndefined();
+      expect(serialized.config.fetch).toBeUndefined();
+      expect(serialized.config.provider).toBe('openrouter.chat');
+      expect(
+        (serialized.config.headers as Record<string, string>).Authorization,
+      ).toBe('Bearer test-api-key');
+
+      // The whole payload must survive the durable boundary.
+      expect(() => structuredClone(serialized)).not.toThrow();
+      expect(() => JSON.stringify(serialized)).not.toThrow();
+    });
+
+    it('round-trips modelId and settings across the durable boundary', () => {
+      const settings = {
+        temperature: 0.7,
+        provider: { order: ['anthropic'], allow_fallbacks: false },
+        extraBody: { transforms: ['middle-out'] },
+      };
+      const model = provider.chat('anthropic/claude-3.5-sonnet', settings);
+
+      const serialized = OpenRouterChatLanguageModel[WORKFLOW_SERIALIZE](model);
+      const restored = OpenRouterChatLanguageModel[WORKFLOW_DESERIALIZE](
+        structuredClone(serialized) as unknown as ChatDeserializeInput,
+      );
+
+      expect(restored).toBeInstanceOf(OpenRouterChatLanguageModel);
+      expect(restored.modelId).toBe('anthropic/claude-3.5-sonnet');
+      expect(restored.settings).toEqual(settings);
+      expect(restored.provider).toBe('openrouter');
+    });
+  });
+
+  describe('OpenRouterCompletionLanguageModel', () => {
+    it('exposes the workflow serde hooks as static methods', () => {
+      expect(typeof OpenRouterCompletionLanguageModel[WORKFLOW_SERIALIZE]).toBe(
+        'function',
+      );
+      expect(
+        typeof OpenRouterCompletionLanguageModel[WORKFLOW_DESERIALIZE],
+      ).toBe('function');
+    });
+
+    it('round-trips modelId and settings across the durable boundary', () => {
+      const settings = { temperature: 0.5, suffix: '\n\n' };
+      const model = provider.completion(
+        'openai/gpt-3.5-turbo-instruct',
+        settings,
+      );
+
+      const serialized =
+        OpenRouterCompletionLanguageModel[WORKFLOW_SERIALIZE](model);
+
+      expect(serialized.config.url).toBeUndefined();
+      expect(serialized.config.fetch).toBeUndefined();
+      expect(() => structuredClone(serialized)).not.toThrow();
+
+      const restored = OpenRouterCompletionLanguageModel[WORKFLOW_DESERIALIZE](
+        structuredClone(serialized) as unknown as CompletionDeserializeInput,
+      );
+
+      expect(restored).toBeInstanceOf(OpenRouterCompletionLanguageModel);
+      expect(restored.modelId).toBe('openai/gpt-3.5-turbo-instruct');
+      expect(restored.settings).toEqual(settings);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`@ai-sdk/workflow`'s `WorkflowAgent` runs each model call as a durable step and serializes the model as a step argument. Under a persisted world (e.g. `@workflow/world-postgres`), those step arguments must be serialized so the step can replay. A live model instance carries closures (`fetch`, `headers`, `url`) that the devalue-based world serializer can only handle if the model class provides serde hooks.

The first-party AI SDK providers (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) implement two static, globally-keyed symbol methods — `WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE` (re-exported by `@ai-sdk/provider-utils` from `@workflow/serde`) — so their models round-trip across the durable boundary. The OpenRouter model classes did not, so they threw:

```
WorkflowRuntimeError: Failed to serialize step arguments at path ".args[1]".
Ensure you're passing serializable types (plain objects, arrays, primitives, Date, RegExp, Map, Set).
```

Swapping the model for `@ai-sdk/openai-compatible` (same OpenRouter endpoint) works, because it implements the hooks.

## Fix

Implement the two hooks on `OpenRouterChatLanguageModel` and `OpenRouterCompletionLanguageModel`, mirroring the first-party providers. Because the OpenRouter constructor is `constructor(modelId, settings, config)`, `settings` is captured alongside `config` for a faithful round-trip:

```ts
static [WORKFLOW_SERIALIZE](model: OpenRouterChatLanguageModel) {
  const { modelId, config } = serializeModelOptions({
    modelId: model.modelId,
    config: model.config,
  });
  return { modelId, config, settings: model.settings };
}

static [WORKFLOW_DESERIALIZE](data) {
  return new OpenRouterChatLanguageModel(data.modelId, data.settings, data.config);
}
```

`serializeModelOptions` (from `@ai-sdk/provider-utils`) resolves the `headers` closure and strips the remaining non-JSON `config` values (`url`, `fetch`), producing a structured-clone-safe payload — exactly as the first-party providers do.

## Changes

- `src/chat/index.ts` — add `WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE` to `OpenRouterChatLanguageModel`
- `src/completion/index.ts` — same for `OpenRouterCompletionLanguageModel`
- `src/workflow-serialization.test.ts` — regression test: hooks exist, serialized payload is structured-clone-safe (closures stripped, headers resolved), and the model round-trips its `modelId` / `settings` across the boundary
- `.changeset/workflow-serialization-hooks.md` — patch changeset

## Verification

- `pnpm stylecheck` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm test` (node + edge) — 463 tests pass, including 5 new

Fixes #525
Closes #525