### PR TITLE
fix(provider): declare specificationVersion v4 on provider object

### DIFF
--- a/.changeset/provider-specification-version.md
+++ b/.changeset/provider-specification-version.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Declare specificationVersion 'v4' and embeddingModel on provider object returned by createOpenRouter

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,5 +1,5 @@
 import { createTestServer } from '@ai-sdk/test-server';
-import { streamText } from 'ai';
+import { createProviderRegistry, streamText } from 'ai';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { OpenRouterChatLanguageModel } from './chat';
 import { OpenRouterCompletionLanguageModel } from './completion';
@@ -22,12 +22,16 @@ describe('createOpenRouter', () => {
   it('creates the supported model factories and callable provider', () => {
     const provider = createOpenRouter({ apiKey: 'test-key' });
 
+    expect(provider.specificationVersion).toBe('v4');
     expect(provider.chat('openai/gpt-4o')).toBeInstanceOf(
       OpenRouterChatLanguageModel,
     );
     expect(provider.completion('openai/gpt-3.5-turbo-instruct')).toBeInstanceOf(
       OpenRouterCompletionLanguageModel,
     );
+    expect(
+      provider.embeddingModel('openai/text-embedding-3-small'),
+    ).toBeInstanceOf(OpenRouterEmbeddingModel);
     expect(
       provider.textEmbeddingModel('openai/text-embedding-3-small'),
     ).toBeInstanceOf(OpenRouterEmbeddingModel);
@@ -71,5 +75,14 @@ describe('createOpenRouter', () => {
     expect(() => Reflect.construct(provider, ['openai/gpt-4o'])).toThrow(
       TypeError,
     );
+  });
+
+  it('integrates cleanly with createProviderRegistry without double-adaptation', () => {
+    const provider = createOpenRouter({ apiKey: 'test-key' });
+    const registry = createProviderRegistry({ openrouter: provider });
+    const model = registry.languageModel('openrouter:openai/gpt-4o');
+
+    expect(model.specificationVersion).toBe('v4');
+    expect(model.modelId).toBe('openai/gpt-4o');
   });
 });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -83,6 +83,14 @@ Creates an OpenRouter completion model for text generation.
   ): OpenRouterCompletionLanguageModel;
 
   /**
+   * Creates an OpenRouter text embedding model.
+   */
+  embeddingModel(
+    modelId: OpenRouterEmbeddingModelId,
+    settings?: OpenRouterEmbeddingSettings,
+  ): OpenRouterEmbeddingModel;
+
+  /**
 Creates an OpenRouter text embedding model. (AI SDK v5)
    */
   textEmbeddingModel(
@@ -305,9 +313,11 @@ export function createOpenRouter(
     settings?: OpenRouterChatSettings | OpenRouterCompletionSettings,
   ) => createLanguageModel(modelId, settings);
 
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createChatModel;
   provider.completion = createCompletionModel;
+  provider.embeddingModel = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.embedding = createEmbeddingModel; // deprecated alias for v4 compatibility
   provider.imageModel = createImageModel;


### PR DESCRIPTION
Fixes #541

### Summary of Changes
- Declare `specificationVersion: 'v4'` and `embeddingModel` on the provider object returned by `createOpenRouter()` in [`src/provider.ts`](file:///src/provider.ts).
- Prevent AI SDK v7 registry (`createProviderRegistry`) from misidentifying the provider as v2 and double-adapting already-v4 models.
- Added assertions and a registry integration test in [`src/provider.test.ts`](file:///src/provider.test.ts).
- Added changeset for `@openrouter/ai-sdk-provider` (patch).