### PR TITLE
fix(usage): preserve is_byok as isByok in providerMetadata.openrouter.usage

### DIFF
--- a/.changeset/preserve-usage-is-byok.md
+++ b/.changeset/preserve-usage-is-byok.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Preserve `is_byok` as `isByok` in `providerMetadata.openrouter.usage`

--- a/README.md
+++ b/README.md
@@ -439,14 +439,23 @@ console.log('Reasoning tokens:', result.usage.outputTokenDetails.reasoningTokens
 
 // Provider-specific BYOK usage details (available in providerMetadata)
 if (result.providerMetadata?.openrouter?.usage) {
-  const costDetails = result.providerMetadata.openrouter.usage.costDetails;
+  const { cost, costDetails, isByok, totalTokens } =
+    result.providerMetadata.openrouter.usage;
+
+  console.log('Is BYOK request:', isByok);
+  console.log('OpenRouter credits cost:', cost);
   if (costDetails) {
-    console.log('BYOK cost:', costDetails.upstreamInferenceCost);
+    console.log('Upstream inference cost:', costDetails.upstreamInferenceCost);
   }
-  console.log('OpenRouter credits cost:', result.providerMetadata.openrouter.usage.cost);
-  console.log(
-    'Total Tokens:',
-    result.providerMetadata.openrouter.usage.totalTokens,
-  );
+  console.log('Total Tokens:', totalTokens);
+
+  // When calculating total cost:
+  // For BYOK requests (isByok: true), upstreamInferenceCost reflects passthrough cost.
+  // For non-BYOK requests (isByok: false), upstreamInferenceCost is already included in cost.
+  const totalCost =
+    isByok
+      ? (cost ?? 0) + (costDetails?.upstreamInferenceCost ?? 0)
+      : (cost ?? 0);
+  console.log('Total cost:', totalCost);
 }
 ```

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1444,6 +1444,7 @@ describe('doStream', () => {
       cost_details?: {
         upstream_inference_cost: number;
       };
+      is_byok?: boolean;
     };
     logprobs?: {
       content:
@@ -1665,6 +1666,50 @@ describe('doStream', () => {
       upstreamInferenceCost: 0.0036,
     });
     expect(openrouterUsage?.cost).toBe(0.0042);
+  });
+
+  it('should include isByok in finish metadata when provided', async () => {
+    prepareStreamResponse({
+      content: ['Hello'],
+      usage: {
+        prompt_tokens: 17,
+        total_tokens: 244,
+        completion_tokens: 227,
+        cost: 0,
+        is_byok: true,
+        cost_details: {
+          upstream_inference_cost: 0.0036,
+        },
+      },
+    });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const elements = (await convertReadableStreamToArray(
+      stream,
+    )) as LanguageModelV4StreamPart[];
+    const finishChunk = elements.find(
+      (
+        chunk,
+      ): chunk is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
+        chunk.type === 'finish',
+    );
+    const openrouterUsage = (
+      finishChunk?.providerMetadata?.openrouter as {
+        usage?: {
+          cost?: number;
+          isByok?: boolean;
+          costDetails?: { upstreamInferenceCost: number };
+        };
+      }
+    )?.usage;
+    expect(openrouterUsage?.isByok).toBe(true);
+    expect(openrouterUsage?.cost).toBe(0);
+    expect(openrouterUsage?.costDetails).toStrictEqual({
+      upstreamInferenceCost: 0.0036,
+    });
   });
 
   it('should prioritize reasoning_details over reasoning when both are present in streaming', async () => {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -496,6 +496,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
             ...(response.usage?.cost != null
               ? { cost: response.usage.cost }
               : {}),
+            ...(response.usage?.is_byok != null
+              ? { isByok: response.usage.is_byok }
+              : {}),
             ...(response.usage?.prompt_tokens_details?.cached_tokens != null
               ? {
                   promptTokensDetails: {
@@ -732,6 +735,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
 
               if (value.usage.cost != null) {
                 openrouterUsage.cost = value.usage.cost;
+              }
+              if (value.usage.is_byok != null) {
+                openrouterUsage.isByok = value.usage.is_byok;
               }
               openrouterUsage.totalTokens = value.usage.total_tokens;
               const upstreamInferenceCost =

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -33,6 +33,7 @@ const OpenRouterChatCompletionBaseResponseSchema = z
           })
           .passthrough()
           .nullish(),
+        is_byok: z.boolean().nullish(),
       })
       .passthrough()
       .nullish(),

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -87,6 +87,7 @@ describe('doGenerate', () => {
       cost_details?: {
         upstream_inference_cost: number;
       };
+      is_byok?: boolean;
     };
     logprobs?: {
       tokens: string[];
@@ -331,6 +332,41 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should include isByok in providerMetadata when provided', async () => {
+    prepareJsonResponse({
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+        cost: 0,
+        is_byok: true,
+        cost_details: {
+          upstream_inference_cost: 0.005,
+        },
+      },
+    });
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    const usage = (
+      providerMetadata?.openrouter as {
+        usage?: {
+          cost?: number;
+          isByok?: boolean;
+          costDetails?: { upstreamInferenceCost: number };
+        };
+      }
+    )?.usage;
+
+    expect(usage?.isByok).toBe(true);
+    expect(usage?.cost).toBe(0);
+    expect(usage?.costDetails).toStrictEqual({
+      upstreamInferenceCost: 0.005,
+    });
+  });
+
   it('should extract logprobs', async () => {
     prepareJsonResponse({ logprobs: TEST_LOGPROBS });
 
@@ -469,6 +505,7 @@ describe('doStream', () => {
       cost_details?: {
         upstream_inference_cost: number;
       };
+      is_byok?: boolean;
     };
     logprobs?: {
       tokens: string[];
@@ -669,6 +706,50 @@ describe('doStream', () => {
       upstreamInferenceCost: 0.0036,
     });
     expect(openrouterUsage?.cost).toBe(0.0025);
+  });
+
+  it('should include isByok in finish metadata when provided', async () => {
+    prepareStreamResponse({
+      content: ['Hello'],
+      usage: {
+        prompt_tokens: 5,
+        total_tokens: 15,
+        completion_tokens: 10,
+        cost: 0,
+        is_byok: true,
+        cost_details: {
+          upstream_inference_cost: 0.0036,
+        },
+      },
+    });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const elements = (await convertReadableStreamToArray(
+      stream,
+    )) as LanguageModelV4StreamPart[];
+    const finishChunk = elements.find(
+      (
+        element,
+      ): element is Extract<LanguageModelV4StreamPart, { type: 'finish' }> =>
+        element.type === 'finish',
+    );
+    const openrouterUsage = (
+      finishChunk?.providerMetadata?.openrouter as {
+        usage?: {
+          cost?: number;
+          isByok?: boolean;
+          costDetails?: { upstreamInferenceCost: number };
+        };
+      }
+    )?.usage;
+    expect(openrouterUsage?.isByok).toBe(true);
+    expect(openrouterUsage?.cost).toBe(0);
+    expect(openrouterUsage?.costDetails).toStrictEqual({
+      upstreamInferenceCost: 0.0036,
+    });
   });
 
   it('should handle error stream parts', async () => {

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -220,6 +220,9 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
             ...(response.usage?.cost != null
               ? { cost: response.usage.cost }
               : {}),
+            ...(response.usage?.is_byok != null
+              ? { isByok: response.usage.is_byok }
+              : {}),
             ...(response.usage?.prompt_tokens_details?.cached_tokens != null
               ? {
                   promptTokensDetails: {
@@ -381,6 +384,9 @@ export class OpenRouterCompletionLanguageModel implements LanguageModelV4 {
 
               if (value.usage.cost != null) {
                 openrouterUsage.cost = value.usage.cost;
+              }
+              if (value.usage.is_byok != null) {
+                openrouterUsage.isByok = value.usage.is_byok;
               }
               openrouterUsage.totalTokens = value.usage.total_tokens;
               const upstreamInferenceCost =

--- a/src/completion/schemas.ts
+++ b/src/completion/schemas.ts
@@ -58,6 +58,7 @@ export const OpenRouterCompletionChunkSchema = z.union([
             })
             .passthrough()
             .nullish(),
+          is_byok: z.boolean().nullish(),
         })
         .passthrough()
         .nullish(),

--- a/src/schemas/provider-metadata.ts
+++ b/src/schemas/provider-metadata.ts
@@ -63,6 +63,7 @@ export const OpenRouterProviderMetadataSchema = z
           })
           .catchall(z.any())
           .optional(),
+        isByok: z.boolean().optional(),
       })
       .catchall(z.any()),
   })

--- a/src/tests/stream-usage-accounting.test.ts
+++ b/src/tests/stream-usage-accounting.test.ts
@@ -406,4 +406,55 @@ describe('OpenRouter Streaming Usage Accounting', () => {
     // When no usage data, raw should be undefined
     expect(finishChunk?.usage?.raw).toBeUndefined();
   });
+
+  it('should preserve isByok in streaming finish metadata when present', async () => {
+    const chunks = [
+      `data: {"id":"test-id","model":"test-model","choices":[{"delta":{"content":"Hello"},"index":0}]}\n\n`,
+      `data: {"choices":[{"finish_reason":"stop","index":0}]}\n\n`,
+      `data: ${JSON.stringify({
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          cost: 0,
+          is_byok: true,
+          cost_details: { upstream_inference_cost: 0.0019 },
+        },
+        choices: [],
+      })}\n\n`,
+      'data: [DONE]\n\n',
+    ];
+
+    server.urls['https://api.openrouter.ai/chat/completions']!.response = {
+      type: 'stream-chunks',
+      chunks,
+    };
+
+    const model = new OpenRouterChatLanguageModel(
+      'test-model',
+      { usage: { include: true } },
+      {
+        provider: 'openrouter.chat',
+        url: () => 'https://api.openrouter.ai/chat/completions',
+        headers: () => ({}),
+        compatibility: 'strict',
+        fetch: global.fetch,
+      },
+    );
+
+    const result = await model.doStream({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      maxOutputTokens: 100,
+    });
+
+    const streamChunks = await convertReadableStreamToArray(result.stream);
+    const finishChunk = streamChunks.find((chunk) => chunk.type === 'finish');
+    const openrouterUsage = finishChunk?.providerMetadata?.openrouter?.usage;
+
+    expect(openrouterUsage).toMatchObject({
+      cost: 0,
+      isByok: true,
+      costDetails: { upstreamInferenceCost: 0.0019 },
+    });
+  });
 });

--- a/src/tests/usage-accounting.test.ts
+++ b/src/tests/usage-accounting.test.ts
@@ -552,4 +552,118 @@ describe('OpenRouter Usage Accounting', () => {
     // When no usage data, raw should be undefined
     expect(result.usage.raw).toBeUndefined();
   });
+
+  it('should preserve isByok: true in providerMetadata when present in response', async () => {
+    server.urls['https://api.openrouter.ai/chat/completions']!.response = {
+      type: 'json-value',
+      body: {
+        id: 'test-id',
+        model: 'test-model',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'Hello' },
+            index: 0,
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          cost: 0,
+          is_byok: true,
+          cost_details: {
+            upstream_inference_cost: 0.0019,
+          },
+        },
+      },
+    };
+
+    const model = new OpenRouterChatLanguageModel(
+      'test-model',
+      {},
+      {
+        provider: 'openrouter.chat',
+        url: () => 'https://api.openrouter.ai/chat/completions',
+        headers: () => ({}),
+        compatibility: 'strict',
+        fetch: global.fetch,
+      },
+    );
+
+    const result = await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxOutputTokens: 100,
+    });
+
+    expect(result.providerMetadata?.openrouter?.usage).toMatchObject({
+      cost: 0,
+      isByok: true,
+      costDetails: {
+        upstreamInferenceCost: 0.0019,
+      },
+    });
+  });
+
+  it('should preserve isByok: false in providerMetadata when present in response', async () => {
+    server.urls['https://api.openrouter.ai/chat/completions']!.response = {
+      type: 'json-value',
+      body: {
+        id: 'test-id',
+        model: 'test-model',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'Hello' },
+            index: 0,
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          cost: 0.0019,
+          is_byok: false,
+          cost_details: {
+            upstream_inference_cost: 0.0019,
+          },
+        },
+      },
+    };
+
+    const model = new OpenRouterChatLanguageModel(
+      'test-model',
+      {},
+      {
+        provider: 'openrouter.chat',
+        url: () => 'https://api.openrouter.ai/chat/completions',
+        headers: () => ({}),
+        compatibility: 'strict',
+        fetch: global.fetch,
+      },
+    );
+
+    const result = await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+      maxOutputTokens: 100,
+    });
+
+    expect(result.providerMetadata?.openrouter?.usage).toMatchObject({
+      cost: 0.0019,
+      isByok: false,
+      costDetails: {
+        upstreamInferenceCost: 0.0019,
+      },
+    });
+  });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,4 +111,5 @@ export type OpenRouterUsageAccounting = {
   costDetails?: {
     upstreamInferenceCost: number;
   };
+  isByok?: boolean;
 };


### PR DESCRIPTION
Fixes #532

### Changes

- Add `isByok?: boolean` to `OpenRouterUsageAccounting` and `OpenRouterProviderMetadataSchema`.
- Accept optional `is_byok` in `OpenRouterChatCompletionBaseResponseSchema` and `OpenRouterCompletionChunkSchema`.
- Forward wire `is_byok` to `providerMetadata.openrouter.usage.isByok` across chat and completion models (both generate and stream).
- Add unit tests verifying `isByok` is preserved when present and omitted when absent.
- Update README BYOK documentation to explain using `isByok` to avoid double-counting or undercounting downstream costs.
- Include changeset.