### PR TITLE
fix(chat): support OpenAI image detail parameter (#493)

### DIFF
--- a/.changeset/support-image-detail.md
+++ b/.changeset/support-image-detail.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': patch
+---
+
+Support OpenAI image detail parameter in multimodal chat requests

--- a/src/chat/convert-to-openrouter-chat-messages.test.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.test.ts
@@ -65,6 +65,291 @@ describe('user messages', () => {
     ]);
   });
 
+  it('should set image_url detail from part providerOptions.openrouter.imageDetail', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
+            mediaType: 'image/png',
+            providerOptions: {
+              openrouter: {
+                imageDetail: 'low',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'low',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should set image_url detail from part providerOptions.openai.imageDetail', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
+            mediaType: 'image/png',
+            providerOptions: {
+              openai: {
+                imageDetail: 'high',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should set image_url detail from part providerOptions.openrouter.detail', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
+            mediaType: 'image/png',
+            providerOptions: {
+              openrouter: {
+                detail: 'auto',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'auto',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should set image_url detail from nested providerOptions.openrouter.openai.detail', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
+            mediaType: 'image/png',
+            providerOptions: {
+              openrouter: {
+                openai: {
+                  detail: 'low',
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'low',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should set image_url detail from message-level providerOptions', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        providerOptions: {
+          openrouter: {
+            imageDetail: 'low',
+          },
+        },
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'low',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should let part-level detail override message-level detail', async () => {
+    const result = convertToOpenRouterChatMessages([
+      {
+        role: 'user',
+        providerOptions: {
+          openrouter: {
+            imageDetail: 'low',
+          },
+        },
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.png'),
+            },
+            mediaType: 'image/png',
+            providerOptions: {
+              openrouter: {
+                imageDetail: 'high',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should use default detail option when not specified on part or message', async () => {
+    const result = convertToOpenRouterChatMessages(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello' },
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/image.png'),
+              },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+      { imageDetail: 'low' },
+    );
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'low',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it.each([
     'file:///tmp/image.png',
     'blob:https://example.com/image-id',

--- a/src/chat/convert-to-openrouter-chat-messages.ts
+++ b/src/chat/convert-to-openrouter-chat-messages.ts
@@ -42,8 +42,81 @@ function getCacheControl(
     anthropic?.cache_control) as OpenRouterCacheControl | undefined;
 }
 
+function extractDetailValue(obj?: Record<string, unknown>): string | undefined {
+  if (!obj) {
+    return undefined;
+  }
+  const val = obj.imageDetail ?? obj.image_detail ?? obj.detail;
+  if (val != null) {
+    return String(val);
+  }
+
+  const nestedOpenai = obj.openai as Record<string, unknown> | undefined;
+  if (nestedOpenai) {
+    const nestedVal =
+      nestedOpenai.imageDetail ??
+      nestedOpenai.image_detail ??
+      nestedOpenai.detail;
+    if (nestedVal != null) {
+      return String(nestedVal);
+    }
+  }
+
+  const nestedParams = obj.provider_parameters as
+    | Record<string, unknown>
+    | undefined;
+  if (nestedParams) {
+    const nestedVal =
+      nestedParams.imageDetail ??
+      nestedParams.image_detail ??
+      nestedParams.detail;
+    if (nestedVal != null) {
+      return String(nestedVal);
+    }
+  }
+
+  return undefined;
+}
+
+export function getImageDetail(
+  partProviderOptions?: SharedV4ProviderMetadata,
+  messageProviderOptions?: SharedV4ProviderMetadata,
+  defaultDetail?: string,
+): string | undefined {
+  const partOpenrouter = partProviderOptions?.openrouter as
+    | Record<string, unknown>
+    | undefined;
+  const partOpenai = partProviderOptions?.openai as
+    | Record<string, unknown>
+    | undefined;
+
+  const partDetail =
+    extractDetailValue(partOpenrouter) ?? extractDetailValue(partOpenai);
+  if (partDetail != null) {
+    return partDetail;
+  }
+
+  const msgOpenrouter = messageProviderOptions?.openrouter as
+    | Record<string, unknown>
+    | undefined;
+  const msgOpenai = messageProviderOptions?.openai as
+    | Record<string, unknown>
+    | undefined;
+
+  const msgDetail =
+    extractDetailValue(msgOpenrouter) ?? extractDetailValue(msgOpenai);
+  if (msgDetail != null) {
+    return msgDetail;
+  }
+
+  return defaultDetail;
+}
+
 export function convertToOpenRouterChatMessages(
   prompt: LanguageModelV4Prompt,
+  options?: {
+    imageDetail?: string;
+  },
 ): OpenRouterChatCompletionsInput {
   const messages: OpenRouterChatCompletionsInput = [];
 
@@ -129,10 +202,16 @@ export function convertToOpenRouterChatMessages(
                     part,
                     defaultMediaType: 'image/jpeg',
                   });
+                  const detail = getImageDetail(
+                    part.providerOptions,
+                    providerOptions,
+                    options?.imageDetail,
+                  );
                   return {
                     type: 'image_url' as const,
                     image_url: {
                       url,
+                      ...(detail && { detail }),
                     },
                     ...(cacheControl && { cache_control: cacheControl }),
                   };
@@ -387,7 +466,7 @@ export function convertToOpenRouterChatMessages(
           if (toolResponse.type === 'tool-approval-response') {
             continue;
           }
-          const content = getToolResultContent(toolResponse);
+          const content = getToolResultContent(toolResponse, options);
 
           messages.push({
             role: 'tool',
@@ -413,6 +492,7 @@ export function convertToOpenRouterChatMessages(
 
 function getToolResultContent(
   input: LanguageModelV4ToolResultPart,
+  options?: { imageDetail?: string },
 ): string | ChatCompletionContentPart[] {
   switch (input.output.type) {
     case 'text':
@@ -422,7 +502,7 @@ function getToolResultContent(
     case 'error-json':
       return JSON.stringify(input.output.value);
     case 'content':
-      return mapToolResultContentParts(input.output.value);
+      return mapToolResultContentParts(input.output.value, options);
     case 'execution-denied':
       return input.output.reason ?? 'Tool execution denied';
   }
@@ -435,6 +515,7 @@ type ToolResultContentPart = Extract<
 
 function mapToolResultContentParts(
   parts: ReadonlyArray<ToolResultContentPart>,
+  options?: { imageDetail?: string },
 ): ChatCompletionContentPart[] {
   return parts.map((part): ChatCompletionContentPart => {
     switch (part.type) {
@@ -449,9 +530,17 @@ function mapToolResultContentParts(
         });
 
         if (part.mediaType?.startsWith('image/')) {
+          const detail = getImageDetail(
+            part.providerOptions,
+            undefined,
+            options?.imageDetail,
+          );
           return {
             type: 'image_url',
-            image_url: { url: dataUrl },
+            image_url: {
+              url: dataUrl,
+              ...(detail && { detail }),
+            },
           };
         }
 

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1406,6 +1406,129 @@ describe('doGenerate', () => {
     expect(toolCalls).toHaveLength(1);
     expect(toolCalls[0]!.toolCallId).toBe('call_abc123');
   });
+
+  it('should forward imageDetail from call-level providerOptions to image_url', async () => {
+    prepareJsonResponse({ content: 'Hello' });
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Analyze this image:' },
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/test.jpg'),
+              },
+              mediaType: 'image/jpeg',
+            },
+          ],
+        },
+      ],
+      providerOptions: {
+        openrouter: {
+          imageDetail: 'low',
+        },
+      },
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const messages = body.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        image_url?: { url: string; detail?: string };
+      }>;
+    }>;
+    expect(messages[0]?.content[1]?.image_url?.detail).toBe('low');
+    expect(body.imageDetail).toBeUndefined();
+  });
+
+  it('should forward imageDetail from part-level providerOptions to image_url', async () => {
+    prepareJsonResponse({ content: 'Hello' });
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Analyze this image:' },
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/test.jpg'),
+              },
+              mediaType: 'image/jpeg',
+              providerOptions: {
+                openai: {
+                  imageDetail: 'high',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const messages = body.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        image_url?: { url: string; detail?: string };
+      }>;
+    }>;
+    expect(messages[0]?.content[1]?.image_url?.detail).toBe('high');
+  });
+
+  it('should forward imageDetail from model settings to image_url', async () => {
+    prepareJsonResponse({ content: 'Hello' });
+
+    const modelWithDetail = provider.chat('test-model', {
+      imageDetail: 'low',
+    });
+
+    await modelWithDetail.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Analyze this image:' },
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/test.jpg'),
+              },
+              mediaType: 'image/jpeg',
+            },
+          ],
+        },
+      ],
+    });
+
+    const body = (await server.calls[0]!.requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    const messages = body.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        image_url?: { url: string; detail?: string };
+      }>;
+    }>;
+    expect(messages[0]?.content[1]?.image_url?.detail).toBe('low');
+  });
 });
 
 describe('doStream', () => {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -102,7 +102,23 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
     topK,
     tools,
     toolChoice,
+    providerOptions,
   }: LanguageModelV4CallOptions) {
+    const openrouterOptions = providerOptions?.openrouter as
+      | Record<string, unknown>
+      | undefined;
+    const openaiOptions = providerOptions?.openai as
+      | Record<string, unknown>
+      | undefined;
+    const callImageDetail =
+      (openrouterOptions?.imageDetail as string | undefined) ??
+      (openrouterOptions?.image_detail as string | undefined) ??
+      (openrouterOptions?.detail as string | undefined) ??
+      (openaiOptions?.imageDetail as string | undefined) ??
+      (openaiOptions?.image_detail as string | undefined) ??
+      (openaiOptions?.detail as string | undefined) ??
+      this.settings.imageDetail;
+
     const baseArgs = {
       // model id:
       model: this.modelId,
@@ -154,7 +170,9 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
       top_k: topK ?? this.settings.topK,
 
       // messages:
-      messages: convertToOpenRouterChatMessages(prompt),
+      messages: convertToOpenRouterChatMessages(prompt, {
+        imageDetail: callImageDetail,
+      }),
 
       // OpenRouter specific settings:
       include_reasoning: this.settings.includeReasoning,
@@ -236,9 +254,14 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
     const providerOptions = options.providerOptions || {};
     const openrouterOptions = providerOptions.openrouter || {};
 
-    // Extract cacheControl (camelCase) and normalize to cache_control (snake_case)
-    const { cacheControl, ...restOpenrouterOptions } =
-      openrouterOptions as Record<string, unknown>;
+    // Extract cacheControl and imageDetail/detail so they don't pollute top-level request body
+    const {
+      cacheControl,
+      imageDetail: _imageDetail,
+      image_detail: _imageDetailSnake,
+      detail: _detail,
+      ...restOpenrouterOptions
+    } = openrouterOptions as Record<string, unknown>;
 
     const args = {
       ...this.getArgs(options),
@@ -546,9 +569,14 @@ export class OpenRouterChatLanguageModel implements LanguageModelV4 {
     const providerOptions = options.providerOptions || {};
     const openrouterOptions = providerOptions.openrouter || {};
 
-    // Extract cacheControl (camelCase) and normalize to cache_control (snake_case)
-    const { cacheControl, ...restOpenrouterOptions } =
-      openrouterOptions as Record<string, unknown>;
+    // Extract cacheControl and imageDetail/detail so they don't pollute top-level request body
+    const {
+      cacheControl,
+      imageDetail: _imageDetail,
+      image_detail: _imageDetailSnake,
+      detail: _detail,
+      ...restOpenrouterOptions
+    } = openrouterOptions as Record<string, unknown>;
 
     const args = {
       ...this.getArgs(options),

--- a/src/types/openrouter-chat-completions-input.ts
+++ b/src/types/openrouter-chat-completions-input.ts
@@ -44,6 +44,7 @@ export interface ChatCompletionContentPartImage {
   type: 'image_url';
   image_url: {
     url: string;
+    detail?: 'auto' | 'low' | 'high' | string;
   };
   cache_control?: OpenRouterCacheControl;
 }

--- a/src/types/openrouter-chat-settings.ts
+++ b/src/types/openrouter-chat-settings.ts
@@ -46,9 +46,14 @@ tokens that were generated.
   logprobs?: boolean | number;
 
   /**
-Whether to enable parallel function calling during tool use. Default to true.
+   * Whether to enable parallel function calling during tool use. Default to true.
    */
   parallelToolCalls?: boolean;
+
+  /**
+   * The image detail level to use for images in the request ('auto', 'low', or 'high').
+   */
+  imageDetail?: 'auto' | 'low' | 'high' | string;
 
   /**
 A unique identifier representing your end-user, which can help OpenRouter to


### PR DESCRIPTION
Fixes #493.

### Summary
- Added `detail?: 'auto' | 'low' | 'high' | string` to `ChatCompletionContentPartImage.image_url`.
- Added `imageDetail?: 'auto' | 'low' | 'high' | string` to `OpenRouterChatSettings`.
- Added extraction for `imageDetail` / `image_detail` / `detail` from part-level, message-level, call-level, and model settings.
- Extracted and forwarded `detail` in user image parts and tool call image results.
- Stripped `imageDetail` from top-level body in `doGenerate` and `doStream` to avoid invalid request fields.
- Added comprehensive unit and integration tests.
- Added changeset.