### PR TITLE
fix(completion): finish AI SDK v7 migration for the completion model

### DIFF
--- a/.changeset/warm-completion-lifecycle.md
+++ b/.changeset/warm-completion-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Fix completion model under AI SDK v7: accept the default toolChoice and emit text-start/text-delta/text-end lifecycle events

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -5,6 +5,7 @@ import type {
 
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server';
+import { generateText, streamText } from 'ai';
 import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { createOpenRouter } from '../provider';
 
@@ -514,10 +515,28 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
     expect(elements).toStrictEqual([
       { type: 'stream-start', warnings: [] },
-      { type: 'text-delta', delta: 'Hello', id: expect.any(String) },
-      { type: 'text-delta', delta: ', ', id: expect.any(String) },
-      { type: 'text-delta', delta: 'World!', id: expect.any(String) },
-      { type: 'text-delta', delta: '', id: expect.any(String) },
+      { type: 'text-start', id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT' },
+      {
+        type: 'text-delta',
+        delta: 'Hello',
+        id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT',
+      },
+      {
+        type: 'text-delta',
+        delta: ', ',
+        id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT',
+      },
+      {
+        type: 'text-delta',
+        delta: 'World!',
+        id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT',
+      },
+      {
+        type: 'text-delta',
+        delta: '',
+        id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT',
+      },
+      { type: 'text-end', id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT' },
       {
         type: 'finish',
         finishReason: { unified: 'stop', raw: 'stop' },
@@ -960,5 +979,76 @@ describe('includeRawChunks', () => {
     // Raw chunk is emitted before error handling, useful for debugging
     expect(rawChunks.length).toBe(1);
     expect(errorChunks.length).toBe(1);
+  });
+});
+
+describe('AI SDK v7 usage (generateText/streamText)', () => {
+  const server = createTestServer({
+    'https://openrouter.ai/api/v1/completions': {
+      response: { type: 'json-value', body: {} },
+    },
+  });
+
+  beforeAll(() => server.server.start());
+  afterEach(() => server.server.reset());
+  afterAll(() => server.server.stop());
+
+  it('should generate text without tools despite the default toolChoice', async () => {
+    // The AI SDK always sends toolChoice: { type: 'auto' }, even when no
+    // tools are configured. The completion model must not reject it.
+    server.urls['https://openrouter.ai/api/v1/completions']!.response = {
+      type: 'json-value',
+      body: {
+        id: 'cmpl-96cAM1v77r4jXa4qb2NSmRREV5oWB',
+        object: 'text_completion',
+        created: 1711363706,
+        model: 'openai/gpt-3.5-turbo-instruct',
+        choices: [
+          {
+            text: 'Hello, World!',
+            index: 0,
+            logprobs: null,
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 4, total_tokens: 34, completion_tokens: 30 },
+      },
+    };
+
+    const result = await generateText({
+      model,
+      prompt: 'Hello',
+    });
+
+    expect(result.text).toBe('Hello, World!');
+  });
+
+  it('should stream text with start/delta/end lifecycle events', async () => {
+    server.urls['https://openrouter.ai/api/v1/completions']!.response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"cmpl-test","object":"text_completion","created":1711363440,"choices":[{"text":"Hello","index":0,"logprobs":null,"finish_reason":null}],"model":"openai/gpt-3.5-turbo-instruct"}\n\n`,
+        `data: {"id":"cmpl-test","object":"text_completion","created":1711363440,"choices":[{"text":", World!","index":0,"logprobs":null,"finish_reason":"stop"}],"model":"openai/gpt-3.5-turbo-instruct"}\n\n`,
+        `data: {"id":"cmpl-test","object":"text_completion","created":1711363440,"model":"openai/gpt-3.5-turbo-instruct","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15},"choices":[]}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const result = streamText({
+      model,
+      prompt: 'Hello',
+    });
+
+    const partTypes: string[] = [];
+    for await (const part of result.fullStream) {
+      partTypes.push(part.type);
+    }
+
+    // Without text-start/text-end the AI SDK drops every delta and the
+    // resulting text is empty.
+    expect(partTypes).toContain('text-start');
+    expect(partTypes).toContain('text-delta');
+    expect(partTypes).toContain('text-end');
+    expect(await result.text).toBe('Hello, World!');
   });
 });

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -100,7 +100,10 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
       });
     }
 
-    if (toolChoice) {
+    // The AI SDK always sends a default toolChoice of { type: 'auto' },
+    // even when no tools are provided. Only reject tool choices that
+    // actually request tool usage, since completions don't support tools.
+    if (toolChoice && toolChoice.type !== 'auto') {
       throw new UnsupportedFunctionalityError({
         functionality: 'toolChoice',
       });
@@ -315,6 +318,9 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
 
     // Track raw usage from the API response for usage.raw
     let rawUsage: JSONObject | undefined;
+    let textStarted = false;
+    let textId: string | undefined;
+    let openrouterResponseId: string | undefined;
     const warnings: Array<SharedV4Warning> = [];
 
     return {
@@ -351,6 +357,10 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
 
             if (value.provider) {
               provider = value.provider;
+            }
+
+            if (value.id) {
+              openrouterResponseId = value.id;
             }
 
             if (value.usage != null) {
@@ -399,10 +409,18 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
             }
 
             if (choice?.text != null) {
+              if (!textStarted) {
+                textId = openrouterResponseId || generateId();
+                controller.enqueue({
+                  type: 'text-start',
+                  id: textId,
+                });
+                textStarted = true;
+              }
               controller.enqueue({
                 type: 'text-delta',
                 delta: choice.text,
-                id: generateId(),
+                id: textId || generateId(),
               });
             }
           },
@@ -411,6 +429,13 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
             if (streamError != null) {
               finishReason = createFinishReason('error');
               controller.enqueue({ type: 'error', error: streamError });
+            }
+
+            if (textStarted) {
+              controller.enqueue({
+                type: 'text-end',
+                id: textId || generateId(),
+              });
             }
 
             // Set raw usage before emitting finish event


### PR DESCRIPTION
## Description

The v7 migration in #511 updated the chat model but left the completion model unusable under AI SDK v7. Two defects, one root cause: the completion path never got the v7 treatment the chat path got.

1. AI SDK v7 always sends a default toolChoice of `{ type: 'auto' }`, even with zero tools configured. The completion model threw UnsupportedFunctionalityError on any toolChoice, so every generateText/streamText call through it failed immediately. The guard now only rejects tool choices that actually request tool usage.

2. doStream emitted bare text-delta parts, each with a fresh generated id and no text-start/text-end. v7 consumers drop deltas that do not belong to a started text part, so streamed text never reached result.text. This PR mirrors the chat model's lifecycle exactly: text-start once with a stable id seeded from the response id, the same id on every delta, text-end in flush.

Includes regression tests that call generateText and streamText from the ai package against the mock server, and an updated stream unit test that codifies the lifecycle events.

## Checklist

- [x] I have run `pnpm stylecheck` and `pnpm typecheck`
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

### Changeset

- [x] I have run `pnpm changeset` to create a changeset file
