### PR TITLE
fix(chat): forward tool strict setting to API request

### DIFF
--- a/.changeset/forward-tool-strict.md
+++ b/.changeset/forward-tool-strict.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Forward tool `strict` setting to function definitions in API requests

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -933,6 +933,107 @@ describe('doGenerate', () => {
     expect(tools[1]).not.toHaveProperty('eager_input_streaming');
   });
 
+  it('should forward tool.strict (true) into function definition', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'strict-tool',
+          description: 'Strict tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<{
+      type: string;
+      function: Record<string, unknown>;
+    }>;
+    expect(tools[0]!.function).toHaveProperty('strict', true);
+  });
+
+  it('should forward tool.strict (false) into function definition', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'non-strict-tool',
+          description: 'Non strict tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+          strict: false,
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<{
+      type: string;
+      function: Record<string, unknown>;
+    }>;
+    expect(tools[0]!.function).toHaveProperty('strict', false);
+  });
+
+  it('should allow overriding tool.strict via providerOptions.openrouter.strict', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'override-tool',
+          description: 'Overridden tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+          strict: true,
+          providerOptions: {
+            openrouter: {
+              strict: false,
+            },
+          },
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const tools = body.tools as Array<{
+      type: string;
+      function: Record<string, unknown>;
+    }>;
+    expect(tools[0]!.function).toHaveProperty('strict', false);
+  });
+
   it('should send both response_format and tools when both are present', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -186,6 +186,8 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
             | Record<string, unknown>
             | undefined;
           const eagerInputStreaming = openrouterOptions?.eager_input_streaming;
+          const strict =
+            (openrouterOptions?.strict as boolean | undefined) ?? tool.strict;
 
           mappedTools.push({
             type: 'function' as const,
@@ -193,6 +195,7 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
               name: tool.name,
               description: tool.description,
               parameters: tool.inputSchema,
+              ...(strict != null ? { strict } : {}),
             },
             ...(eagerInputStreaming != null && {
               eager_input_streaming: eagerInputStreaming,


### PR DESCRIPTION
Fixes #543

### Summary of Changes
- Forward `tool.strict` to the tool function definition in the OpenRouter request body in [`src/chat/index.ts`](file:///src/chat/index.ts).
- Support overriding `strict` via `tool.providerOptions.openrouter.strict`.
- Added unit tests in [`src/chat/index.test.ts`](file:///src/chat/index.test.ts) covering `strict: true`, `strict: false`, and provider option overrides.
- Added changeset for `@openrouter/ai-sdk-provider` (patch).