### PR TITLE
feat: add runtime reranking model support

### DIFF
--- a/.changeset/reranking-model-runtime.md
+++ b/.changeset/reranking-model-runtime.md
@@ -1,0 +1,5 @@
+---
+'@openrouter/ai-sdk-provider': minor
+---
+
+Implement `rerankingModel` on the provider. `createOpenRouter()` and the default `openrouter` instance now expose `rerankingModel(modelId, settings?)`, which calls the OpenRouter `/rerank` endpoint and works with the AI SDK `rerank()` function. Previously the method existed in the typings but was undefined at runtime.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,35 @@ OpenRouter supports various embedding models including:
 - `openai/text-embedding-ada-002`
 - And more available on [OpenRouter](https://openrouter.ai/models?output_modalities=embeddings)
 
+## Reranking
+
+OpenRouter supports rerank models that reorder documents by relevance to a query.
+
+### Basic Usage
+
+```ts
+import { rerank } from 'ai';
+import { openrouter } from '@openrouter/ai-sdk-provider';
+
+const { rerankedDocuments, ranking } = await rerank({
+  model: openrouter.rerankingModel('cohere/rerank-v3.5'),
+  query: 'What is the capital of France?',
+  documents: [
+    'Berlin is the capital of Germany.',
+    'Paris is the capital of France.',
+  ],
+});
+
+console.log(rerankedDocuments); // Documents sorted by relevance
+console.log(ranking); // Original index and relevance score per document
+```
+
+### Supported Reranking Models
+
+OpenRouter supports various reranking models including:
+- `cohere/rerank-v3.5`
+- And more available on [OpenRouter](https://openrouter.ai/collections/rerank-models)
+
 ## Passing Extra Body to OpenRouter
 
 There are 3 ways to pass extra body to OpenRouter:

--- a/e2e/issues/issue-500-reranking-model.test.ts
+++ b/e2e/issues/issue-500-reranking-model.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for GitHub issue #500
+ * https://github.com/OpenRouterTeam/ai-sdk-provider/issues/500
+ *
+ * Reported error: `TypeError: openrouter.rerankingModel is not a function`
+ * (rerankingModel appeared in the provider typings but was undefined at runtime)
+ * Model: cohere/rerank-v3.5
+ *
+ * This test verifies that rerankingModel is implemented at runtime and maps
+ * doRerank calls to the OpenRouter /rerank endpoint.
+ */
+import { rerank } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { createOpenRouter } from '@/src';
+
+const mockFetch = async (
+  _url: URL | RequestInfo,
+  _init?: RequestInit,
+): Promise<Response> => {
+  return new Response(
+    JSON.stringify({
+      id: 'gen-rerank-123',
+      model: 'cohere/rerank-v3.5',
+      provider: 'cohere',
+      results: [
+        {
+          index: 1,
+          relevance_score: 0.98,
+          document: { text: 'Berlin is the capital of Germany.' },
+        },
+        {
+          index: 0,
+          relevance_score: 0.12,
+          document: { text: 'Paris is the capital of France.' },
+        },
+      ],
+      usage: {
+        search_units: 1,
+        total_tokens: 150,
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    },
+  );
+};
+
+describe('Issue #500: rerankingModel exists in typings but is undefined at runtime', () => {
+  it('should expose rerankingModel on the provider at runtime', () => {
+    const openrouter = createOpenRouter({ apiKey: 'test-key' });
+
+    expect(typeof openrouter.rerankingModel).toBe('function');
+    const model = openrouter.rerankingModel('cohere/rerank-v3.5');
+    expect(model.modelId).toBe('cohere/rerank-v3.5');
+    expect(model.specificationVersion).toBe('v4');
+  });
+
+  it('should rerank documents through the ai rerank function', async () => {
+    const openrouter = createOpenRouter({
+      apiKey: 'test-key',
+      fetch: mockFetch,
+    });
+
+    const result = await rerank({
+      model: openrouter.rerankingModel('cohere/rerank-v3.5'),
+      query: 'What is the capital of Germany?',
+      documents: [
+        'Paris is the capital of France.',
+        'Berlin is the capital of Germany.',
+      ],
+    });
+
+    expect(result.rerankedDocuments).toEqual([
+      'Berlin is the capital of Germany.',
+      'Paris is the capital of France.',
+    ]);
+    expect(result.ranking).toEqual([
+      {
+        originalIndex: 1,
+        score: 0.98,
+        document: 'Berlin is the capital of Germany.',
+      },
+      {
+        originalIndex: 0,
+        score: 0.12,
+        document: 'Paris is the capital of France.',
+      },
+    ]);
+  });
+});

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -18,6 +18,10 @@ import type {
   OpenRouterImageSettings,
 } from './types/openrouter-image-settings';
 import type {
+  OpenRouterRerankingModelId,
+  OpenRouterRerankingSettings,
+} from './types/openrouter-reranking-settings';
+import type {
   OpenRouterVideoModelId,
   OpenRouterVideoSettings,
 } from './types/openrouter-video-settings';
@@ -27,6 +31,7 @@ import { OpenRouterChatLanguageModel } from './chat';
 import { OpenRouterCompletionLanguageModel } from './completion';
 import { OpenRouterEmbeddingModel } from './embedding';
 import { OpenRouterImageModel } from './image';
+import { OpenRouterRerankingModel } from './reranking';
 import { webSearch } from './tool/web-search';
 import { withUserAgentSuffix } from './utils/with-user-agent-suffix';
 import { VERSION } from './version';
@@ -106,6 +111,14 @@ Creates an OpenRouter image model for image generation.
     modelId: OpenRouterImageModelId,
     settings?: OpenRouterImageSettings,
   ): OpenRouterImageModel;
+
+  /**
+Creates an OpenRouter reranking model for reranking documents against a query.
+   */
+  rerankingModel(
+    modelId: OpenRouterRerankingModelId,
+    settings?: OpenRouterRerankingSettings,
+  ): OpenRouterRerankingModel;
 
   /**
 Creates an OpenRouter video model for video generation.
@@ -268,6 +281,18 @@ export function createOpenRouter(
       extraBody: options.extraBody,
     });
 
+  const createRerankingModel = (
+    modelId: OpenRouterRerankingModelId,
+    settings: OpenRouterRerankingSettings = {},
+  ) =>
+    new OpenRouterRerankingModel(modelId, settings, {
+      provider: 'openrouter.reranking',
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+      extraBody: options.extraBody,
+    });
+
   const createVideoModel = (
     modelId: OpenRouterVideoModelId,
     settings: OpenRouterVideoSettings = {},
@@ -311,6 +336,7 @@ export function createOpenRouter(
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.embedding = createEmbeddingModel; // deprecated alias for v4 compatibility
   provider.imageModel = createImageModel;
+  provider.rerankingModel = createRerankingModel;
   provider.videoModel = createVideoModel;
   provider.tools = {
     webSearch: webSearch,

--- a/src/reranking/index.test.ts
+++ b/src/reranking/index.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { createOpenRouter } from '../provider';
+import { OpenRouterRerankingModel } from './index';
+
+describe('OpenRouterRerankingModel', () => {
+  const mockFetch = async (
+    _url: URL | RequestInfo,
+    _init?: RequestInit,
+  ): Promise<Response> => {
+    return new Response(
+      JSON.stringify({
+        id: 'gen-rerank-123',
+        model: 'cohere/rerank-v3.5',
+        provider: 'cohere',
+        results: [
+          {
+            index: 1,
+            relevance_score: 0.98,
+            document: { text: 'Berlin is the capital of Germany.' },
+          },
+          {
+            index: 0,
+            relevance_score: 0.12,
+            document: { text: 'Paris is the capital of France.' },
+          },
+        ],
+        usage: {
+          search_units: 1,
+          total_tokens: 150,
+          cost: 0.00002,
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      },
+    );
+  };
+
+  describe('provider methods', () => {
+    it('should expose rerankingModel method', () => {
+      const provider = createOpenRouter({ apiKey: 'test-key' });
+      expect(provider.rerankingModel).toBeDefined();
+      expect(typeof provider.rerankingModel).toBe('function');
+    });
+
+    it('should create a reranking model instance', () => {
+      const provider = createOpenRouter({ apiKey: 'test-key' });
+      const model = provider.rerankingModel('cohere/rerank-v3.5');
+      expect(model).toBeInstanceOf(OpenRouterRerankingModel);
+      expect(model.modelId).toBe('cohere/rerank-v3.5');
+      expect(model.provider).toBe('openrouter');
+      expect(model.specificationVersion).toBe('v4');
+    });
+  });
+
+  describe('doRerank', () => {
+    it('should map the rerank response to a ranking result', async () => {
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mockFetch,
+      });
+      const model = provider.rerankingModel('cohere/rerank-v3.5');
+
+      const result = await model.doRerank({
+        documents: {
+          type: 'text',
+          values: [
+            'Paris is the capital of France.',
+            'Berlin is the capital of Germany.',
+          ],
+        },
+        query: 'What is the capital of Germany?',
+      });
+
+      expect(result.ranking).toEqual([
+        { index: 1, relevanceScore: 0.98 },
+        { index: 0, relevanceScore: 0.12 },
+      ]);
+      expect(
+        (result.providerMetadata?.openrouter as { usage?: { cost?: number } })
+          ?.usage?.cost,
+      ).toBe(0.00002);
+      expect(result.response?.id).toBe('gen-rerank-123');
+      expect(result.response?.modelId).toBe('cohere/rerank-v3.5');
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should pass query, documents, and top_n to the API', async () => {
+      let capturedRequest: Record<string, unknown> | undefined;
+
+      const mockFetchWithCapture = async (
+        _url: URL | RequestInfo,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        capturedRequest = JSON.parse(init?.body as string);
+        return new Response(
+          JSON.stringify({
+            model: 'cohere/rerank-v3.5',
+            results: [{ index: 0, relevance_score: 0.9 }],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      };
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mockFetchWithCapture,
+      });
+
+      const model = provider.rerankingModel('cohere/rerank-v3.5', {
+        provider: {
+          order: ['cohere'],
+          allow_fallbacks: false,
+        },
+      });
+
+      await model.doRerank({
+        documents: {
+          type: 'text',
+          values: ['doc 1', 'doc 2', 'doc 3'],
+        },
+        query: 'test query',
+        topN: 2,
+      });
+
+      expect(capturedRequest?.model).toBe('cohere/rerank-v3.5');
+      expect(capturedRequest?.query).toBe('test query');
+      expect(capturedRequest?.documents).toEqual(['doc 1', 'doc 2', 'doc 3']);
+      expect(capturedRequest?.top_n).toBe(2);
+      expect(capturedRequest?.provider).toEqual({
+        order: ['cohere'],
+        allow_fallbacks: false,
+      });
+    });
+
+    it('should support object documents', async () => {
+      let capturedRequest: Record<string, unknown> | undefined;
+
+      const mockFetchWithCapture = async (
+        _url: URL | RequestInfo,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        capturedRequest = JSON.parse(init?.body as string);
+        return new Response(
+          JSON.stringify({
+            model: 'cohere/rerank-v3.5',
+            results: [{ index: 0, relevance_score: 0.9 }],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      };
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mockFetchWithCapture,
+      });
+
+      const model = provider.rerankingModel('cohere/rerank-v3.5');
+
+      await model.doRerank({
+        documents: {
+          type: 'object',
+          values: [{ text: 'doc 1' }, { text: 'doc 2' }],
+        },
+        query: 'test query',
+      });
+
+      expect(capturedRequest?.documents).toEqual([
+        { text: 'doc 1' },
+        { text: 'doc 2' },
+      ]);
+    });
+
+    it('should omit top_n when not provided', async () => {
+      let capturedRequest: Record<string, unknown> | undefined;
+
+      const mockFetchWithCapture = async (
+        _url: URL | RequestInfo,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        capturedRequest = JSON.parse(init?.body as string);
+        return new Response(
+          JSON.stringify({
+            model: 'cohere/rerank-v3.5',
+            results: [{ index: 0, relevance_score: 0.9 }],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      };
+
+      const provider = createOpenRouter({
+        apiKey: 'test-key',
+        fetch: mockFetchWithCapture,
+      });
+
+      const model = provider.rerankingModel('cohere/rerank-v3.5');
+
+      await model.doRerank({
+        documents: { type: 'text', values: ['doc 1'] },
+        query: 'test query',
+      });
+
+      expect('top_n' in (capturedRequest ?? {})).toBe(false);
+    });
+  });
+});

--- a/src/reranking/index.ts
+++ b/src/reranking/index.ts
@@ -1,0 +1,103 @@
+import type {
+  RerankingModelV4,
+  RerankingModelV4CallOptions,
+  RerankingModelV4Result,
+} from '@ai-sdk/provider';
+import type {
+  OpenRouterRerankingModelId,
+  OpenRouterRerankingSettings,
+} from '../types/openrouter-reranking-settings';
+
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  postJsonToApi,
+} from '@ai-sdk/provider-utils';
+import { openrouterFailedResponseHandler } from '../schemas/error-response';
+import { OpenRouterProviderMetadataSchema } from '../schemas/provider-metadata';
+import { OpenRouterRerankingResponseSchema } from './schemas';
+
+type OpenRouterRerankingConfig = {
+  provider: string;
+  headers: () => Record<string, string | undefined>;
+  url: (options: { modelId: string; path: string }) => string;
+  fetch?: typeof fetch;
+  extraBody?: Record<string, unknown>;
+};
+
+export class OpenRouterRerankingModel implements RerankingModelV4 {
+  readonly specificationVersion = 'v4' as const;
+  readonly provider = 'openrouter';
+  readonly modelId: OpenRouterRerankingModelId;
+  readonly settings: OpenRouterRerankingSettings;
+
+  private readonly config: OpenRouterRerankingConfig;
+
+  constructor(
+    modelId: OpenRouterRerankingModelId,
+    settings: OpenRouterRerankingSettings,
+    config: OpenRouterRerankingConfig,
+  ) {
+    this.modelId = modelId;
+    this.settings = settings;
+    this.config = config;
+  }
+
+  async doRerank(
+    options: RerankingModelV4CallOptions,
+  ): Promise<RerankingModelV4Result> {
+    const { documents, query, topN, abortSignal, headers } = options;
+
+    const args = {
+      model: this.modelId,
+      query,
+      documents: documents.values,
+      ...(topN != null && { top_n: topN }),
+      provider: this.settings.provider,
+      ...this.config.extraBody,
+      ...this.settings.extraBody,
+    };
+
+    const { value: responseValue, responseHeaders } = await postJsonToApi({
+      url: this.config.url({
+        path: '/rerank',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), headers),
+      body: args,
+      failedResponseHandler: openrouterFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        OpenRouterRerankingResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      ranking: responseValue.results.map((result) => ({
+        index: result.index,
+        relevanceScore: result.relevance_score,
+      })),
+      providerMetadata: {
+        openrouter: OpenRouterProviderMetadataSchema.parse({
+          provider: responseValue.provider ?? '',
+          usage: {
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: responseValue.usage?.total_tokens ?? 0,
+            ...(responseValue.usage?.cost != null
+              ? { cost: responseValue.usage.cost }
+              : {}),
+          },
+        }),
+      },
+      response: {
+        ...(responseValue.id != null && { id: responseValue.id }),
+        modelId: responseValue.model,
+        headers: responseHeaders,
+        body: responseValue,
+      },
+      warnings: [],
+    };
+  }
+}

--- a/src/reranking/schemas.ts
+++ b/src/reranking/schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod/v4';
+
+const openrouterRerankingUsageSchema = z.object({
+  search_units: z.number().optional(),
+  total_tokens: z.number().optional(),
+  cost: z.number().optional(),
+});
+
+export const OpenRouterRerankingResponseSchema = z.object({
+  id: z.string().optional(),
+  model: z.string(),
+  provider: z.string().optional(),
+  results: z.array(
+    z.object({
+      index: z.number(),
+      relevance_score: z.number(),
+      document: z.record(z.string(), z.any()).optional(),
+    }),
+  ),
+  usage: openrouterRerankingUsageSchema.optional(),
+});
+
+export type OpenRouterRerankingResponse = z.infer<
+  typeof OpenRouterRerankingResponseSchema
+>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export type { LanguageModelV4, LanguageModelV4Prompt };
 
 export * from './openrouter-embedding-settings';
 export * from './openrouter-image-settings';
+export * from './openrouter-reranking-settings';
 export * from './openrouter-video-settings';
 
 export type OpenRouterProviderOptions = {

--- a/src/types/openrouter-reranking-settings.ts
+++ b/src/types/openrouter-reranking-settings.ts
@@ -1,0 +1,36 @@
+import type { OpenRouterSharedSettings } from '..';
+
+// https://openrouter.ai/models?output_modalities=rerank
+export type OpenRouterRerankingModelId = string;
+
+export type OpenRouterRerankingSettings = {
+  /**
+   * Provider routing preferences to control request routing behavior
+   */
+  provider?: {
+    /**
+     * List of provider slugs to try in order (e.g. ["cohere"])
+     */
+    order?: string[];
+    /**
+     * Whether to allow backup providers when primary is unavailable (default: true)
+     */
+    allow_fallbacks?: boolean;
+    /**
+     * Control whether to use providers that may store data
+     */
+    data_collection?: 'allow' | 'deny';
+    /**
+     * List of provider slugs to allow for this request
+     */
+    only?: string[];
+    /**
+     * List of provider slugs to skip for this request
+     */
+    ignore?: string[];
+    /**
+     * Sort providers by price, throughput, or latency
+     */
+    sort?: 'price' | 'throughput' | 'latency';
+  };
+} & OpenRouterSharedSettings;


### PR DESCRIPTION
Closes #500

Note: #509 also targets this issue, but implements the v3 reranking spec, which no longer matches main after the AI SDK v7 migration (`ProviderV4.rerankingModel` requires `RerankingModelV4`). This PR is a fresh v4 implementation. Maintainers: please pick whichever you prefer.

## Summary
- add `OpenRouterRerankingModel`, which calls `POST /api/v1/rerank` and maps `results` into `ranking` with `relevanceScore`, plus provider metadata and response info
- expose `rerankingModel(modelId, settings?)` on `createOpenRouter()` and the default `openrouter` instance, following the existing embedding/image/video pattern
- add `OpenRouterRerankingSettings` with provider routing preferences and shared settings
- works with the AI SDK `rerank()` function

## Test plan
- [x] unit tests in `src/reranking/index.test.ts` (provider exposure, response mapping, request body, object documents, `top_n` handling)
- [x] regression test in `e2e/issues/issue-500-reranking-model.test.ts`
- [x] `pnpm stylecheck`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test:node` and `pnpm test:edge` (464 passed each)
- [x] `pnpm test:issues` (new test passes; pre-existing live-API tests fail without `.env.e2e` credentials)

## Changeset
minor: adds public `rerankingModel` API