### PR TITLE
fix(image): merge runtime provider options with configured routing preferences

### DIFF
--- a/.changeset/merge-image-provider-routing-options.md
+++ b/.changeset/merge-image-provider-routing-options.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Merge runtime provider routing options with configured image model provider preferences

--- a/src/image/index.test.ts
+++ b/src/image/index.test.ts
@@ -795,5 +795,120 @@ describe('OpenRouterImageModel', () => {
         order: ['google'],
       });
     });
+
+    it('should merge runtime providerOptions.openrouter.provider with configured model provider preferences', async () => {
+      const mock = createCapturingMockFetch(TEST_IMAGE_BASE64);
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.imageModel('google/gemini-2.5-flash-image', {
+        provider: {
+          order: ['google'],
+          allow_fallbacks: true,
+          sort: 'price',
+        },
+      });
+
+      await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {
+          openrouter: {
+            provider: {
+              order: ['black-forest-labs'],
+            },
+          },
+        },
+      });
+
+      expect(mock.capturedBody?.provider).toEqual({
+        order: ['black-forest-labs'],
+        allow_fallbacks: true,
+        sort: 'price',
+      });
+    });
+
+    it('should preserve configured provider preferences when runtime provider options omit provider', async () => {
+      const mock = createCapturingMockFetch(TEST_IMAGE_BASE64);
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+      });
+      const model = provider.imageModel('google/gemini-2.5-flash-image', {
+        provider: {
+          order: ['google'],
+          allow_fallbacks: true,
+        },
+      });
+
+      await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {
+          openrouter: {
+            custom_field: 'test',
+          },
+        },
+      });
+
+      expect(mock.capturedBody?.provider).toEqual({
+        order: ['google'],
+        allow_fallbacks: true,
+      });
+      expect(mock.capturedBody?.custom_field).toBe('test');
+    });
+
+    it('should merge config extraBody, model provider, and runtime provider options', async () => {
+      const mock = createCapturingMockFetch(TEST_IMAGE_BASE64);
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mock.fetch,
+        extraBody: {
+          provider: {
+            data_collection: 'deny',
+          },
+        },
+      });
+      const model = provider.imageModel('google/gemini-2.5-flash-image', {
+        provider: {
+          order: ['google'],
+          allow_fallbacks: true,
+        },
+      });
+
+      await model.doGenerate({
+        prompt: 'A cat',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {
+          openrouter: {
+            provider: {
+              order: ['black-forest-labs'],
+            },
+          },
+        },
+      });
+
+      expect(mock.capturedBody?.provider).toEqual({
+        data_collection: 'deny',
+        order: ['black-forest-labs'],
+        allow_fallbacks: true,
+      });
+    });
   });
 });

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -92,6 +92,43 @@ export class OpenRouterImageModel implements ImageModelV4 {
       ? files.map((file: ImageModelV4File) => convertFileToInputReference(file))
       : undefined;
 
+    const { provider: runtimeProvider, ...restOpenrouterOptions } =
+      openrouterOptions;
+
+    const configExtraProvider = this.config.extraBody?.provider as
+      | Record<string, unknown>
+      | undefined;
+    const settingsExtraProvider = this.settings.extraBody?.provider as
+      | Record<string, unknown>
+      | undefined;
+    const configuredProvider = this.settings.provider;
+
+    const hasProvider =
+      configuredProvider !== undefined ||
+      runtimeProvider !== undefined ||
+      settingsExtraProvider !== undefined ||
+      configExtraProvider !== undefined;
+
+    const provider = hasProvider
+      ? {
+          ...(typeof configExtraProvider === 'object' &&
+          configExtraProvider !== null
+            ? configExtraProvider
+            : {}),
+          ...(typeof settingsExtraProvider === 'object' &&
+          settingsExtraProvider !== null
+            ? settingsExtraProvider
+            : {}),
+          ...(typeof configuredProvider === 'object' &&
+          configuredProvider !== null
+            ? configuredProvider
+            : {}),
+          ...(typeof runtimeProvider === 'object' && runtimeProvider !== null
+            ? (runtimeProvider as Record<string, unknown>)
+            : {}),
+        }
+      : undefined;
+
     const body: Record<string, unknown> = {
       model: this.modelId,
       prompt: prompt ?? '',
@@ -103,12 +140,10 @@ export class OpenRouterImageModel implements ImageModelV4 {
         input_references: inputReferences,
       }),
       ...(this.settings.user !== undefined && { user: this.settings.user }),
-      ...(this.settings.provider !== undefined && {
-        provider: this.settings.provider,
-      }),
       ...this.config.extraBody,
       ...this.settings.extraBody,
-      ...openrouterOptions,
+      ...restOpenrouterOptions,
+      ...(provider !== undefined && { provider }),
     };
 
     const { value: responseValue, responseHeaders } = await postJsonToApi({


### PR DESCRIPTION
Fixes #538

### Changes

- In `OpenRouterImageModel.doGenerate`, build and merge provider routing options across configured settings, extraBody, and runtime `providerOptions.openrouter.provider`.
- Ensure runtime options override specified fields while preserving sibling routing preferences (such as `allow_fallbacks`, `sort`, `require_parameters`, and `data_collection`).
- Add unit tests verifying sibling field preservation and config extraBody merging.
- Include changeset.