### PR TITLE
Set provider specification version to 'v4'

### DIFF
--- a/.changeset/chubby-bananas-matter.md
+++ b/.changeset/chubby-bananas-matter.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Set provider specification version to 'v4'

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -22,6 +22,7 @@ describe('createOpenRouter', () => {
   it('creates the supported model factories and callable provider', () => {
     const provider = createOpenRouter({ apiKey: 'test-key' });
 
+    expect(provider.specificationVersion).toBe('v4');
     expect(provider.chat('openai/gpt-4o')).toBeInstanceOf(
       OpenRouterChatLanguageModel,
     );

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -305,6 +305,7 @@ export function createOpenRouter(
     settings?: OpenRouterChatSettings | OpenRouterCompletionSettings,
   ) => createLanguageModel(modelId, settings);
 
+  provider.specificationVersion = 'v4';
   provider.languageModel = createLanguageModel;
   provider.chat = createChatModel;
   provider.completion = createCompletionModel;


### PR DESCRIPTION
While all the models have `specificationVersion: 'v4'`, the provider itself did not, triggering:
`Warning: AI SDK Warning (openrouter / openai/gpt-5.4): The feature "specificationVersion" is used in a compatibility mode. Using v2 specification compatibility mode. Some features may not be available.`

## Description

<!-- Briefly describe your changes -->

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file

> **Note:** A changeset is required for your changes to trigger a release. If your PR only contains docs, tests, or CI changes that don't need a release, run `pnpm changeset --empty` instead.
